### PR TITLE
build: rebuild test addons conditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ distclean:
 	-rm -rf node_modules
 	-rm -rf deps/icu
 	-rm -rf deps/icu4c*.tgz deps/icu4c*.zip deps/icu-tmp
+	-rm -rf test/addons/doc-*/
 
 test: all
 	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
@@ -108,14 +109,33 @@ test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
 		--directory="$(shell pwd)/test/gc/node_modules/weak" \
 		--nodedir="$(shell pwd)"
 
-build-addons: $(NODE_EXE)
-	rm -rf test/addons/doc-*/
-	./$(NODE_EXE) tools/doc/addon-verify.js
-	$(foreach dir, \
-			$(sort $(dir $(wildcard test/addons/*/*.gyp))), \
-			./$(NODE_EXE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
-					--directory="$(shell pwd)/$(dir)" \
-					--nodedir="$(shell pwd)" && ) echo "build done"
+ADDONS_TESTS = \
+	async-hello-world \
+	at-exit \
+	hello-world-function-export \
+	hello-world \
+	repl-domain-abort \
+
+# Note: don't depend on $(NODE_EXE) here, that unconditionally forces a rebuild.
+test/addons/%/build/Release/binding.node: \
+		test/addons/%/binding.cc test/addons/%/binding.gyp
+	./$(NODE_EXE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
+		--nodedir="$(PWD)" --directory="$(dir $<)"
+
+build-static-addons: \
+	$(NODE_EXE) $(ADDONS_TESTS:%=test/addons/%/build/Release/binding.node)
+
+# Note: don't depend on $(NODE_EXE) here, that unconditionally forces a rebuild.
+test/addons/.stamp: tools/doc/addon-verify.js doc/api/addons.markdown
+	./$(NODE_EXE) $<
+	$(foreach dir, $(dir $(wildcard test/addons/doc-*/*.gyp)), \
+		./$(NODE_EXE) deps/npm/node_modules/node-gyp/bin/node-gyp \
+			rebuild --nodedir="$(PWD)" --directory="$(dir)")
+	touch $@
+
+build-doc-addons: $(NODE_EXE) test/addons/.stamp
+
+build-addons: build-doc-addons build-static-addons
 
 test-gc: all test/gc/node_modules/weak/build/Release/weakref.node
 	$(PYTHON) tools/test.py --mode=release gc
@@ -171,7 +191,7 @@ test-npm-publish: $(NODE_EXE)
 	npm_package_config_publishtest=true ./$(NODE_EXE) deps/npm/test/run.js
 
 test-addons: test-build
-	$(PYTHON) tools/test.py --mode=release addons
+	$(PYTHON) tools/test.py -J addons
 
 test-timers:
 	$(MAKE) --directory=tools faketime

--- a/test/addons/.gitignore
+++ b/test/addons/.gitignore
@@ -1,3 +1,4 @@
+.stamp
 Makefile
 *.Makefile
 *.mk


### PR DESCRIPTION
Before this commit, `make test-addons` and the targets that depend on
it (test-ci, test-all) would always do a full rebuild of the files in
test/addons and the addons scraped from doc/api/addons.markdown.

This commit introduces a proper dependency chain so that files are only
rebuilt when changed, shaving off about 10-20 seconds from each run.

R=@chrisdickinson