### PR TITLE
Cleanup stream state in net

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ information about the governance of the io.js project, see
 * **Fedor Indutny** ([@indutny](https://github.com/indutny)) &lt;fedor.indutny@gmail.com&gt; (Technical Committee)
 * **Trevor Norris** ([@trevnorris](https://github.com/trevnorris)) &lt;trev.norris@gmail.com&gt; (Technical Committee)
 * **Chris Dickinson** ([@chrisdickinson](https://github.com/chrisdickinson)) &lt;christopher.s.dickinson@gmail.com&gt; (Technical Committee)
+<br>Release GPG key: 9554F04D7259F04124DE6B476D5A82AC7E37093B
 * **Colin Ihrig** ([@cjihrig](https://github.com/cjihrig)) &lt;cjihrig@gmail.com&gt; (Technical Committee)
 * **Mikeal Rogers** ([@mikeal](https://github.com/mikeal)) &lt;mikeal.rogers@gmail.com&gt;
 * **Rod Vagg** ([@rvagg](https://github.com/rvagg)) &lt;rod@vagg.org&gt;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -104,9 +104,6 @@ function WritableState(options, stream) {
   // emit prefinish if the only thing we're waiting for is _write cbs
   // This is relevant for synchronous Transform streams
   this.prefinished = false;
-
-  // True if the error was already emitted and should not be thrown again
-  this.errorEmitted = false;
 }
 
 WritableState.prototype.getBuffer = function writableStateGetBuffer() {
@@ -299,7 +296,6 @@ function onwriteError(stream, state, sync, er, cb) {
     cb(er);
   }
 
-  stream._writableState.errorEmitted = true;
   stream.emit('error', er);
 }
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -306,9 +306,9 @@ TLSSocket.prototype._init = function(socket) {
   }
 
   this.ssl.onerror = function(err) {
-    if (self._writableState.errorEmitted)
+    if (self._errorEmitted)
       return;
-    self._writableState.errorEmitted = true;
+    self._errorEmitted = true;
 
     // Destroy socket if error happened before handshake's finish
     if (!this._secureEstablished) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -117,6 +117,7 @@ function initSocketHandle(self) {
 function Socket(options) {
   if (!(this instanceof Socket)) return new Socket(options);
 
+  this._errorEmitted = false;
   this._connecting = false;
   this._hadError = false;
   this._handle = null;
@@ -420,12 +421,14 @@ Socket.prototype._destroy = function(exception, cb) {
   var self = this;
 
   function fireErrorCallbacks() {
+    var hadSeenError = self._errorEmitted;
+    self._errorEmitted = self._errorEmitted || Boolean(exception);
     if (cb) cb(exception);
-    if (exception && !self._writableState.errorEmitted) {
+    else if (exception && !hadSeenError) {
       process.nextTick(function() {
         self.emit('error', exception);
       });
-      self._writableState.errorEmitted = true;
+      self._errorEmitted = true;
     }
   };
 
@@ -840,7 +843,7 @@ Socket.prototype.connect = function(options, cb) {
     this._writableState.ended = false;
     this._writableState.ending = false;
     this._writableState.finished = false;
-    this._writableState.errorEmitted = false;
+    this._errorEmitted = false;
     this.destroyed = false;
     this._handle = null;
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -422,9 +422,10 @@ Socket.prototype._destroy = function(exception, cb) {
 
   function fireErrorCallbacks() {
     var hadSeenError = self._errorEmitted;
-    self._errorEmitted = self._errorEmitted || Boolean(exception);
-    if (cb) cb(exception);
-    else if (exception && !hadSeenError) {
+    self._errorEmitted = self._errorEmitted || !!(exception);
+    if (cb) {
+      cb(exception);
+    } else if (exception && !hadSeenError) {
       process.nextTick(function() {
         self.emit('error', exception);
       });

--- a/lib/net.js
+++ b/lib/net.js
@@ -170,7 +170,7 @@ function Socket(options) {
       // stop the handle from reading and pause the stream
       this._handle.reading = false;
       this._handle.readStop();
-      this._readableState.flowing = false;
+      this.pause();
     } else {
       this.read(0);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -127,6 +127,8 @@ function Socket(options) {
   else if (options === undefined)
     options = {};
 
+  // handle strings directly
+  options.decodeStrings = false;
   stream.Duplex.call(this, options);
 
   if (options.handle) {
@@ -157,9 +159,6 @@ function Socket(options) {
 
   this._pendingData = null;
   this._pendingEncoding = '';
-
-  // handle strings directly
-  this._writableState.decodeStrings = false;
 
   // default to *not* allowing half open sockets
   this.allowHalfOpen = options && options.allowHalfOpen || false;

--- a/lib/net.js
+++ b/lib/net.js
@@ -192,11 +192,10 @@ function onSocketFinish() {
   }
 
   debug('onSocketFinish');
-  if (!this.readable || this._readableState.ended) {
+  if (!this.readable) {
     debug('oSF: ended, destroy', this._readableState);
     return this.destroy();
   }
-
   debug('oSF: not ended, call shutdown()');
 
   // otherwise, just shutdown, or destroy() if not possible
@@ -238,13 +237,10 @@ function onSocketEnd() {
   // ended should already be true, since this is called *after*
   // the EOF errno and onread has eof'ed
   debug('onSocketEnd', this._readableState);
-  this._readableState.ended = true;
   if (this._readableState.endEmitted) {
-    this.readable = false;
     maybeDestroy(this);
   } else {
     this.once('end', function() {
-      this.readable = false;
       maybeDestroy(this);
     });
     this.read(0);


### PR DESCRIPTION
part of #445

This set of patches removes much of the private state manipulation `net.Socket` was doing:

* 58912a0: Removes the `this._writableState.decodeStrings = false` in favor of always setting `options.decodeStrings = false` before `stream.Duplex.call(this, options)`. 
* ee369cd: Instead of manually setting `this._readableState.flowing = false`, call [`this.pause()`](https://github.com/iojs/io.js/blob/v1.x/lib/_stream_readable.js#L715-L723). Since we have not returned from object instantiation, there should be no side effects.
*  9c26dd1: A bit trickier: only destroy in `onSocketFinish` we are already not readable – whether that's because we started as `readable = false` *or* because we're [in the dead zone](https://github.com/iojs/io.js/blob/v1.x/lib/_stream_readable.js#L882-L890) between `ended = true` and `readable = false`. What this means in practice is that sockets that *would* have been destroyed here will instead be destroyed by `onSocketEnd` (as that `nextTick`'d function completes.)
* 29e7d80: Maybe controversial, *but*: the `errorEmitted` attribute was *only* made available for the purposes of `net.Socket` (and `tls.TLSSocket`), and even then only for errors that they can intercept themselves. I moved that attribute down to those child classes, because there's no need within Writable to track that information (basically trying to localize the illicit information spillage).

R=@rvagg, @isaacs, or @bnoordhuis ?
