### PR TITLE
async-wrap: always call before and after hooks

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -45,6 +45,8 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
       kExternalUint32Array,
       async_hooks->fields_count());
 
+  async_hooks->enabled = true;
+
   env->set_async_hooks_init_function(args[1].As<Function>());
   env->set_async_hooks_pre_function(args[2].As<Function>());
   env->set_async_hooks_post_function(args[3].As<Function>());

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -38,6 +38,8 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   //   non-zero to have those callbacks called. This only affects the init
   //   callback. If the init callback was called, then the pre/post callbacks
   //   will automatically be called.
+  // - kEnabled (1): Tells the AsyncWrap constructor whether it should
+  //   make any calls to the JS hook functions.
   Local<Object> async_hooks_obj = args[0].As<Object>();
   Environment::AsyncHooks* async_hooks = env->async_hooks();
   async_hooks_obj->SetIndexedPropertiesToExternalArrayData(
@@ -45,7 +47,7 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
       kExternalUint32Array,
       async_hooks->fields_count());
 
-  async_hooks->enabled = true;
+  async_hooks->set_enabled(true);
 
   env->set_async_hooks_init_function(args[1].As<Function>());
   env->set_async_hooks_pre_function(args[2].As<Function>());

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -75,7 +75,7 @@ inline bool Environment::AsyncHooks::is_enabled() const {
 }
 
 inline void Environment::AsyncHooks::set_enabled(bool enabled) {
-  fields_[kEnabled] = (uint32_t)enabled;
+  fields_[kEnabled] = static_cast<uint32_t>(enabled);
 }
 
 inline Environment::DomainFlag::DomainFlag() {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -55,6 +55,7 @@ inline v8::Isolate* Environment::IsolateData::isolate() const {
 }
 
 inline Environment::AsyncHooks::AsyncHooks() {
+  enabled = false;
   for (int i = 0; i < kFieldsCount; i++) fields_[i] = 0;
 }
 
@@ -212,6 +213,11 @@ inline void Environment::Dispose() {
 
 inline v8::Isolate* Environment::isolate() const {
   return isolate_;
+}
+
+inline bool Environment::use_async_hook() const {
+  // The const_cast is okay, it doesn't violate conceptual const-ness.
+  return const_cast<Environment*>(this)->async_hooks()->enabled;
 }
 
 inline bool Environment::call_async_init_hook() const {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -55,7 +55,6 @@ inline v8::Isolate* Environment::IsolateData::isolate() const {
 }
 
 inline Environment::AsyncHooks::AsyncHooks() {
-  enabled = false;
   for (int i = 0; i < kFieldsCount; i++) fields_[i] = 0;
 }
 
@@ -69,6 +68,14 @@ inline int Environment::AsyncHooks::fields_count() const {
 
 inline bool Environment::AsyncHooks::call_init_hook() {
   return fields_[kCallInitHook] != 0;
+}
+
+inline bool Environment::AsyncHooks::is_enabled() const {
+  return fields_[kEnabled] != 0;
+}
+
+inline void Environment::AsyncHooks::set_enabled(bool enabled) {
+  fields_[kEnabled] = (uint32_t)enabled;
 }
 
 inline Environment::DomainFlag::DomainFlag() {
@@ -217,7 +224,7 @@ inline v8::Isolate* Environment::isolate() const {
 
 inline bool Environment::use_async_hook() const {
   // The const_cast is okay, it doesn't violate conceptual const-ness.
-  return const_cast<Environment*>(this)->async_hooks()->enabled;
+  return const_cast<Environment*>(this)->async_hooks()->is_enabled();
 }
 
 inline bool Environment::call_async_init_hook() const {

--- a/src/env.h
+++ b/src/env.h
@@ -255,6 +255,7 @@ class Environment {
     inline uint32_t* fields();
     inline int fields_count() const;
     inline bool call_init_hook();
+    bool enabled;
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -358,6 +359,7 @@ class Environment {
 
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
+  inline bool use_async_hook() const;
   inline bool call_async_init_hook() const;
   inline bool in_domain() const;
   inline uint32_t watched_providers() const;

--- a/src/env.h
+++ b/src/env.h
@@ -255,7 +255,8 @@ class Environment {
     inline uint32_t* fields();
     inline int fields_count() const;
     inline bool call_init_hook();
-    bool enabled;
+    inline bool is_enabled() const;
+    inline void set_enabled(bool enabled);
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -264,6 +265,9 @@ class Environment {
     enum Fields {
       // Set this to not zero if the init hook should be called.
       kCallInitHook,
+      // Set this to not zero if async wrap should be enabled. This is
+      // automatically set when SetupHooks is called.
+      kEnabled,
       kFieldsCount
     };
 

--- a/test/parallel/test-async-wrap-disabled.js
+++ b/test/parallel/test-async-wrap-disabled.js
@@ -1,0 +1,33 @@
+var common = require('../common');
+var assert = require('assert');
+
+var asyncWrap = process.binding('async_wrap');
+
+var asyncHooksObject = {};
+var kEnabled = 1;
+asyncWrap.setupHooks(asyncHooksObject, init, before, after);
+asyncHooksObject[kEnabled] = 0;
+
+var order = [];
+
+function init() {
+  order.push('init ' + this.constructor.name);
+}
+
+function before() {
+  order.push('before ' + this.constructor.name);
+}
+
+function after() {
+  order.push('after ' + this.constructor.name);
+}
+
+setTimeout(function () {
+  order.push('callback');
+});
+
+process.once('exit', function () {
+  assert.deepEqual(order, [
+    'callback'
+  ]);
+});

--- a/test/parallel/test-async-wrap-init-hook.js
+++ b/test/parallel/test-async-wrap-init-hook.js
@@ -1,0 +1,33 @@
+var common = require('../common');
+var assert = require('assert');
+
+var asyncWrap = process.binding('async_wrap');
+
+var asyncHooksObject = {};
+var kCallInitHook = 0;
+asyncWrap.setupHooks(asyncHooksObject, init, before, after);
+asyncHooksObject[kCallInitHook] = 1;
+
+var order = [];
+
+function init() {
+  order.push('init ' + this.constructor.name);
+}
+
+function before() {
+  order.push('before ' + this.constructor.name);
+}
+
+function after() {
+  order.push('after ' + this.constructor.name);
+}
+
+setTimeout(function () {
+  order.push('callback');
+});
+
+process.once('exit', function () {
+  assert.deepEqual(order, [
+    'init Timer', 'before Timer', 'callback', 'after Timer'
+  ]);
+});

--- a/test/parallel/test-async-wrap-no-init-hook.js
+++ b/test/parallel/test-async-wrap-no-init-hook.js
@@ -1,0 +1,31 @@
+var common = require('../common');
+var assert = require('assert');
+
+var asyncWrap = process.binding('async_wrap');
+
+var asyncHooksObject = {};
+asyncWrap.setupHooks(asyncHooksObject, init, before, after);
+
+var order = [];
+
+function init() {
+  order.push('init ' + this.constructor.name);
+}
+
+function before() {
+  order.push('before ' + this.constructor.name);
+}
+
+function after() {
+  order.push('after ' + this.constructor.name);
+}
+
+setTimeout(function () {
+  order.push('callback');
+});
+
+process.once('exit', function () {
+  assert.deepEqual(order, [
+    'before Timer', 'callback', 'after Timer'
+  ]);
+});


### PR DESCRIPTION
This patch allows the before and after hook to be called even if the
kCallInitHook flag is 0.

* `test/parallel/test-async-wrap-no-init-hook.js` did not pass before.
* `test/parallel/test-async-wrap-init-hook.js` did pass before. I just added it for the sake of completeness.

_issue tracking: https://github.com/AndreasMadsen/trace/issues/12_