### PR TITLE
lib: fix process.send() sync i/o regression

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -566,6 +566,13 @@ exports._forkChild = function(fd) {
   // set process.send()
   var p = createPipe(true);
   p.open(fd);
+
+  // p.open() puts the file descriptor in non-blocking mode
+  // but it must be synchronous for backwards compatibility.
+  var err = p.setBlocking(true);
+  if (err)
+    throw errnoException(err, 'setBlocking');
+
   p.unref();
   setupChannel(process, p);
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -134,10 +134,9 @@ function Socket(options) {
   } else if (options.fd !== undefined) {
     this._handle = createHandle(options.fd);
     this._handle.open(options.fd);
-    if ((options.fd == 1 || options.fd == 2) &&
-        (this._handle instanceof Pipe) &&
-        process.platform === 'win32') {
-      // Make stdout and stderr blocking on Windows
+    // this._handle.open() puts the file descriptor in non-blocking
+    // mode but it must be synchronous for backwards compatibility.
+    if ((options.fd == 1 || options.fd == 2) && this._handle instanceof Pipe) {
       var err = this._handle.setBlocking(true);
       if (err)
         throw errnoException(err, 'setBlocking');

--- a/test/parallel/test-child-process-sync-process-send.js
+++ b/test/parallel/test-child-process-sync-process-send.js
@@ -1,0 +1,23 @@
+var common = require('../common');
+var assert = require('assert');
+var fork = require('child_process').fork;
+var N = 4 << 20;  // 4 MB
+
+for (var big = '*'; big.length < N; big += big);
+
+if (process.argv[2] === 'child') {
+  process.send(big);
+  process.exit(42);
+}
+
+var proc = fork(__filename, ['child']);
+
+proc.on('message', common.mustCall(function(msg) {
+  assert.equal(typeof msg, 'string');
+  assert.equal(msg.length, N);
+  assert.equal(msg, big);
+}));
+
+proc.on('exit', common.mustCall(function(exitCode) {
+  assert.equal(exitCode, 42);
+}));

--- a/test/parallel/test-net-sync-stdio.js
+++ b/test/parallel/test-net-sync-stdio.js
@@ -1,0 +1,23 @@
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var N = 4 << 20;  // 4 MB
+
+for (var big = '*'; big.length < N; big += big);
+
+if (process.argv[2] === 'child') {
+  process.stdout.write(big);
+  process.exit(42);
+}
+
+var stdio = ['inherit', 'pipe', 'inherit'];
+var proc = spawn(process.execPath, [__filename, 'child'], { stdio: stdio });
+
+var chunks = [];
+proc.stdout.setEncoding('utf8');
+proc.stdout.on('data', chunks.push.bind(chunks));
+
+proc.on('exit', common.mustCall(function(exitCode) {
+  assert.equal(exitCode, 42);
+  assert.equal(chunks.join(''), big);
+}));


### PR DESCRIPTION
process.send() should be synchronous, i.e. it should block until the
message has been sent in full, but it wasn't after the second-to-last
libuv upgrade because of commit libuv/libuv@393c1c5 ("unix: set
non-block mode in uv_{pipe,tcp,udp}_open"), which made its way into
io.js in commit 07bd05b ("deps: update libuv to 1.2.1").

Commit libuv/libuv@b36d4ff ("unix: implement uv_stream_set_blocking()")
as landed in io.js in commit 9681fca ("deps: update libuv to 1.4.0")
makes it possible to restore the synchronous behavior again and that's
precisely what this commit does.

Fixes: https://github.com/iojs/io.js/issues/760

R=@brendanashworth @piscisaureus

On Windows, this sets the UV_HANDLE_BLOCKING_WRITES flag on the handle.  I'd like @piscisaureus to confirm whether that's harmless or not.

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/160/