### PR TITLE
Always call callbacks in lib/_http_outgoing.js

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -71,19 +71,19 @@ function OutgoingMessage() {
   this._headers = null;
   this._headerNames = {};
 
-  var that = this;
+  var self = this;
 
   // Call remaining callbacks if stream closes prematurely
-  this.once('close', function(){
-    if(that.output.length === 0) return;
+  this.once('close', function() {
+    if(self.output.length === 0) return;
 
     var err = new Error('stream closed prematurely');
 
-    var outputCallbacks = that.outputCallbacks;
+    var outputCallbacks = self.outputCallbacks;
 
-    that.output = [];
-    that.outputEncodings = [];
-    that.outputCallbacks = [];
+    self.output = [];
+    self.outputEncodings = [];
+    self.outputCallbacks = [];
 
     for(var i=0; i<outputCallbacks.length; i++){
         var callback = outputCallbacks[i];

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -70,6 +70,27 @@ function OutgoingMessage() {
   this._header = null;
   this._headers = null;
   this._headerNames = {};
+
+  var that = this;
+
+  // Call remaining callbacks if stream closes prematurely
+  this.once('close', function(){
+    if(that.output.length === 0) return;
+
+    var err = new Error('stream closed prematurely');
+
+    var outputCallbacks = that.outputCallbacks;
+
+    that.output = [];
+    that.outputEncodings = [];
+    that.outputCallbacks = [];
+
+    for(var i=0; i<outputCallbacks.length; i++){
+        var callback = outputCallbacks[i];
+        if(typeof callback === 'function')
+            callback(err);
+    }
+  });
 }
 util.inherits(OutgoingMessage, Stream);
 
@@ -159,12 +180,8 @@ OutgoingMessage.prototype._writeRaw = function(data, encoding, callback) {
 
     // Directly write to socket.
     return connection.write(data, encoding, callback);
-  } else if (connection && connection.destroyed) {
-    // The socket was destroyed.  If we're still trying to write to it,
-    // then we haven't gotten the 'close' event yet.
-    return false;
   } else {
-    // buffer, as long as we're not destroyed.
+    // buffer, as long as we didn't get the "close" event
     return this._buffer(data, encoding, callback);
   }
 };
@@ -407,9 +424,10 @@ Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
 
 OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
   var self = this;
+  var err;
 
   if (this.finished) {
-    var err = new Error('write after end');
+    err = new Error('write after end');
     process.nextTick(function() {
       self.emit('error', err);
       if (callback) callback(err);
@@ -423,8 +441,11 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
   }
 
   if (!this._hasBody) {
-    debug('This type of response MUST NOT have a body. ' +
-          'Ignoring write() calls.');
+    err = new Error('this type of response must not have a body');
+    process.nextTick(function() {
+      self.emit('error', err);
+      if (callback) callback(err);
+    });
     return true;
   }
 
@@ -432,10 +453,13 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
     throw new TypeError('first argument must be a string or Buffer');
   }
 
-
   // If we get an empty string or buffer, then just do nothing, and
   // signal the user to keep writing.
-  if (chunk.length === 0) return true;
+  if (chunk.length === 0) {
+    if (typeof callback === 'function')
+      process.nextTick(callback);
+    return true;
+  }
 
   var len, ret;
   if (this.chunkedEncoding) {
@@ -511,11 +535,23 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
     throw new TypeError('first argument must be a string or Buffer');
   }
 
+  var self = this;
+
   if (this.finished) {
+    if(data && data.length > 0){
+        //If the user tried to write data, tell him it failed
+        var err = new Error('write after end');
+        process.nextTick(function() {
+          self.emit('error', err);
+          if (callback) callback(err);
+        });
+    } else {
+        //If he only wanted to end the stream anyways, lucky for him
+        if(callback) process.nextTick(callback);
+    }
     return false;
   }
 
-  var self = this;
   function finish() {
     self.emit('finish');
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -75,7 +75,7 @@ function OutgoingMessage() {
 
   // Call remaining callbacks if stream closes prematurely
   this.once('close', function() {
-    if(self.output.length === 0) return;
+    if (self.output.length === 0) return;
 
     var err = new Error('stream closed prematurely');
 
@@ -85,10 +85,10 @@ function OutgoingMessage() {
     self.outputEncodings = [];
     self.outputCallbacks = [];
 
-    for(var i=0; i<outputCallbacks.length; i++){
-        var callback = outputCallbacks[i];
-        if(typeof callback === 'function')
-            callback(err);
+    for (var i = 0; i < outputCallbacks.length; i++) {
+      var callback = outputCallbacks[i];
+      if (typeof callback === 'function')
+        callback(err);
     }
   });
 }
@@ -538,16 +538,17 @@ OutgoingMessage.prototype.end = function(data, encoding, callback) {
   var self = this;
 
   if (this.finished) {
-    if(data && data.length > 0){
-        //If the user tried to write data, tell him it failed
-        var err = new Error('write after end');
-        process.nextTick(function() {
-          self.emit('error', err);
-          if (callback) callback(err);
-        });
+    if (data && data.length > 0) {
+      //If the user tried to write data, tell him it failed
+      var err = new Error('write after end');
+      process.nextTick(function() {
+        self.emit('error', err);
+        if (callback) callback(err);
+      });
     } else {
-        //If he only wanted to end the stream anyways, lucky for him
-        if(callback) process.nextTick(callback);
+      //If he only wanted to end the stream anyways, lucky for him
+      if (callback)
+        process.nextTick(callback);
     }
     return false;
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -441,11 +441,8 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
   }
 
   if (!this._hasBody) {
-    err = new Error('this type of response must not have a body');
-    process.nextTick(function() {
-      self.emit('error', err);
-      if (callback) callback(err);
-    });
+    debug('This type of response MUST NOT have a body. ' +
+          'Ignoring write() calls.');
     return true;
   }
 

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -42,7 +42,7 @@ server.listen(common.PORT, function() {
 
     // Each failed write will cause an error, but
     // we are only interested in one
-    if(gotError) return;
+    if (gotError) return;
 
     gotError = true;
     switch (er.code) {

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -39,7 +39,11 @@ server.listen(common.PORT, function() {
   var sawEnd = false;
 
   req.on('error', function(er) {
-    assert(!gotError);
+
+    // Each failed write will cause an error, but
+    // we are only interested in one
+    if(gotError) return;
+
     gotError = true;
     switch (er.code) {
       // This is the expected case

--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -18,17 +18,17 @@ var server = http.createServer(function(req, res) {
 
   var callbackCalled = false;
 
-  res.end('ok', function(){
+  res.end('ok', function() {
     assert.ok(!callbackCalled);
     callbackCalled = true;
   });
 
   // We might get a socket already closed error here
   // Not really a surpise
-  res.on('error', function(){});
+  res.on('error', function() {});
 
-  res.on('close', function(){
-    process.nextTick(function(){
+  res.on('close', function() {
+    process.nextTick(function() {
       assert.ok(callbackCalled, "end() callback should've been called");
     });
   });
@@ -36,7 +36,7 @@ var server = http.createServer(function(req, res) {
   // Oh no!  The connection died!
   req.socket.destroy();
 
-  if (++done === numRequests)
+  if (++done == numRequests)
     server.close();
 });
 


### PR DESCRIPTION
Fixes https://github.com/iojs/io.js/issues/1047

The changes will make sure that callbacks given to end() or write() will always be called, with or without an error depending on the circumstances.

A summary of the changes:

- A few paths where the code would've just returned have been changed to also call the supplied callback.
- Callbacks remaining in this.outputCallbacks will be called once the stream closes.
- Tests have been updated accordingly to test for the changes.
