### PR TITLE
http: deprecate legacy array header notation

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -178,6 +178,26 @@ OutgoingMessage.prototype._buffer = function(data, encoding, callback) {
 };
 
 
+// Deprecated legacy API (316e283).
+const convertLegacyArrayHeaders = util.deprecate(function(headers) {
+  var objHeaders = {};
+
+  for (var i = 0; i < headers.length; i++) {
+    var key = headers[i][0];
+    var value = headers[i][1];
+
+    if (Array.isArray(objHeaders[key]))
+      objHeaders[key].push(value);
+    else if (objHeaders[key] != null)
+      objHeaders[key] = [objHeaders[key], value];
+    else
+      objHeaders[key] = value;
+  }
+
+  return objHeaders;
+}, 'http header array notation is deprecated. Use object notation instead.');
+
+
 OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
   // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
   // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
@@ -191,21 +211,17 @@ OutgoingMessage.prototype._storeHeader = function(firstLine, headers) {
     messageHeader: firstLine
   };
 
+  if (Array.isArray(headers))
+    headers = convertLegacyArrayHeaders(headers);
+
   if (headers) {
     var keys = Object.keys(headers);
-    var isArray = Array.isArray(headers);
-    var field, value;
 
     for (var i = 0, l = keys.length; i < l; i++) {
-      var key = keys[i];
-      if (isArray) {
-        field = headers[key][0];
-        value = headers[key][1];
-      } else {
-        field = key;
-        value = headers[key];
-      }
+      var field = keys[i];
+      var value = headers[field];
 
+      // Case: multiple values for one header.
       if (Array.isArray(value)) {
         for (var j = 0; j < value.length; j++) {
           storeHeader(this, state, field, value[j]);
@@ -476,21 +492,15 @@ OutgoingMessage.prototype.write = function(chunk, encoding, callback) {
 
 
 OutgoingMessage.prototype.addTrailers = function(headers) {
+  if (Array.isArray(headers))
+    headers = convertLegacyArrayHeaders(headers);
+
   this._trailer = '';
   var keys = Object.keys(headers);
-  var isArray = Array.isArray(headers);
-  var field, value;
   for (var i = 0, l = keys.length; i < l; i++) {
     var key = keys[i];
-    if (isArray) {
-      field = headers[key][0];
-      value = headers[key][1];
-    } else {
-      field = key;
-      value = headers[key];
-    }
 
-    this._trailer += field + ': ' + value + CRLF;
+    this._trailer += key + ': ' + headers[key] + CRLF;
   }
 };
 


### PR DESCRIPTION
Ever since commit 316e283, flat object header notation has been
preferred over array-in-array notation, ex:

```
[['Content-Type', 'text/plain'], ['X-Data', 'hello world']]
```

This commit officially deprecates this functionality. This frees us up
for further optimizations and cleaner code, removing the spaghetti-like
residue of this five-year-old feature.