### PR TITLE
fs: check stream option and set encoding on fs.WritableStream

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1615,13 +1615,15 @@ function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
 
-  if (typeof options === 'string')
+  if (options === undefined)
+    options = {};
+  else if (typeof options === 'string')
     options = { encoding: options };
-  else if (options && typeof options !== 'object')
-    throw new TypeError('Bad arguments');
+  else if (typeof options !== 'object')
+    throw new TypeError('options must be a string or an object');
 
   // a little bit bigger buffer and water marks by default
-  options = Object.create(options || {});
+  options = Object.create(options);
   if (options.highWaterMark === undefined)
     options.highWaterMark = 64 * 1024;
 
@@ -1786,12 +1788,12 @@ function WriteStream(path, options) {
   if (!(this instanceof WriteStream))
     return new WriteStream(path, options);
 
-  if (typeof options === 'string')
+  if (options === undefined || options === null)
+    options = {};
+  else if (typeof options === 'string')
     options = { encoding: options };
-  else if (options && typeof options !== 'object')
-    throw new TypeError('Bad arguments');
-
-  options = options || {};
+  else if (typeof options !== 'object')
+    throw new TypeError('options must be a string or an object');
 
   Writable.call(this, options);
 
@@ -1813,6 +1815,10 @@ function WriteStream(path, options) {
     }
 
     this.pos = this.start;
+  }
+
+  if (options.encoding) {
+    this.setDefaultEncoding(options.encoding);
   }
 
   if (typeof this.fd !== 'number')

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1615,6 +1615,11 @@ function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
 
+  if (typeof options === 'string')
+    options = { encoding: options };
+  else if (options && typeof options !== 'object')
+    throw new TypeError('Bad arguments');
+
   // a little bit bigger buffer and water marks by default
   options = Object.create(options || {});
   if (options.highWaterMark === undefined)
@@ -1780,6 +1785,11 @@ fs.WriteStream = WriteStream;
 function WriteStream(path, options) {
   if (!(this instanceof WriteStream))
     return new WriteStream(path, options);
+
+  if (typeof options === 'string')
+    options = { encoding: options };
+  else if (options && typeof options !== 'object')
+    throw new TypeError('Bad arguments');
 
   options = options || {};
 

--- a/test/parallel/test-fs-read-stream-encoding.js
+++ b/test/parallel/test-fs-read-stream-encoding.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const stream = require('stream');
+const encoding = 'base64';
+
+const example = path.join(common.fixturesDir, 'x.txt');
+const assertStream = new stream.Writable({
+  write: function(chunk, enc, next) {
+    const expected = new Buffer('xyz');
+    assert(chunk.equals(expected));
+  }
+});
+assertStream.setDefaultEncoding(encoding);
+fs.createReadStream(example, encoding).pipe(assertStream);

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -1,8 +1,19 @@
+'use strict';
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
 const example = path.join(common.fixturesDir, 'x.txt');
-assert.throws(function() { fs.createReadStream(example, 123); }, TypeError);
-assert.throws(function() { fs.createReadStream(example, true); }, TypeError);
+assert.throws(function() { 
+  fs.createReadStream(example, 123); 
+}, TypeError, 'options must be a string or an object');
+assert.throws(function() { 
+  fs.createReadStream(example, 0); 
+}, TypeError, 'options must be a string or an object');
+assert.throws(function() { 
+  fs.createReadStream(example, true); 
+}, TypeError, 'options must be a string or an object');
+assert.throws(function() { 
+  fs.createReadStream(example, false); 
+}, TypeError, 'options must be a string or an object');

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -1,0 +1,8 @@
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const example = path.join(common.fixturesDir, 'x.txt');
+assert.throws(function() { fs.createReadStream(example, 123); }, TypeError);
+assert.throws(function() { fs.createReadStream(example, true); }, TypeError);

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const stream = require('stream');
+const firstEncoding = 'base64';
+const secondEncoding = 'binary';
+
+const example = path.join(common.fixturesDir, 'x.txt');
+const dummy = path.join(common.tmpDir, '/x.txt');
+const exampleReadStream = fs.createReadStream(example, firstEncoding);
+const dummyWriteStream = fs.createWriteStream(dummy, firstEncoding);
+exampleReadStream.pipe(dummyWriteStream).on('finish', function(){
+  const assertWriteStream = new stream.Writable({
+    write: function(chunk, enc, next) {
+      const expected = new Buffer('xyz\n');
+      assert(chunk.equals(expected));
+    }
+  });
+  assertWriteStream.setDefaultEncoding(secondEncoding);
+  fs.createReadStream(dummy, secondEncoding).pipe(assertWriteStream);
+});

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -1,8 +1,19 @@
+'use strict';
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
 const example = path.join(common.tmpDir, '/dummy');
-assert.throws(function() { fs.createReadStream(example, 123); }, TypeError);
-assert.throws(function() { fs.createReadStream(example, true); }, TypeError);
+assert.throws(function() { 
+  fs.createWriteStream(example, 123); 
+}, TypeError, 'options must be a string or an object');
+assert.throws(function() { 
+  fs.createWriteStream(example, 0); 
+}, TypeError, 'options must be a string or an object');
+assert.throws(function() { 
+  fs.createWriteStream(example, true); 
+}, TypeError, 'options must be a string or an object');
+assert.throws(function() { 
+  fs.createWriteStream(example, false); 
+}, TypeError, 'options must be a string or an object');

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -1,0 +1,8 @@
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const example = path.join(common.tmpDir, '/dummy');
+assert.throws(function() { fs.createReadStream(example, 123); }, TypeError);
+assert.throws(function() { fs.createReadStream(example, true); }, TypeError);


### PR DESCRIPTION
Reviewer: @bnoordhuis 

# Problem 1

On Node.js v0.12
```javascript
// illegal option but does not throw an Error, just ignore.
fs.createReadStream('foo.txt', 'utf8');

// illegal option but does not throw an Error, just ignore.
fs.createWriteStream('hoge', 'utf8');
```

On io.js v1.6.4
```javascript
// illegal option and throw an Error
fs.createReadStream('foo.txt', 'utf8');

fs.js:1619
  options = Object.create(options || {});
                   ^
TypeError: Object prototype may only be an Object or null: utf8
    at Function.create (native)
    at new ReadStream (fs.js:1619:20)
    at Object.fs.createReadStream (fs.js:1608:10)
    at Object.<anonymous> (/Users/yosuke/go/src/github.com/yosuke-furukawa/fork/io.js/test/parallel/test-fs-write-stream-encoding.js:12:30)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:428:10)
    at Module.load (module.js:335:32)
    at Function.Module._load (module.js:290:12)
    at Function.Module.runMain (module.js:451:10)
    at startup (node.js:124:18)

// illegal option but does not throw an Error, just ignore.
fs.createWriteStream('hoge', 'utf8');
```

## Bug found modules

- https://github.com/workshopper/workshopper-adventure/commit/75aee8b44900e58bbe792f395040103cdbc2749d
- https://github.com/eventualbuddha/decaffeinate/issues/21

## Cause

I found this pull request https://github.com/iojs/io.js/pull/635 . this PR uses `Object.create` in createReadStream. `Object.create` does not accept `string`.

Of course, the above scripts and modules are weird. we have never written such options in our [api document](https://iojs.org/api/fs.html#fs_fs_createreadstream_path_options).

BUT I have 2 opinions.

- the error message(`TypeError: Object prototype may only be an Object or null: utf8`) is not so easy to understand. We should return `Bad Arguments` like [other functions](https://github.com/iojs/io.js/blob/v1.x/lib/fs.js#L232). 
- `fs.createReadStream` and `fs.createWriteStream` should accept 2nd string argument as an encoding type. our existing functions like `fs.readFile`, `fs.writeFile`, have same behavior like [here](https://github.com/iojs/io.js/blob/v1.x/lib/fs.js#L229-L230). the behavior misleads some developers.

## Fix

- https://github.com/iojs/io.js/commit/49695792040656e511bdb403a0c46213482a1b35

# Problem2

According to the [createWriteStream api docs](https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options), `encoding` option could be found in the default.

But I set the encoding option to `fs.createWriteStream('foo.txt', {encoding: 'utf8'})`, the encoding option is ignored. 

## Fix

- https://github.com/iojs/io.js/commit/2f418b697d68a889e12078552beb9b3e837fb1fe

This pull request includes the fix both problem1 and problem2. comments and discussions are welcome.