### PR TITLE
make node-gyp work with io.js-nightly versions

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -39,7 +39,13 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
+  var nightly = process.version.indexOf('nightly') > -1
+
+  var distUrl = gyp.opts['dist-url'] ||
+                gyp.opts.disturl ||
+                (nightly ? 
+                  'https://iojs.org/download/nightly' :
+                  'https://iojs.org/dist')
 
 
   // Determine which node dev files version we are installing

--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -43,7 +43,7 @@ function install (gyp, argv, callback) {
 
   var distUrl = gyp.opts['dist-url'] ||
                 gyp.opts.disturl ||
-                (nightly ? 
+                (nightly ?
                   'https://iojs.org/download/nightly' :
                   'https://iojs.org/dist')
 


### PR DESCRIPTION
Check process.version for 'nightly'. If using io.js nightly, the disUrl is changed accordingly, allowing for the correct tarball url path to be created.

This allows node-gyp to work in io.js nightly versions.