### PR TITLE
http: use official IANA Status Codes

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -27,9 +27,11 @@ const STATUS_CODES = exports.STATUS_CODES = {
   205 : 'Reset Content',
   206 : 'Partial Content',
   207 : 'Multi-Status',               // RFC 4918
+  208 : 'Already Reported',
+  226 : 'IM Used',
   300 : 'Multiple Choices',
   301 : 'Moved Permanently',
-  302 : 'Moved Temporarily',
+  302 : 'Found',
   303 : 'See Other',
   304 : 'Not Modified',
   305 : 'Use Proxy',
@@ -43,17 +45,18 @@ const STATUS_CODES = exports.STATUS_CODES = {
   405 : 'Method Not Allowed',
   406 : 'Not Acceptable',
   407 : 'Proxy Authentication Required',
-  408 : 'Request Time-out',
+  408 : 'Request Timeout',
   409 : 'Conflict',
   410 : 'Gone',
   411 : 'Length Required',
   412 : 'Precondition Failed',
-  413 : 'Request Entity Too Large',
-  414 : 'Request-URI Too Large',
+  413 : 'Payload Too Large',
+  414 : 'URI Too Long',
   415 : 'Unsupported Media Type',
-  416 : 'Requested Range Not Satisfiable',
+  416 : 'Range Not Satisfiable',
   417 : 'Expectation Failed',
   418 : 'I\'m a teapot',              // RFC 2324
+  421 : 'Misdirected Request',
   422 : 'Unprocessable Entity',       // RFC 4918
   423 : 'Locked',                     // RFC 4918
   424 : 'Failed Dependency',          // RFC 4918
@@ -66,10 +69,11 @@ const STATUS_CODES = exports.STATUS_CODES = {
   501 : 'Not Implemented',
   502 : 'Bad Gateway',
   503 : 'Service Unavailable',
-  504 : 'Gateway Time-out',
+  504 : 'Gateway Timeout',
   505 : 'HTTP Version Not Supported',
   506 : 'Variant Also Negotiates',    // RFC 2295
   507 : 'Insufficient Storage',       // RFC 4918
+  508 : 'Loop Detected',
   509 : 'Bandwidth Limit Exceeded',
   510 : 'Not Extended',               // RFC 2774
   511 : 'Network Authentication Required' // RFC 6585


### PR DESCRIPTION
[RFC 7231](https://tools.ietf.org/html/rfc7231) states about HTTP status codes:
> Note that this list is not exhaustive -- it does not include extension status codes defined in other specifications. **The complete list of status codes is maintained by IANA**.  See Section 8.2 for
details.

Section 8.2:
> The "Hypertext Transfer Protocol (HTTP) Status Code Registry" defines the namespace for the response status-code token (Section 6). The status code registry is maintained at
<[http://www.iana.org/assignments/http-status-codes](http://www.iana.org/assignments/http-status-codes)>.

> This section replaces the registration procedure for HTTP Status Codes previously defined in Section 7.1 of [RFC2817].

The **official** list of HTTP Status Codes is maintained by the IANA [here](http://www.iana.org/assignments/http-status-codes). There are other RFCs that define other codes, but these are not official.

From the io.js documentation:
> A collection of **all** the **standard** HTTP response status codes

I have found a few issues in [`http.STATUS_CODES`](https://iojs.org/api/http.html#http_http_status_codes).

## Missing status codes

These are official Status Codes, but are not defined in `STATUS_CODES`:

* 208 Already Reported
* 226 IM Used
* 421 Misdirected Request
* 508 Loop Detected

## Status codes with wrong description

These codes have an alternate description that does not match the official standard:

| code | Official description  | Description in io.js            |
| ---- | :--- | :--- |
| 302  | Found                 | Moved Temporarily               |
| 408  | Request Timeout       | Request Time-out                |
| 413  | Payload Too Large     | Request Entity Too Large        |
| 414  | URI Too Long          | Request-URI Too Large           |
| 416  | Range Not Satisfiable | Requested Range Not Satisfiable |
| 504  | Gateway Timeout       | Gateway Time-out                |

## Non-Standard codes

These codes are not standardized by the IANA, but included anyway:

* 418 I'm a teapot
* 425 Unordered Collection  
  *According to a comment, this is defined in RFC 4918, but it's not. Not even in a draft of RFC 4918.*
* 509 Bandwidth Limit Exceeded
  *The only mention of this I could find is in [Anti-DDoS Throttling of HTTP Requests by User-Agent](https://tools.ietf.org/html/draft-sigurdsson-anti-ddos-http-throttling-00.html):*  
  
  > 509 is the (non-standard) Bandwidth Limit Exceeded status code, which might indicate DDoS.

------

This PR adds missing codes and corrects those with a wrong description, but the falsely included (not official) codes have been kept.
IANA's RFC references have been added as comments.