### PR TITLE
Net: Defer reading until listeners could be added

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -209,6 +209,20 @@ function onocspresponse(resp) {
   this.emit('OCSPResponse', resp);
 }
 
+function initRead(tls, wrapped) {
+  // If we were destroyed already don't bother reading
+  if (!tls._handle)
+    return;
+
+  // Socket already has some buffered data - emulate receiving it
+  if (wrapped && wrapped._readableState && wrapped._readableState.length) {
+    var buf;
+    while ((buf = wrapped.read()) !== null)
+      tls._handle.receive(buf);
+  }
+
+  tls.read(0);
+}
 
 /**
  * Provides a wrap of socket stream to do encrypted communication.
@@ -257,7 +271,9 @@ function TLSSocket(socket, options) {
   // starting the flow of the data
   this.readable = true;
   this.writable = true;
-  this.read(0);
+
+  // Read on next tick so the caller has a chance to setup listeners
+  process.nextTick(initRead, this, socket);
 }
 util.inherits(TLSSocket, net.Socket);
 exports.TLSSocket = TLSSocket;
@@ -415,13 +431,6 @@ TLSSocket.prototype._init = function(socket, wrap) {
 
   if (options.handshakeTimeout > 0)
     this.setTimeout(options.handshakeTimeout, this._handleTimeout);
-
-  // Socket already has some buffered data - emulate receiving it
-  if (socket && socket._readableState && socket._readableState.length) {
-    var buf;
-    while ((buf = socket.read()) !== null)
-      ssl.receive(buf);
-  }
 
   if (socket instanceof net.Socket) {
     this._parent = socket;


### PR DESCRIPTION
Defer reading until user-land has a chance to add listeners. This
allows the TLS wrapper to listen for _tlsError and trigger a
clientError event if the socket already has data that could trigger.

Fixes #1114