### PR TITLE
fs: fix leak of end listener in ReadStream

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1654,7 +1654,7 @@ function ReadStream(path, options) {
   if (typeof this.fd !== 'number')
     this.open();
 
-  this.on('end', function() {
+  this.once('end', function() {
     if (this.autoClose) {
       this.destroy();
     }


### PR DESCRIPTION
When read is end, it leaves listener of `end` event.
This could be checked this way:
```js
var fs      = require('fs'),
    read    = fs.createReadStream(__filename),
    write   = fs.createWriteStream(__filename + '-copy');

read.pipe(write);

read.once('end', function() {
    var listeners = read.listeners('end');
    console.log('' + listeners[0])
});
```
The code will log this function:
```js
function () {
    if (this.autoClose) {
      this.destroy();
    }
  }
```
Version of `iojs` is:
```
> iojs -v
v1.8.1
```