### PR TITLE
cluster: sometimes debug-port value for child process can be broken

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -284,8 +284,10 @@ function masterInit() {
   function createWorkerProcess(id, env) {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
-    var debugPort = (process.debugPort + id) % kDebugPortRange + kDebugPortStart;
+    var debugPort = process.debugPort + id;
     var hasDebugArg = false;
+
+    debugPort = debugPort % kDebugPortRange + kDebugPortStart;
 
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,6 +17,7 @@ cluster.Worker = Worker;
 cluster.isWorker = ('NODE_UNIQUE_ID' in process.env);
 cluster.isMaster = (cluster.isWorker === false);
 
+const debugPortRange = (65536 - 1024);
 
 function Worker(options) {
   if (!(this instanceof Worker))
@@ -282,7 +283,7 @@ function masterInit() {
   function createWorkerProcess(id, env) {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
-    var debugPort = process.debugPort + id;
+    var debugPort = (process.debugPort + id) % debugPortRange + 1024;
     var hasDebugArg = false;
 
     workerEnv = util._extend(workerEnv, env);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,7 +17,8 @@ cluster.Worker = Worker;
 cluster.isWorker = ('NODE_UNIQUE_ID' in process.env);
 cluster.isMaster = (cluster.isWorker === false);
 
-const debugPortRange = (65536 - 1024);
+const kDebugPortStart = 1024;
+const kDebugPortRange = (65536 - kDebugPortStart);
 
 function Worker(options) {
   if (!(this instanceof Worker))
@@ -283,7 +284,7 @@ function masterInit() {
   function createWorkerProcess(id, env) {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
-    var debugPort = (process.debugPort + id) % debugPortRange + 1024;
+    var debugPort = (process.debugPort + id) % kDebugPortRange + kDebugPortStart;
     var hasDebugArg = false;
 
     workerEnv = util._extend(workerEnv, env);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,8 +17,8 @@ cluster.Worker = Worker;
 cluster.isWorker = ('NODE_UNIQUE_ID' in process.env);
 cluster.isMaster = (cluster.isWorker === false);
 
-const kDebugPortStart = 1024;
-const kDebugPortRange = (65536 - kDebugPortStart);
+const kDebugPortMin = 1024;
+const kDebugPortMax = 65535;
 
 function Worker(options) {
   if (!(this instanceof Worker))
@@ -281,13 +281,21 @@ function masterInit() {
     cluster.emit('setup', settings);
   }
 
+  var nextDebugPort = process.debugPort;
+
+  function getDebugPort() {
+    ++nextDebugPort;
+    if (nextDebugPort > kDebugPortMax) {
+      nextDebugPort = kDebugPortMin;
+    }
+    return nextDebugPort;
+  }
+
   function createWorkerProcess(id, env) {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
-    var debugPort = process.debugPort + id;
+    var debugPort = getDebugPort();
     var hasDebugArg = false;
-
-    debugPort = debugPort % kDebugPortRange + kDebugPortStart;
 
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;

--- a/test/parallel/test-cluster-debugport-overflow.js
+++ b/test/parallel/test-cluster-debugport-overflow.js
@@ -12,7 +12,8 @@ if (process.argv[2] == 'master') {
    }
 } else {
    // iojs --debug-port=65535 test-cluster-debugport-overflow.js master
-   spawn(process.argv[0], ['--debug-port=65535', __filename, 'master']).on('close', function(code){
+   var args = ['--debug-port=65535', __filename, 'master'];
+   spawn(process.argv[0], args).on('close', function(code) {
       assert.equal(42, code, 'Worker was started');
    });
 }

--- a/test/parallel/test-cluster-debugport-overflow.js
+++ b/test/parallel/test-cluster-debugport-overflow.js
@@ -6,7 +6,7 @@ if (process.argv[2] == 'master') {
    if (cluster.isMaster) {
       cluster.fork().on('exit', function(code) {
          process.exit(code);
-      })
+      });
    } else {
       process.exit(42);
    }

--- a/test/parallel/test-cluster-debugport-overflow.js
+++ b/test/parallel/test-cluster-debugport-overflow.js
@@ -1,0 +1,18 @@
+var spawn = require('child_process').spawn;
+var cluster = require('cluster');
+var assert = require('assert');
+
+if (process.argv[2] == 'master') {
+   if (cluster.isMaster) {
+      cluster.fork().on('exit', function(code) {
+         process.exit(code);
+      })
+   } else {
+      process.exit(42);
+   }
+} else {
+   // iojs --debug-port=65535 test-cluster-debugport-overflow.js master
+   spawn(process.argv[0], ['--debug-port=65535', __filename, 'master']).on('close', function(code){
+      assert.equal(42, code, 'Worker was started');
+   });
+}


### PR DESCRIPTION
In case of long running cluster, if worker processes is restarting
periodically, --debug-port value may become out of range [1024, 65535].