### PR TITLE
core: implement hrtimefp()

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -803,6 +803,22 @@ a diff reading, useful for benchmarks and measuring intervals:
     }, 1000);
 
 
+## process.hrtimefp()
+
+Returns a double of the milliseconds in high-resolution time. It's similar to
+doing:
+
+    var time = process.hrtime();
+    var timefp = t[0] * 1e3 + t[1] / 1e6;
+
+You may pass in the result of a previous call to get the diff reading:
+
+    var time = process.hrtimefp();
+
+    // Perform benchmark
+
+    time = process.hrtimefp(time);
+
 ## process.mainModule
 
 Alternate way to retrieve

--- a/src/node.cc
+++ b/src/node.cc
@@ -1994,6 +1994,15 @@ void Hrtime(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(tuple);
 }
 
+void Hrtimefp(const FunctionCallbackInfo<Value>& args) {
+  uint64_t time = 0;
+
+  if (args.Length() > 0)
+    time = args[0]->IntegerValue();
+
+  args.GetReturnValue().Set((static_cast<double>(uv_hrtime()) / 1e6) - time);
+}
+
 extern "C" void node_module_register(void* m) {
   struct node_module* mp = reinterpret_cast<struct node_module*>(m);
 
@@ -2838,6 +2847,7 @@ void SetupProcessObject(Environment* env,
   env->SetMethod(process, "_debugEnd", DebugEnd);
 
   env->SetMethod(process, "hrtime", Hrtime);
+  env->SetMethod(process, "hrtimefp", Hrtimefp);
 
   env->SetMethod(process, "dlopen", DLOpen);
 

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -23,3 +23,7 @@ function validateTuple(tuple) {
     assert(isFinite(v));
   });
 }
+
+var t = process.hrtimefp();
+
+assert.okay(typeof t, 'number');


### PR DESCRIPTION
hrtime() works with tuples, which comes at a performance cost. Instead,
by returning a double we're able to reduce the call from ~230ns to ~80ns
per call.

Note: I'm doing this to save the ~150ns per call that working with tuples is currently costing me.

R=@bnoordhuis
R=@indutny