### PR TITLE
net: do not set V4MAPPED on FreeBSD

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -267,8 +267,9 @@ The following flags can be passed as hints to `dns.lookup`.
 of addresses supported by the current system. For example, IPv4 addresses
 are only returned if the current system has at least one IPv4 address
 configured. Loopback addresses are not considered.
-- `dns.V4MAPPED`: If the IPv6 family was specified, but no IPv6 addresses
-were found, then return IPv4 mapped IPv6 addresses.
+- `dns.V4MAPPED`: If the IPv6 family was specified, but no IPv6 addresses were
+found, then return IPv4 mapped IPv6 addresses. Note that it is not supported
+on some operating systems (e.g FreeBSD 10.1).
 
 ## Implementation considerations
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -128,11 +128,6 @@ exports.lookup = function lookup(hostname, options, callback) {
         hints !== (exports.ADDRCONFIG | exports.V4MAPPED)) {
       throw new TypeError('invalid argument: hints must use valid flags');
     }
-
-    // FIXME(indutny): V4MAPPED on FreeBSD results in EAI_BADFLAGS, because
-    // the libc does not support it
-    if (process.platform === 'freebsd' && family !== 6)
-      hints &= ~exports.V4MAPPED;
   } else {
     family = options >>> 0;
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -924,8 +924,18 @@ function lookupAndConnect(self, options) {
     hints: 0
   };
 
-  if (dnsopts.family !== 4 && dnsopts.family !== 6)
-    dnsopts.hints = dns.ADDRCONFIG | dns.V4MAPPED;
+  if (dnsopts.family !== 4 && dnsopts.family !== 6) {
+    dnsopts.hints = dns.ADDRCONFIG;
+    // The AI_V4MAPPED hint is not supported on FreeBSD, and getaddrinfo
+    // returns EAI_BADFLAGS. However, it seems to be supported on most other
+    // systems. See
+    // http://lists.freebsd.org/pipermail/freebsd-bugs/2008-February/028260.html
+    // and
+    // https://svnweb.freebsd.org/base/head/lib/libc/net/getaddrinfo.c?r1=172052&r2=175955
+    // for more information on the lack of support for FreeBSD.
+    if (process.platform !== 'freebsd')
+      dnsopts.hints |= dns.V4MAPPED;
+  }
 
   debug('connect: find host ' + host);
   debug('connect: dns options ' + dnsopts);


### PR DESCRIPTION
AI_V4MAPPED is not supported on FreeBSD. This was originally fixed in 04bea9f9c224d9f863f671a1ad52a3f392b292cb. However, a possibly better alternative just landed in https://github.com/joyent/node/commit/0e392f3b68fecf8d45032a8f427e22f7f1cb25cf. This commit reverts 04bea9f9c224d9f863f671a1ad52a3f392b292cb and applies https://github.com/joyent/node/commit/0e392f3b68fecf8d45032a8f427e22f7f1cb25cf.

The original fix unsets the flag during DNS lookup on FreeBSD. The new, alternative approach, does not set the flag in the first place in `connect()`.

R=@indutny 