### PR TITLE
test: eval mode net.listen should emit listening

### DIFF
--- a/test/parallel/test-net-listen-anyaddr.js
+++ b/test/parallel/test-net-listen-anyaddr.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var common = require('../common');
+var cp = require('child_process');
+
+var args = [
+  '-e',
+  "require('net').createServer().listen(0, function() { this.close(); });",
+];
+
+// should exit cleanly almost immediately
+var opts = {
+  timeout: common.platformTimeout(1000),
+};
+
+cp.execFile(process.execPath, args, opts, assert.ifError);


### PR DESCRIPTION
I found this when trying to confirm the format of the address object. The following hangs on most releases of node higher than 0.10.38:
```
node -e "require('net').createServer().listen(0, function() { console.log(this.address()); this.close(); });"
```

It seems that Server does not emit a listen event when no address is specified _and_ is called in eval mode.

I don't fully understand _how_ the regression was introduced, but `git bisect` seemed pretty confident that it was in 5b636feaa8550ca39229e7d8805c73c72f7995dc.

/to @trevnorris for the indicated commit
/cc @piscisaureus @sam-github 

