### PR TITLE
build: refactor pkg-config for shared libraries

### DIFF
--- a/configure
+++ b/configure
@@ -700,14 +700,15 @@ def configure_library(lib, output):
     libs = pkg_libs if pkg_libs else default_lib
     libpath = pkg_libpath if pkg_libpath else default_libpath
 
+    # libpath needs to be provided ahead libraries
+    if libpath:
+      output['libraries'] += [libpath]
     if libs:
       # libs passed to the linker cannot contain spaces.
       # (libpath on the other hand can)
       output['libraries'] += libs.split()
     if cflags:
       output['include_dirs'] += [cflags]
-    if libpath:
-      output['libraries'] += [libpath]
 
 
 def configure_v8(o):
@@ -850,10 +851,10 @@ def configure_intl(o):
       print 'See above errors or the README.md.'
       sys.exit(1)
     (libs, cflags, libpath) = pkgicu
-    # safe to split, cannot contain spaces
-    o['libraries'] += libs.split()
     # libpath provides linker path which may contain spaces
     o['libraries'] += [libpath]
+    # safe to split, cannot contain spaces
+    o['libraries'] += libs.split()
     o['cflags'] += cflags.split()
     # use the "system" .gyp
     o['variables']['icu_gyp_path'] = 'tools/icu/icu-system.gyp'

--- a/configure
+++ b/configure
@@ -343,7 +343,8 @@ def b(value):
 
 
 def pkg_config(pkg):
-  pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
+  pkg_config = os.environ.get('PKG_CONFIG_PATH',
+    os.environ.get('PKG_CONFIG', 'pkg-config'))
   pkg_config_args = '--silence-errors'
   retval = ()
   for flag in ['--libs', '--cflags']:

--- a/configure
+++ b/configure
@@ -343,26 +343,29 @@ def b(value):
 
 
 def pkg_config(pkg):
-  pkg_config = os.environ.get('PKG_CONFIG_PATH',
-    os.environ.get('PKG_CONFIG', 'pkg-config'))
-  pkg_config_args = '--silence-errors'
+  pkg_config = 'pkg-config'
+  pkg_config = os.environ.get('PKG_CONFIG', pkg_config)
+  pkg_config = os.environ.get('PKG_CONFIG_PATH', pkg_config)
+  args = '--silence-errors'
   retval = ()
-  for flag in ['--libs-only-l', '--cflags-only-I']:
+  for flag in ['--libs-only-l', '--cflags-only-I', '--libs-only-L']:
     try:
-     val = subprocess.check_output([pkg_config, pkg_config_args, flag, pkg]).rstrip('\n')
+      val = subprocess.check_output([pkg_config, args, flag, pkg]).rstrip('\n')
     except subprocess.CalledProcessError:
       # most likely missing a .pc-file
       val = None
     except OSError:
       # no pkg-config/pkgconf installed
-      return (None, None)
+      return (None, None, None)
     retval += (val,)
   return retval
+
 
 def format_libraries(list):
   """Returns string of space separated libraries"""
   set = list.split(',')
   return ' '.join('-l{0}'.format(i) for i in set)
+
 
 def try_check_compiler(cc, lang):
   try:
@@ -681,24 +684,26 @@ def configure_node(o):
 
 
 def configure_library(lib, output):
-  shared_lib = 'shared_%s' % lib
-  output['variables']['node_%s' % shared_lib] = b(getattr(options, shared_lib))
+  shared_lib = 'shared_' + lib
+  output['variables']['node_' + shared_lib] = b(getattr(options, shared_lib))
 
   if getattr(options, shared_lib):
-    default_lib = format_libraries(getattr(options, '%s_libname' % shared_lib))
-    default_libpath = getattr(options, '%s_libpath' % shared_lib)
-    default_cflags = getattr(options, '%s_includes' % shared_lib)
-    
-    (pkg_libs, pkg_cflags) = pkg_config(lib)
-    libs = pkg_libs if pkg_libs else default_lib
+    default_cflags = getattr(options, shared_lib + '_includes')
+    default_lib = format_libraries(getattr(options, shared_lib + '_libname'))
+    default_libpath = getattr(options, shared_lib + '_libpath')
+    if default_libpath:
+      default_libpath = "-L" + default_libpath
+    (pkg_libs, pkg_cflags, pkg_libpath) = pkg_config(lib)
     cflags = pkg_cflags.split("-I") if pkg_cflags else default_cflags
+    libs = pkg_libs if pkg_libs else default_lib
+    libpath = pkg_libpath if pkg_libpath else default_libpath
   
     if libs:
       output['libraries'] += libs.split()
     if cflags:
       output['include_dirs'] += [cflags]
-    if default_libpath:
-      output['libraries'] += ['-L%s' % default_libpath]
+    if libpath:
+      output['libraries'] += [libpath]
 
 def configure_v8(o):
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
@@ -834,12 +839,13 @@ def configure_intl(o):
     # ICU from pkg-config.
     o['variables']['v8_enable_i18n_support'] = 1
     pkgicu = pkg_config('icu-i18n')
-    if not pkgicu:
+    if pkgicu[1] == None:
       print 'Error: could not load pkg-config data for "icu-i18n".'
       print 'See above errors or the README.md.'
       sys.exit(1)
-    (libs, cflags) = pkgicu
+    (libs, cflags, libpath) = pkgicu
     o['libraries'] += libs.split()
+    o['libraries'] += libpath.split()
     o['cflags'] += cflags.split()
     # use the "system" .gyp
     o['variables']['icu_gyp_path'] = 'tools/icu/icu-system.gyp'

--- a/configure
+++ b/configure
@@ -345,7 +345,6 @@ def b(value):
 def pkg_config(pkg):
   pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
   pkg_config_args = '--silence-errors'
-
   retval = ()
   for flag in ['--libs', '--cflags']:
     try:
@@ -356,9 +355,7 @@ def pkg_config(pkg):
     except OSError:
       # no pkg-config/pkgconf installed
       return (None, None)
-
     retval += (val,)
-
   return retval
 
 def format_libraries(list):
@@ -717,7 +714,6 @@ def configure_openssl(o):
 
   if options.without_ssl:
     return
-
   configure_library('openssl', o)
 
 def configure_fullystatic(o):

--- a/configure
+++ b/configure
@@ -1013,11 +1013,7 @@ configure_intl(output)
 configure_fullystatic(output)
 
 # remove duplicates from libraries
-unique_libraries = []
-for library in output['libraries']:
-  if library not in unique_libraries:
-     unique_libraries.append(library)
-output['libraries'] = unique_libraries
+output['libraries'] = list(set(output['libraries']))
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/configure
+++ b/configure
@@ -840,7 +840,7 @@ def configure_intl(o):
     # ICU from pkg-config.
     o['variables']['v8_enable_i18n_support'] = 1
     pkgicu = pkg_config('icu-i18n')
-    if pkgicu[1] == None:
+    if pkgicu[0] == None:
       print 'Error: could not load pkg-config data for "icu-i18n".'
       print 'See above errors or the README.md.'
       sys.exit(1)

--- a/configure
+++ b/configure
@@ -350,7 +350,9 @@ def pkg_config(pkg):
   retval = ()
   for flag in ['--libs-only-l', '--cflags-only-I', '--libs-only-L']:
     try:
-      val = subprocess.check_output([pkg_config, args, flag, pkg]).rstrip('\n')
+      val = subprocess.check_output([pkg_config, args, flag, pkg])
+      # check_output returns bytes
+      val = val.encode().strip().rstrip('\n')
     except subprocess.CalledProcessError:
       # most likely missing a .pc-file
       val = None
@@ -697,7 +699,7 @@ def configure_library(lib, output):
     cflags = pkg_cflags.split("-I") if pkg_cflags else default_cflags
     libs = pkg_libs if pkg_libs else default_lib
     libpath = pkg_libpath if pkg_libpath else default_libpath
-  
+
     if libs:
       output['libraries'] += libs.split()
     if cflags:

--- a/configure
+++ b/configure
@@ -345,11 +345,6 @@ def b(value):
 def pkg_config(pkg):
   pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
   pkg_config_args = '--silence-errors'
-  try:
-    subprocess.check_output([pkg_config, '--version'])
-  except OSError:
-    # no pkg-config/pkgconf installed
-    return (None, None)
 
   retval = ()
   for flag in ['--libs', '--cflags']:
@@ -358,6 +353,9 @@ def pkg_config(pkg):
     except subprocess.CalledProcessError:
       # most likely missing a .pc-file
       val = None
+    except OSError:
+      # no pkg-config/pkgconf installed
+      return (None, None)
 
     retval += (val,)
 

--- a/configure
+++ b/configure
@@ -1019,9 +1019,6 @@ configure_winsdk(output)
 configure_intl(output)
 configure_fullystatic(output)
 
-# remove duplicates from libraries
-output['libraries'] = list(set(output['libraries']))
-
 # variables should be a root level element,
 # move everything else to target_defaults
 variables = output['variables']

--- a/configure
+++ b/configure
@@ -360,7 +360,6 @@ def pkg_config(pkg):
 
 def format_libraries(list):
   """Returns string of space separated libraries"""
-  list = list.replace(' ', '')
   set = list.split(',')
   return ' '.join('-l{0}'.format(i) for i in set)
 

--- a/configure
+++ b/configure
@@ -694,18 +694,21 @@ def configure_library(lib, output):
     default_lib = format_libraries(getattr(options, shared_lib + '_libname'))
     default_libpath = getattr(options, shared_lib + '_libpath')
     if default_libpath:
-      default_libpath = "-L" + default_libpath
+      default_libpath = '-L' + default_libpath
     (pkg_libs, pkg_cflags, pkg_libpath) = pkg_config(lib)
-    cflags = pkg_cflags.split("-I") if pkg_cflags else default_cflags
+    cflags = pkg_cflags.split('-I') if pkg_cflags else default_cflags
     libs = pkg_libs if pkg_libs else default_lib
     libpath = pkg_libpath if pkg_libpath else default_libpath
 
     if libs:
+      # libs passed to the linker cannot contain spaces.
+      # (libpath on the other hand can)
       output['libraries'] += libs.split()
     if cflags:
       output['include_dirs'] += [cflags]
     if libpath:
       output['libraries'] += [libpath]
+
 
 def configure_v8(o):
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
@@ -842,13 +845,15 @@ def configure_intl(o):
     # ICU from pkg-config.
     o['variables']['v8_enable_i18n_support'] = 1
     pkgicu = pkg_config('icu-i18n')
-    if pkgicu[0] == None:
+    if pkgicu[0] is None:
       print 'Error: could not load pkg-config data for "icu-i18n".'
       print 'See above errors or the README.md.'
       sys.exit(1)
     (libs, cflags, libpath) = pkgicu
+    # safe to split, cannot contain spaces
     o['libraries'] += libs.split()
-    o['libraries'] += libpath.split()
+    # libpath provides linker path which may contain spaces
+    o['libraries'] += [libpath]
     o['cflags'] += cflags.split()
     # use the "system" .gyp
     o['variables']['icu_gyp_path'] = 'tools/icu/icu-system.gyp'

--- a/configure
+++ b/configure
@@ -365,8 +365,8 @@ def pkg_config(pkg):
 
 def format_libraries(list):
   """Returns string of space separated libraries"""
-  set = list.split(',')
-  return ' '.join('-l{0}'.format(i) for i in set)
+  libraries = list.split(',')
+  return ' '.join('-l{0}'.format(i) for i in libraries)
 
 
 def try_check_compiler(cc, lang):

--- a/configure
+++ b/configure
@@ -343,18 +343,31 @@ def b(value):
 
 
 def pkg_config(pkg):
-  cmd = os.popen('pkg-config --libs %s' % pkg, 'r')
-  libs = cmd.readline().strip()
-  ret = cmd.close()
-  if (ret): return None
+  pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
+  pkg_config_args = '--silence-errors'
+  try:
+    subprocess.check_output([pkg_config, '--version'])
+  except OSError:
+    # no pkg-config/pkgconf installed
+    return (None, None)
 
-  cmd = os.popen('pkg-config --cflags %s' % pkg, 'r')
-  cflags = cmd.readline().strip()
-  ret = cmd.close()
-  if (ret): return None
+  retval = ()
+  for flag in ['--libs', '--cflags']:
+    try:
+     val = subprocess.check_output([pkg_config, pkg_config_args, flag, pkg])
+    except subprocess.CalledProcessError:
+      # most likely missing a .pc-file
+      val = None
 
-  return (libs, cflags)
+    retval += (val,)
 
+  return retval
+
+def format_libraries(list):
+  """Returns string of space separated libraries"""
+  list = list.replace(' ', '')
+  set = list.split(',')
+  return ' '.join('-l{0}'.format(i) for i in set)
 
 def try_check_compiler(cc, lang):
   try:
@@ -672,41 +685,25 @@ def configure_node(o):
     o['variables']['node_target_type'] = 'static_library'
 
 
-def configure_libz(o):
-  o['variables']['node_shared_zlib'] = b(options.shared_zlib)
+def configure_library(lib, output):
+  shared_lib = 'shared_%s' % lib
+  output['variables']['node_%s' % shared_lib] = b(getattr(options, shared_lib))
 
-  if options.shared_zlib:
-    o['libraries'] += ['-l%s' % options.shared_zlib_libname]
-  if options.shared_zlib_libpath:
-    o['libraries'] += ['-L%s' % options.shared_zlib_libpath]
-  if options.shared_zlib_includes:
-    o['include_dirs'] += [options.shared_zlib_includes]
-
-
-def configure_http_parser(o):
-    o['variables']['node_shared_http_parser'] = b(options.shared_http_parser)
-
-    if options.shared_http_parser:
-      o['libraries'] += ['-l%s' % options.shared_http_parser_libname]
-    if options.shared_http_parser_libpath:
-        o['libraries'] += ['-L%s' % options.shared_http_parser_libpath]
-    if options.shared_http_parser_includes:
-        o['include_dirs'] += [options.shared_http_parser_includes]
-
-
-def configure_libuv(o):
-  o['variables']['node_shared_libuv'] = b(options.shared_libuv)
-
-  if options.shared_libuv:
-    o['libraries'] += ['-l%s' % options.shared_libuv_libname]
-  if options.shared_libuv_libpath:
-    o['libraries'] += ['-L%s' % options.shared_libuv_libpath]
-  else:
-    o['variables']['uv_library'] = 'static_library'
-
-  if options.shared_libuv_includes:
-    o['include_dirs'] += [options.shared_libuv_includes]
-
+  if getattr(options, shared_lib):
+    default_lib = format_libraries(getattr(options, '%s_libname' % shared_lib))
+    default_libpath = getattr(options, '%s_libpath' % shared_lib)
+    default_cflags = getattr(options, '%s_includes' % shared_lib)
+    
+    (pkg_libs, pkg_cflags) = pkg_config(lib)
+    libs = pkg_libs if pkg_libs else default_lib
+    cflags = pkg_cflags if pkg_cflags else default_cflags
+  
+    if libs:
+      output['libraries'] += libs.split()
+    if cflags:
+      output['include_dirs'] += cflags.split()
+    if default_libpath:
+      output['libraries'] += ['-L%s' % default_libpath]
 
 def configure_v8(o):
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
@@ -718,26 +715,12 @@ def configure_v8(o):
 def configure_openssl(o):
   o['variables']['node_use_openssl'] = b(not options.without_ssl)
   o['variables']['node_shared_openssl'] = b(options.shared_openssl)
-  o['variables']['openssl_no_asm'] = (
-    1 if options.openssl_no_asm else 0)
+  o['variables']['openssl_no_asm'] = 1 if options.openssl_no_asm else 0
 
   if options.without_ssl:
     return
 
-  if options.shared_openssl:
-    (libs, cflags) = pkg_config('openssl') or ('-lssl -lcrypto', '')
-
-    libnames = options.shared_openssl_libname.split(',')
-    o['libraries'] += ['-l%s' % s for s in libnames]
-
-    if options.shared_openssl_libpath:
-      o['libraries'] += ['-L%s' % options.shared_openssl_libpath]
-
-    if options.shared_openssl_includes:
-      o['include_dirs'] += [options.shared_openssl_includes]
-    else:
-      o['cflags'] += cflags.split()
-
+  configure_library('openssl', o)
 
 def configure_fullystatic(o):
   if options.fully_static:
@@ -1020,14 +1003,21 @@ if (options.dest_os):
 flavor = GetFlavor(flavor_params)
 
 configure_node(output)
-configure_libz(output)
-configure_http_parser(output)
-configure_libuv(output)
+configure_library('zlib', output)
+configure_library('http_parser', output)
+configure_library('libuv', output)
 configure_v8(output)
 configure_openssl(output)
 configure_winsdk(output)
 configure_intl(output)
 configure_fullystatic(output)
+
+# remove duplicates from libraries
+unique_libraries = []
+for library in output['libraries']:
+  if library not in unique_libraries:
+     unique_libraries.append(library)
+output['libraries'] = unique_libraries
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/configure
+++ b/configure
@@ -343,9 +343,7 @@ def b(value):
 
 
 def pkg_config(pkg):
-  pkg_config = 'pkg-config'
-  pkg_config = os.environ.get('PKG_CONFIG', pkg_config)
-  pkg_config = os.environ.get('PKG_CONFIG_PATH', pkg_config)
+  pkg_config = os.environ.get('PKG_CONFIG', 'pkg-config')
   args = '--silence-errors'
   retval = ()
   for flag in ['--libs-only-l', '--cflags-only-I', '--libs-only-L']:

--- a/configure
+++ b/configure
@@ -347,9 +347,9 @@ def pkg_config(pkg):
     os.environ.get('PKG_CONFIG', 'pkg-config'))
   pkg_config_args = '--silence-errors'
   retval = ()
-  for flag in ['--libs', '--cflags']:
+  for flag in ['--libs-only-l', '--cflags-only-I']:
     try:
-     val = subprocess.check_output([pkg_config, pkg_config_args, flag, pkg])
+     val = subprocess.check_output([pkg_config, pkg_config_args, flag, pkg]).rstrip('\n')
     except subprocess.CalledProcessError:
       # most likely missing a .pc-file
       val = None
@@ -691,12 +691,12 @@ def configure_library(lib, output):
     
     (pkg_libs, pkg_cflags) = pkg_config(lib)
     libs = pkg_libs if pkg_libs else default_lib
-    cflags = pkg_cflags if pkg_cflags else default_cflags
+    cflags = pkg_cflags.split("-I") if pkg_cflags else default_cflags
   
     if libs:
       output['libraries'] += libs.split()
     if cflags:
-      output['include_dirs'] += cflags.split()
+      output['include_dirs'] += [cflags]
     if default_libpath:
       output['libraries'] += ['-L%s' % default_libpath]
 

--- a/configure
+++ b/configure
@@ -721,6 +721,7 @@ def configure_openssl(o):
     return
   configure_library('openssl', o)
 
+
 def configure_fullystatic(o):
   if options.fully_static:
     o['libraries'] += ['-static']


### PR DESCRIPTION
Improve detection and usage of pkg-config. This simplifies the setup of all our shared libraries.

If pkg-config is installed on the host and `--shared` flags are passed by the user, we try to get defaults from pkg-config instead of using the default provided by configure.

/R = @iojs/build, @bnoordhuis 