### PR TITLE
lib: simplify nextTick() usage

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -293,20 +293,14 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
 }
 
 function onwriteError(stream, state, sync, er, cb) {
+  --state.pendingcb;
   if (sync)
-    process.nextTick(onwriteErrorNT, state, cb, er);
-  else {
-    state.pendingcb--;
+    process.nextTick(cb, er);
+  else
     cb(er);
-  }
 
   stream._writableState.errorEmitted = true;
   stream.emit('error', er);
-}
-
-function onwriteErrorNT(state, cb, er) {
-  state.pendingcb--;
-  cb(er);
 }
 
 function onwriteStateUpdate(state) {

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -448,16 +448,16 @@ CryptoStream.prototype.destroy = function(err) {
   }
   this._opposite.destroy();
 
-  process.nextTick(destroyNT, this, err);
+  process.nextTick(destroyNT, this, err ? true : false);
 };
 
 
-function destroyNT(self, err) {
+function destroyNT(self, hadErr) {
   // Force EOF
   self.push(null);
 
   // Emit 'close' event
-  self.emit('close', err ? true : false);
+  self.emit('close', hadErr);
 }
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -444,9 +444,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
   }
   if (!this._handle.renegotiate()) {
     if (callback) {
-      process.nextTick(function() {
-        callback(new Error('Failed to renegotiate'));
-      });
+      process.nextTick(callback, new Error('Failed to renegotiate'));
     }
     return false;
   }

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -321,17 +321,12 @@ Socket.prototype.send = function(buffer,
                                   !!callback);
       if (err && callback) {
         // don't emit as error, dgram_legacy.js compatibility
-        process.nextTick(sendEmitErrorNT, err, address, port, callback);
+        var ex = exceptionWithHostPort(err, 'send', address, port);
+        process.nextTick(callback, ex);
       }
     }
   });
 };
-
-
-function sendEmitErrorNT(err, address, port, callback) {
-  var ex = exceptionWithHostPort(err, 'send', address, port);
-  callback(ex);
-}
 
 
 function afterSend(err) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -61,14 +61,13 @@ function makeAsync(callback) {
       // The API already returned, we can invoke the callback immediately.
       callback.apply(null, arguments);
     } else {
-      process.nextTick(callMakeAsyncCbNT, callback, arguments);
+      var args = new Array(arguments.length + 1);
+      args[0] = callback;
+      for (var i = 1, a = 0; a < arguments.length; ++i, ++a)
+        args[i] = arguments[a];
+      process.nextTick.apply(null, args);
     }
   };
-}
-
-
-function callMakeAsyncCbNT(callback, args) {
-  callback.apply(null, args);
 }
 
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -268,12 +268,8 @@ function writeAfterFIN(chunk, encoding, cb) {
   // TODO: defer error events consistently everywhere, not just the cb
   self.emit('error', er);
   if (typeof cb === 'function') {
-    process.nextTick(writeAfterFINNT, cb, er);
+    process.nextTick(cb, er);
   }
-}
-
-function writeAfterFINNT(cb, er) {
-  cb(er);
 }
 
 exports.Socket = Socket;
@@ -426,9 +422,7 @@ Socket.prototype._destroy = function(exception, cb) {
   function fireErrorCallbacks() {
     if (cb) cb(exception);
     if (exception && !self._writableState.errorEmitted) {
-      process.nextTick(function() {
-        self.emit('error', exception);
-      });
+      process.nextTick(emitErrorNT, self, exception);
       self._writableState.errorEmitted = true;
     }
   };
@@ -946,7 +940,10 @@ function lookupAndConnect(self, options) {
       // immediately calls net.Socket.connect() on it (that's us).
       // There are no event listeners registered yet so defer the
       // error event to the next tick.
-      process.nextTick(connectErrorNT, self, err, options);
+      err.host = options.host;
+      err.port = options.port;
+      err.message = err.message + ' ' + options.host + ':' + options.port;
+      process.nextTick(connectErrorNT, self, err);
     } else {
       self._unrefTimer();
       connect(self,
@@ -960,10 +957,7 @@ function lookupAndConnect(self, options) {
 }
 
 
-function connectErrorNT(self, err, options) {
-  err.host = options.host;
-  err.port = options.port;
-  err.message = err.message + ' ' + options.host + ':' + options.port;
+function connectErrorNT(self, err) {
   self.emit('error', err);
   self._destroy();
 }
@@ -1177,9 +1171,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
     if (typeof rval === 'number') {
       var error = exceptionWithHostPort(rval, 'listen', address, port);
-      process.nextTick(function() {
-        self.emit('error', error);
-      });
+      process.nextTick(emitErrorNT, self, error);
       return;
     }
     self._handle = rval;
@@ -1194,9 +1186,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
     var ex = exceptionWithHostPort(err, 'listen', address, port);
     self._handle.close();
     self._handle = null;
-    process.nextTick(function() {
-      self.emit('error', ex);
-    });
+    process.nextTick(emitErrorNT, self, ex);
     return;
   }
 
@@ -1209,6 +1199,11 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
   process.nextTick(emitListeningNT, self);
 };
+
+
+function emitErrorNT(self, err) {
+  self.emit('error', err);
+}
 
 
 function emitListeningNT(self) {
@@ -1384,9 +1379,7 @@ function onconnection(err, clientHandle) {
 
 Server.prototype.getConnections = function(cb) {
   function end(err, connections) {
-    process.nextTick(function() {
-      cb(err, connections);
-    });
+    process.nextTick(cb, err, connections);
   }
 
   if (!this._usingSlaves) {
@@ -1465,11 +1458,14 @@ Server.prototype._emitCloseIfDrained = function() {
     return;
   }
 
-  process.nextTick(function() {
-    debug('SERVER: emit close');
-    self.emit('close');
-  });
+  process.nextTick(emitCloseNT, self);
 };
+
+
+function emitCloseNT(self) {
+  debug('SERVER: emit close');
+  self.emit('close');
+}
 
 
 Server.prototype.listenFD = util.deprecate(function(fd, type) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -97,9 +97,7 @@ function listOnTimeout() {
           // when the timeout threw its exception.
           var oldDomain = process.domain;
           process.domain = null;
-          process.nextTick(function() {
-            list[kOnTimeout]();
-          });
+          process.nextTick(listOnTimeoutNT, list);
           process.domain = oldDomain;
         }
       }
@@ -110,6 +108,11 @@ function listOnTimeout() {
   assert(L.isEmpty(list));
   list.close();
   delete lists[msecs];
+}
+
+
+function listOnTimeoutNT(list) {
+  list[kOnTimeout]();
 }
 
 


### PR DESCRIPTION
This commit removes unnecessary `nextTick()` closures and adds some shared `nextTick()` callbacks for better re-use.