### PR TITLE
os: make `tmpdir` be const value

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -3,6 +3,24 @@
 const binding = process.binding('os');
 const util = require('util');
 const isWindows = process.platform === 'win32';
+const tmpdir = getTmpdir();
+
+function getTmpdir() {
+  var path;
+  if (isWindows) {
+    path = process.env.TEMP ||
+           process.env.TMP ||
+           (process.env.SystemRoot || process.env.windir) + '\\temp';
+  } else {
+    path = process.env.TMPDIR ||
+           process.env.TMP ||
+           process.env.TEMP ||
+           '/tmp';
+  }
+  if (/[\\\/]$/.test(path))
+    path = path.slice(0, -1);
+  return path;
+}
 
 exports.hostname = binding.getHostname;
 exports.loadavg = binding.getLoadAvg;
@@ -23,20 +41,7 @@ exports.platform = function() {
 };
 
 exports.tmpdir = function() {
-  var path;
-  if (isWindows) {
-    path = process.env.TEMP ||
-           process.env.TMP ||
-           (process.env.SystemRoot || process.env.windir) + '\\temp';
-  } else {
-    path = process.env.TMPDIR ||
-           process.env.TMP ||
-           process.env.TEMP ||
-           '/tmp';
-  }
-  if (/[\\\/]$/.test(path))
-    path = path.slice(0, -1);
-  return path;
+  return tmpdir;
 };
 
 exports.tmpDir = exports.tmpdir;


### PR DESCRIPTION
This patch also make the function `getTmpdir()` be called once with a little improvement, but the main purpose of this PR is to make `tmpdir` as `const` as well.