### PR TITLE
Fix to handle tls error properly

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -362,7 +362,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
     self._writableState.errorEmitted = true;
 
     // Destroy socket if error happened before handshake's finish
-    if (!this._secureEstablished) {
+    if (!self._secureEstablished) {
       self._tlsError(err);
       self.destroy();
     } else if (options.isServer &&


### PR DESCRIPTION
This is a fix of the error handling of tls and tls_wrap. Especially it fixes the error handling when the server receiving a fatal TLS alert just after TLS handshake completed.  Testing is very hard to implement within node and `openssl s_client` so that we take this fix to resolve the issue of #1642 from the comments from reporters.

CI results are  https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/655/ where the test failures on Windows are related to child process not related this.

Fix: https://github.com/iojs/io.js/issues/1642

R= @indutny 
