### PR TITLE
os: add .homedir()

### DIFF
--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -10,6 +10,10 @@ Use `require('os')` to access this module.
 
 Returns the operating system's default directory for temporary files.
 
+## os.homedir()
+
+Returns the home directory path of the current user.
+
 ## os.endianness()
 
 Returns the endianness of the CPU. Possible values are `'BE'` for big endian

--- a/lib/os.js
+++ b/lib/os.js
@@ -51,3 +51,8 @@ if (binding.isBigEndian)
   exports.endianness = function() { return 'BE'; };
 else
   exports.endianness = function() { return 'LE'; };
+
+exports.homedir = function() {
+  const location = isWindows ? process.env.USERPROFILE : process.env.HOME;
+  return location;
+};

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -90,3 +90,9 @@ switch (platform) {
 
 var EOL = os.EOL;
 assert.ok(EOL.length > 0);
+
+if (process.platform === 'win32') {
+  assert.equal(os.homedir(), process.env.USERPROFILE);
+} else {
+  assert.equal(os.homedir(), process.env.HOME);
+}


### PR DESCRIPTION
In almost every cli-client that I write I need the current homedir
at a certain point.

While we have a function for getting the directory for storing
temporary files (callled `tmpdir`), a function for receiving the
location of the home directory is still missing.