### PR TITLE
repl: globals must be an array

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -90,6 +90,9 @@ You can use your own `eval` function if it has following signature:
       callback(null, result);
     }
 
+The first argument `cmd` will be assigned to the value `.scope` rather than 
+the original words when `input` stream accepts the `<tab>` keyword.
+
 Multiple REPLs may be started against the same running instance of io.js.  Each
 will share the same global object but will have unique I/O.
 
@@ -226,10 +229,13 @@ There are a few special REPL commands:
     >.save ./file/to/save.js
   - `.load` - Load a file into the current REPL session.
     >.load ./file/to/load.js
+  - `.scope` - Show both global and local(scope) variables
+    >.scope
 
 The following key combinations in the REPL have these special effects:
 
   - `<ctrl>C` - Similar to the `.break` keyword.  Terminates the current
     command.  Press twice on a blank line to forcibly exit.
   - `<ctrl>D` - Similar to the `.exit` keyword.
+  - `<tab>` - Similar to the `.scope` keyword.
 

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -90,8 +90,8 @@ You can use your own `eval` function if it has following signature:
       callback(null, result);
     }
 
-The first argument `cmd` will be assigned to the value `.scope` rather than 
-the original words when `input` stream accepts the `<tab>` keyword.
+On tab completion - `eval` will be called with `.scope` as an input string. It
+is expected to return an array of scope names to be used for the auto-completion.
 
 Multiple REPLs may be started against the same running instance of io.js.  Each
 will share the same global object but will have unique I/O.

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -229,13 +229,11 @@ There are a few special REPL commands:
     >.save ./file/to/save.js
   - `.load` - Load a file into the current REPL session.
     >.load ./file/to/load.js
-  - `.scope` - Show both global and local(scope) variables
-    >.scope
 
 The following key combinations in the REPL have these special effects:
 
   - `<ctrl>C` - Similar to the `.break` keyword.  Terminates the current
     command.  Press twice on a blank line to forcibly exit.
   - `<ctrl>D` - Similar to the `.exit` keyword.
-  - `<tab>` - Similar to the `.scope` keyword.
+  - `<tab>` - Show both global and local(scope) variables
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -624,7 +624,7 @@ REPLServer.prototype.complete = function(line, callback) {
           completionGroupsLoaded();
         } else {
           this.eval('.scope', this.context, 'repl', function(err, globals) {
-            if (err || !globals) {
+            if (err || !globals || !Array.isArray(globals)) {
               addStandardGlobals(completionGroups, filter);
             } else if (Array.isArray(globals[0])) {
               // Add grouped globals

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -939,13 +939,6 @@ function defineDefaultCommands(repl) {
       this.displayPrompt();
     }
   });
-
-  repl.defineCommand('scope', {
-    help: 'Show both global and local(scope) variables',
-    action: function(file) {
-      this.complete('', this._tabComplete.bind(this));
-    }
-  });
 }
 
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -939,6 +939,13 @@ function defineDefaultCommands(repl) {
       this.displayPrompt();
     }
   });
+
+  repl.defineCommand('scope', {
+    help: 'Show both global and local(scope) variables',
+    action: function(file) {
+      this.complete('', this._tabComplete.bind(this));
+    }
+  });
 }
 
 

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -2,37 +2,6 @@ var assert = require('assert');
 var util = require('util');
 var repl = require('repl');
 var zlib = require('zlib');
-var defaultScopes = [
-  'Array',
-  'Boolean',
-  'Date',
-  'Error',
-  'EvalError',
-  'Function',
-  'Infinity',
-  'JSON',
-  'Math',
-  'NaN',
-  'Number',
-  'Object',
-  'RangeError',
-  'ReferenceError',
-  'RegExp',
-  'String',
-  'SyntaxError',
-  'TypeError',
-  'URIError',
-  'decodeURI',
-  'decodeURIComponent',
-  'encodeURI',
-  'encodeURIComponent',
-  'eval',
-  'isFinite',
-  'isNaN',
-  'parseFloat',
-  'parseInt',
-  'undefined'
-];
 
 // just use builtin stream inherited from Duplex
 var putIn = zlib.createGzip();
@@ -46,5 +15,4 @@ testMe._domain.on('error', function (e) {
 
 testMe.complete('', function(err, results) {
   assert.equal(err, null);
-  assert.deepEqual(results[0], defaultScopes);
 });

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -1,16 +1,41 @@
 var assert = require('assert');
 var util = require('util');
-var repl = require('./index');
+var repl = require('repl');
+var zlib = require('zlib');
+var defaultScopes = [
+  'Array',
+  'Boolean',
+  'Date',
+  'Error',
+  'EvalError',
+  'Function',
+  'Infinity',
+  'JSON',
+  'Math',
+  'NaN',
+  'Number',
+  'Object',
+  'RangeError',
+  'ReferenceError',
+  'RegExp',
+  'String',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'decodeURI',
+  'decodeURIComponent',
+  'encodeURI',
+  'encodeURIComponent',
+  'eval',
+  'isFinite',
+  'isNaN',
+  'parseFloat',
+  'parseInt',
+  'undefined'
+];
 
-function ArrayStream() {}
-// A stream to push an array into a REPL
-util.inherits(ArrayStream, require('stream').Stream);
-ArrayStream.prototype.readable = true;
-ArrayStream.prototype.writable = true;
-ArrayStream.prototype.resume = function() {};
-ArrayStream.prototype.write = function() {};
-
-var putIn = new ArrayStream();
+// just use builtin stream inherited from Duplex
+var putIn = zlib.createGzip();
 var testMe = repl.start('', putIn, function(cmd, context, filename, callback) {
   callback(null, cmd);
 });
@@ -19,4 +44,7 @@ testMe._domain.on('error', function (e) {
   assert.fail();
 });
 
-testMe.complete('', function () {});
+testMe.complete('', function(err, results) {
+  assert.equal(err, null);
+  assert.deepEqual(results[0], defaultScopes);
+});

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+var util = require('util');
+var repl = require('./index');
+
+function ArrayStream() {}
+// A stream to push an array into a REPL
+util.inherits(ArrayStream, require('stream').Stream);
+ArrayStream.prototype.readable = true;
+ArrayStream.prototype.writable = true;
+ArrayStream.prototype.resume = function() {};
+ArrayStream.prototype.write = function() {};
+
+var putIn = new ArrayStream();
+var testMe = repl.start('', putIn, function(cmd, context, filename, callback) {
+  callback(null, cmd);
+});
+
+testMe._domain.on('error', function (e) {
+  assert.fail();
+});
+
+testMe.complete('', function () {});


### PR DESCRIPTION
Reproduce source code:

```
repl.start('>', stream, function(cmd, ctx, file, next) {
  next(cmd);
});
```

and press <tab> in runtime, it would prints an error over the globals list, that's because we pass the `cmd`(the value is `.scope`) to `eval` function, but we don't verify if the globals is an array.

/cc @indutny 