### PR TITLE
WIP? tools: add update-dep.sh

### DIFF
--- a/deps/floating-patches/patches-npm/deps-make-node-gyp-work-with
+++ b/deps/floating-patches/patches-npm/deps-make-node-gyp-work-with
@@ -1,0 +1,170 @@
+deps: make node-gyp work with io.js
+
+From: cjihrig <cjihrig@gmail.com>
+
+Every npm version bump requires a few patches to be floated on
+node-gyp for io.js compatibility. These patches are found in
+03d199276e21c1fa08d8df14eeb654c90cc5aa20,
+5de334c23096492014a097ff487f07ad8eaee6d2, and
+da730c76e98fb9fd18dac445dafbbec74d79f802. This commit squashes
+them into a single commit.
+
+PR-URL: https://github.com/iojs/io.js/pull/990
+Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
+---
+ deps/npm/node_modules/node-gyp/addon.gypi     |    2 +
+ deps/npm/node_modules/node-gyp/lib/build.js   |    8 +++--
+ deps/npm/node_modules/node-gyp/lib/install.js |   40 +++++++++++++------------
+ 3 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/deps/npm/node_modules/node-gyp/addon.gypi b/deps/npm/node_modules/node-gyp/addon.gypi
+index 0b81fab..63fefe3 100644
+--- a/deps/npm/node_modules/node-gyp/addon.gypi
++++ b/deps/npm/node_modules/node-gyp/addon.gypi
+@@ -42,7 +42,7 @@
+           '-luuid.lib',
+           '-lodbc32.lib',
+           '-lDelayImp.lib',
+-          '-l"<(node_root_dir)/$(ConfigurationName)/node.lib"'
++          '-l"<(node_root_dir)/$(ConfigurationName)/iojs.lib"'
+         ],
+         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
+         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'
+diff --git a/deps/npm/node_modules/node-gyp/lib/build.js b/deps/npm/node_modules/node-gyp/lib/build.js
+index df24aaf..f9722ae 100644
+--- a/deps/npm/node_modules/node-gyp/lib/build.js
++++ b/deps/npm/node_modules/node-gyp/lib/build.js
+@@ -173,7 +173,7 @@ function build (gyp, argv, callback) {
+   }
+ 
+   /**
+-   * Copies the node.lib file for the current target architecture into the
++   * Copies the iojs.lib file for the current target architecture into the
+    * current proper dev dir location.
+    */
+ 
+@@ -181,15 +181,15 @@ function build (gyp, argv, callback) {
+     if (!win || !copyDevLib) return doBuild()
+ 
+     var buildDir = path.resolve(nodeDir, buildType)
+-      , archNodeLibPath = path.resolve(nodeDir, arch, 'node.lib')
+-      , buildNodeLibPath = path.resolve(buildDir, 'node.lib')
++      , archNodeLibPath = path.resolve(nodeDir, arch, 'iojs.lib')
++      , buildNodeLibPath = path.resolve(buildDir, 'iojs.lib')
+ 
+     mkdirp(buildDir, function (err, isNew) {
+       if (err) return callback(err)
+       log.verbose('"' + buildType + '" dir needed to be created?', isNew)
+       var rs = fs.createReadStream(archNodeLibPath)
+         , ws = fs.createWriteStream(buildNodeLibPath)
+-      log.verbose('copying "node.lib" for ' + arch, buildNodeLibPath)
++      log.verbose('copying "iojs.lib" for ' + arch, buildNodeLibPath)
+       rs.pipe(ws)
+       rs.on('error', callback)
+       ws.on('error', callback)
+diff --git a/deps/npm/node_modules/node-gyp/lib/install.js b/deps/npm/node_modules/node-gyp/lib/install.js
+index 6f72e6a..f9176b3 100644
+--- a/deps/npm/node_modules/node-gyp/lib/install.js
++++ b/deps/npm/node_modules/node-gyp/lib/install.js
+@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
+     }
+   }
+ 
+-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
++  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
+ 
+ 
+   // Determine which node dev files version we are installing
+@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
+ 
+       // now download the node tarball
+       var tarPath = gyp.opts['tarball']
+-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
++      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
+         , badDownload = false
+         , extractCount = 0
+         , gunzip = zlib.createGunzip()
+@@ -267,7 +267,7 @@ function install (gyp, argv, callback) {
+         var async = 0
+ 
+         if (win) {
+-          // need to download node.lib
++          // need to download iojs.lib
+           async++
+           downloadNodeLib(deref)
+         }
+@@ -343,36 +343,36 @@ function install (gyp, argv, callback) {
+       }
+ 
+       function downloadNodeLib (done) {
+-        log.verbose('on Windows; need to download `node.lib`...')
++        log.verbose('on Windows; need to download `iojs.lib`...')
+         var dir32 = path.resolve(devDir, 'ia32')
+           , dir64 = path.resolve(devDir, 'x64')
+-          , nodeLibPath32 = path.resolve(dir32, 'node.lib')
+-          , nodeLibPath64 = path.resolve(dir64, 'node.lib')
+-          , nodeLibUrl32 = distUrl + '/v' + version + '/node.lib'
+-          , nodeLibUrl64 = distUrl + '/v' + version + '/x64/node.lib'
++          , nodeLibPath32 = path.resolve(dir32, 'iojs.lib')
++          , nodeLibPath64 = path.resolve(dir64, 'iojs.lib')
++          , nodeLibUrl32 = distUrl + '/v' + version + '/win-x86/iojs.lib'
++          , nodeLibUrl64 = distUrl + '/v' + version + '/win-x64/iojs.lib'
+ 
+-        log.verbose('32-bit node.lib dir', dir32)
+-        log.verbose('64-bit node.lib dir', dir64)
+-        log.verbose('`node.lib` 32-bit url', nodeLibUrl32)
+-        log.verbose('`node.lib` 64-bit url', nodeLibUrl64)
++        log.verbose('32-bit iojs.lib dir', dir32)
++        log.verbose('64-bit iojs.lib dir', dir64)
++        log.verbose('`iojs.lib` 32-bit url', nodeLibUrl32)
++        log.verbose('`iojs.lib` 64-bit url', nodeLibUrl64)
+ 
+         var async = 2
+         mkdir(dir32, function (err) {
+           if (err) return done(err)
+-          log.verbose('streaming 32-bit node.lib to:', nodeLibPath32)
++          log.verbose('streaming 32-bit iojs.lib to:', nodeLibPath32)
+ 
+           var req = download(nodeLibUrl32)
+           if (!req) return
+           req.on('error', done)
+           req.on('response', function (res) {
+             if (res.statusCode !== 200) {
+-              done(new Error(res.statusCode + ' status code downloading 32-bit node.lib'))
++              done(new Error(res.statusCode + ' status code downloading 32-bit iojs.lib'))
+               return
+             }
+ 
+             getContentSha(res, function (_, checksum) {
+-              contentShasums['node.lib'] = checksum
+-              log.verbose('content checksum', 'node.lib', checksum)
++              contentShasums['win-x86/iojs.lib'] = checksum
++              log.verbose('content checksum', 'win-x86/iojs.lib', checksum)
+             })
+ 
+             var ws = fs.createWriteStream(nodeLibPath32)
+@@ -385,20 +385,20 @@ function install (gyp, argv, callback) {
+         })
+         mkdir(dir64, function (err) {
+           if (err) return done(err)
+-          log.verbose('streaming 64-bit node.lib to:', nodeLibPath64)
++          log.verbose('streaming 64-bit iojs.lib to:', nodeLibPath64)
+ 
+           var req = download(nodeLibUrl64)
+           if (!req) return
+           req.on('error', done)
+           req.on('response', function (res) {
+             if (res.statusCode !== 200) {
+-              done(new Error(res.statusCode + ' status code downloading 64-bit node.lib'))
++              done(new Error(res.statusCode + ' status code downloading 64-bit iojs.lib'))
+               return
+             }
+ 
+             getContentSha(res, function (_, checksum) {
+-              contentShasums['x64/node.lib'] = checksum
+-              log.verbose('content checksum', 'x64/node.lib', checksum)
++              contentShasums['win-x64/iojs.lib'] = checksum
++              log.verbose('content checksum', 'win-x64/iojs.lib', checksum)
+             })
+ 
+             var ws = fs.createWriteStream(nodeLibPath64)

--- a/deps/floating-patches/patches-npm/series
+++ b/deps/floating-patches/patches-npm/series
@@ -1,0 +1,3 @@
+# This series applies on GIT commit 56e4255382ad4d2426e034624b41bbe97d18bca0
+deps-make-node-gyp-work-with
+win-node-gyp-enable-delay-load

--- a/deps/floating-patches/patches-npm/win-node-gyp-enable-delay-load
+++ b/deps/floating-patches/patches-npm/win-node-gyp-enable-delay-load
@@ -1,0 +1,112 @@
+win,node-gyp: enable delay-load hook by default
+
+From: Bert Belder <bertbelder@gmail.com>
+
+The delay-load hook allows node.exe/iojs.exe to be renamed. See efadffe
+for more background.
+
+Bug: https://github.com/iojs/io.js/issues/751
+Bug: https://github.com/iojs/io.js/issues/965
+Upstream PR: https://github.com/TooTallNate/node-gyp/pull/599
+
+PR-URL: https://github.com/iojs/io.js/pull/1251
+Reviewed-By: Rod Vagg <rod@vagg.org>
+
+PR-URL: https://github.com/iojs/io.js/pull/1266
+Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
+
+PR-URL: https://github.com/iojs/io.js/pull/1433
+Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
+---
+ deps/npm/node_modules/node-gyp/addon.gypi          |   25 ++++++++++++++++
+ .../node-gyp/src/win_delay_load_hook.c             |   32 ++++++++++++++++++++
+ 2 files changed, 57 insertions(+)
+ create mode 100644 deps/npm/node_modules/node-gyp/src/win_delay_load_hook.c
+
+diff --git a/deps/npm/node_modules/node-gyp/addon.gypi b/deps/npm/node_modules/node-gyp/addon.gypi
+index 63fefe3..1fe142f 100644
+--- a/deps/npm/node_modules/node-gyp/addon.gypi
++++ b/deps/npm/node_modules/node-gyp/addon.gypi
+@@ -1,7 +1,9 @@
+ {
+   'target_defaults': {
+     'type': 'loadable_module',
++    'win_delay_load_hook': 'true',
+     'product_prefix': '',
++
+     'include_dirs': [
+       '<(node_root_dir)/src',
+       '<(node_root_dir)/deps/uv/include',
+@@ -13,11 +15,34 @@
+         'product_extension': 'node',
+         'defines': [ 'BUILDING_NODE_EXTENSION' ],
+       }],
++
+       ['_type=="static_library"', {
+         # set to `1` to *disable* the -T thin archive 'ld' flag.
+         # older linkers don't support this flag.
+         'standalone_static_library': '<(standalone_static_library)'
+       }],
++
++      ['_win_delay_load_hook=="true"', {
++        # If the addon specifies `'win_delay_load_hook': 'true'` in its
++        # binding.gyp, link a delay-load hook into the DLL. This hook ensures
++        # that the addon will work regardless of whether the node/iojs binary
++        # is named node.exe, iojs.exe, or something else.
++        'conditions': [
++          [ 'OS=="win"', {
++            'sources': [
++              'src/win_delay_load_hook.c',
++            ],
++            'msvs_settings': {
++              'VCLinkerTool': {
++                'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
++                # Don't print a linker warning when no imports from either .exe
++                # are used.
++                'AdditionalOptions': [ '/ignore:4199' ],
++              },
++            },
++          }],
++        ],
++      }],
+     ],
+ 
+     'conditions': [
+diff --git a/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.c b/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.c
+new file mode 100644
+index 0000000..05c4c39
+--- /dev/null
++++ b/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.c
+@@ -0,0 +1,32 @@
++/*
++ * When this file is linked to a DLL, it sets up a delay-load hook that
++ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
++ * dynamically. Instead of trying to locate the .exe file it'll just return
++ * a handle to the process image.
++ *
++ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
++ */
++
++#ifdef _MSC_VER
++
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++#include <delayimp.h>
++#include <string.h>
++
++static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
++  if (event != dliNotePreLoadLibrary)
++    return NULL;
++
++  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
++      _stricmp(info->szDll, "node.exe") != 0)
++    return NULL;
++
++  HMODULE m = GetModuleHandle(NULL);
++  return (FARPROC) m;
++}
++
++PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
++
++#endif

--- a/tools/update-dep.sh
+++ b/tools/update-dep.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -e
+
+# always change the working directory to the io.js/deps directory
+cd $(dirname $0)/../deps
+
+# parse depdancy name and version from the first argument
+dep=`echo $1 | cut -d'@' -f1`
+version=`echo $1 | cut -d'@' -f2`
+
+# bail if we don't have a name or version
+if [ -z $dep -o -z $version ]; then
+  echo "A dep with version info must be provided. `depname@X.Y.Z`" >&2
+  exit 0
+fi
+
+# rename libuv to uv
+if [ $dep == "libuv" ]; then dep="uv"; fi
+# rename http-parser to http_parser
+if [ $dep == "http-parser" ]; then dep="http_parser"; fi
+
+# url templates
+if [ $dep == "npm" ]; then
+  url="https://github.com/npm/npm/archive/v"$version".zip"
+elif [ $dep == "uv" ]; then
+  url="https://github.com/libuv/libuv/archive/v"$version".zip"
+elif [ $dep == "http_parser" ]; then
+  url="https://github.com/joyent/http-parser/archive/v"$version".zip"
+else
+  echo "The dependency "$dep" was not recognized. It should be one of:" >&2
+  ls >&2
+  exit 0
+fi
+
+# make a new tmp dir
+rm -rf tmp
+mkdir tmp
+cd tmp
+
+echo "downloading "$url
+# download our depandancy at the specified version
+# -O save it to a file
+# -L accept redirects (github..)
+# -# progress bar
+# -f fail with code 22 if the request errors
+curl -OL#f $url
+
+echo extracting...
+# -q makes unzip completely silent..
+unzip -q "v"$version".zip"
+rm -f "v"$version".zip"
+
+
+if [ $dep == "npm" ]; then
+  echo building npm "(make release)"...
+
+  # build npm as release (produces .tgz and .zip)
+  cd "npm-"$version
+  make release
+
+  # cd back tino io.js/deps
+  cd ../..
+
+  # remove deps/npm
+  rm -rf npm
+
+  # untar the packaged release npm
+  tar -zxf "tmp/npm-"$version"/release/npm-"$version".tgz"
+else
+  echo copying files...
+
+  # FIXME?: assume a extracted single folder
+  # github always packs repos like this
+  extracted=`ls | cut -d' ' -f1`
+
+  # cd back tino io.js/deps
+  cd ..
+
+  # remove deps/$dep
+  rm -rf $dep
+  mkdir $dep
+
+  # copy everything over
+  cp -r "tmp/"$extracted"/" $dep"/"
+fi
+
+echo cleaning up...
+# remove our tmp directory
+rm -rf tmp
+
+# cd into the io.js home directory
+cd ..
+
+# get our current git branch for future reference
+git_ref=`git symbolic-ref --short -q HEAD`
+
+# just fail if we are in a detached HEAD or something
+if [ -z $git_ref ]; then
+  echo "Unusable git state. Please checkout a branch." >&2
+  exit 0
+fi
+
+echo creating a new git branch and commit...
+# make a new branche, commit to it, and do automatic fixups.
+git checkout -b $dep"@"$version
+git add "deps/"$dep
+git commit -m "deps: upgrade "$dep" to "$version
+git rebase --whitespace=fix $git_ref
+
+echo applying any floating patches...
+# initialize stacked git and apply any patches we find
+stg init || true
+stg repair
+stg import --series "deps/floating-patches/patches-"$dep"/series" || true
+
+# cleanup garbage that stgit leaves...
+git branch -D $dep"@"$version".stgit"
+
+echo "done updating "$dep"@"$version


### PR DESCRIPTION
This is a working, but possibly rough implementation of a dependency upgrade tool as discussed around #1419.

In particular, I don't feel confident at all about stgit. it works, but it leaves a mess and doesn't work if you try to do the same upgrade twice without manually resetting stgit.

This can't do c-ares (yet?) and doesn't touch v8 because v8 requires a whole world of other things that may be more suitable for it's own tool.

R=@othiym23 / @rvagg / @chrisdickinson / @bnoordhuis 