### PR TITLE
src: fix preload timing

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -82,16 +82,9 @@
         delete process.env.NODE_UNIQUE_ID;
       }
 
-      // Load any preload modules
-      if (process._preload_modules) {
-        var Module = NativeModule.require('module');
-        process._preload_modules.forEach(function(module) {
-          Module._load(module);
-        });
-      }
-
       if (process._eval != null) {
         // User passed '-e' or '--eval' arguments to Node.
+        startup.preloadModules();
         evalScript('[eval]');
       } else if (process.argv[1]) {
         // make process.argv[1] into a full path
@@ -99,7 +92,7 @@
         process.argv[1] = path.resolve(process.argv[1]);
 
         var Module = NativeModule.require('module');
-
+        startup.preloadModules();
         if (global.v8debug &&
             process.execArgv.some(function(arg) {
               return arg.match(/^--debug-brk(=[0-9]*)?$/);
@@ -855,6 +848,16 @@
     process._rawDebug = function() {
       rawDebug(format.apply(null, arguments));
     };
+  };
+
+  // Load preload modules
+  startup.preloadModules = function() {
+    if (process._preload_modules) {
+      var Module = NativeModule.require('module');
+      process._preload_modules.forEach(function(module) {
+        Module._load(module);
+      });
+    }
   };
 
   // Below you find a minimal module system, which is used to load the node

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -80,3 +80,15 @@ child_process.exec(nodeBinary + ' '
     if (err) throw err;
     assert.ok(/worker terminated with code 43/.test(stdout));
   });
+
+// https://github.com/iojs/io.js/issues/1691
+var originalCwd = process.cwd();
+process.chdir(path.join(__dirname, '../fixtures/'));
+child_process.exec(nodeBinary + ' '
+  + '--expose_debug_as=v8debug '
+  + '--require ' + fixture('cluster-preload.js') + ' '
+  + 'cluster-preload-test.js',
+  function(err, stdout, stderr) {
+    if (err) throw err;
+    assert.ok(/worker terminated with code 43/.test(stdout));
+  });


### PR DESCRIPTION
related: https://github.com/iojs/io.js/pull/881
related: https://github.com/iojs/io.js/issues/1691

I investigate the issue.
it should load modules after `path.resolve(process.argv[1]);`

Reviewer: @ofrobots