### PR TITLE
http: flush stored header

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -636,10 +636,11 @@ OutgoingMessage.prototype._flush = function() {
 
 OutgoingMessage.prototype.flushHeaders = function() {
   if (!this._header) {
-    // Force-flush the headers.
     this._implicitHeader();
-    this._send('');
   }
+
+  // Force-flush the headers.
+  this._send('');
 };
 
 OutgoingMessage.prototype.flush = util.deprecate(function() {

--- a/test/parallel/test-http-flush-headers.js
+++ b/test/parallel/test-http-flush-headers.js
@@ -5,7 +5,7 @@ const http = require('http');
 
 const server = http.createServer();
 server.on('request', function(req, res) {
-  assert(req.headers['foo'], 'bar');
+  assert.equal(req.headers['foo'], 'bar');
   res.end('ok');
   server.close();
 });

--- a/test/parallel/test-http-flush-response-headers.js
+++ b/test/parallel/test-http-flush-response-headers.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer();
+
+server.on('request', function(req, res) {
+  res.writeHead(200, {'foo': 'bar'});
+  res.flushHeaders();
+  res.flushHeaders(); // Should be idempotent.
+});
+server.listen(common.PORT, common.localhostIPv4, function() {
+  var req = http.request({
+    method: 'GET',
+    host: common.localhostIPv4,
+    port: common.PORT,
+  }, onResponse);
+
+  req.end();
+
+  function onResponse(res) {
+    assert.equal(res.headers['foo'], 'bar');
+    res.destroy();
+    server.close();
+  }
+});


### PR DESCRIPTION
`flushHeaders` should work for header written with `writeHead`.

R=@bnoordhuis 