### PR TITLE
core: implement runtime flag to print warn on sync

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -99,6 +99,7 @@
       'sources': [
         'src/debug-agent.cc',
         'src/async-wrap.cc',
+        'src/env.cc',
         'src/fs_event_wrap.cc',
         'src/cares_wrap.cc',
         'src/handle_wrap.cc',

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -176,6 +176,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       using_abort_on_uncaught_exc_(false),
       using_asyncwrap_(false),
       printed_error_(false),
+      trace_sync_io_(false),
       debugger_agent_(this),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
@@ -323,6 +324,10 @@ inline bool Environment::printed_error() const {
 
 inline void Environment::set_printed_error(bool value) {
   printed_error_ = value;
+}
+
+inline void Environment::set_trace_sync_io(bool value) {
+  trace_sync_io_ = value;
 }
 
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,0 +1,58 @@
+#include "env.h"
+#include "env-inl.h"
+#include "v8.h"
+#include <stdio.h>
+
+namespace node {
+
+using v8::HandleScope;
+using v8::Local;
+using v8::Message;
+using v8::StackFrame;
+using v8::StackTrace;
+
+void Environment::PrintSyncTrace() const {
+  if (!trace_sync_io_)
+    return;
+
+  HandleScope handle_scope(isolate());
+  Local<v8::StackTrace> stack =
+      StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed);
+
+  fprintf(stderr, "WARNING: Detected use of sync API\n");
+
+  for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
+    Local<StackFrame> stack_frame = stack->GetFrame(i);
+    node::Utf8Value fn_name_s(isolate(), stack_frame->GetFunctionName());
+    node::Utf8Value script_name(isolate(), stack_frame->GetScriptName());
+    const int line_number = stack_frame->GetLineNumber();
+    const int column = stack_frame->GetColumn();
+
+    if (stack_frame->IsEval()) {
+      if (stack_frame->GetScriptId() == Message::kNoScriptIdInfo) {
+        fprintf(stderr, "    at [eval]:%i:%i\n", line_number, column);
+      } else {
+        fprintf(stderr,
+                "    at [eval] (%s:%i:%i)\n",
+                *script_name,
+                line_number,
+                column);
+      }
+      break;
+    }
+
+    if (fn_name_s.length() == 0) {
+      fprintf(stderr, "    at %s:%i:%i\n", *script_name, line_number, column);
+    } else {
+      fprintf(stderr,
+              "    at %s (%s:%i:%i)\n",
+              *fn_name_s,
+              *script_name,
+              line_number,
+              column);
+    }
+  }
+  fflush(stderr);
+}
+
+}  // namespace node

--- a/src/env.h
+++ b/src/env.h
@@ -420,6 +420,9 @@ class Environment {
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
 
+  void PrintSyncTrace() const;
+  inline void set_trace_sync_io(bool value);
+
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
   inline void ThrowRangeError(const char* errmsg);
@@ -506,6 +509,7 @@ class Environment {
   bool using_abort_on_uncaught_exc_;
   bool using_asyncwrap_;
   bool printed_error_;
+  bool trace_sync_io_;
   debugger::Agent debugger_agent_;
 
   HandleWrapQueue handle_wrap_queue_;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4630,6 +4630,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
                   EIO_PBKDF2,
                   EIO_PBKDF2After);
   } else {
+    env->PrintSyncTrace();
     Local<Value> argv[2];
     EIO_PBKDF2(req);
     EIO_PBKDF2After(req, argv);
@@ -4786,6 +4787,7 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
                   RandomBytesAfter);
     args.GetReturnValue().Set(obj);
   } else {
+    env->PrintSyncTrace();
     Local<Value> argv[2];
     RandomBytesWork(req->work_req());
     RandomBytesCheck(req, argv);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -280,6 +280,7 @@ struct fs_req_wrap {
 
 #define SYNC_DEST_CALL(func, path, dest, ...)                                 \
   fs_req_wrap req_wrap;                                                       \
+  env->PrintSyncTrace();                                                      \
   int err = uv_fs_ ## func(env->event_loop(),                                 \
                          &req_wrap.req,                                       \
                          __VA_ARGS__,                                         \

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -181,6 +181,7 @@ class ZCtx : public AsyncWrap {
 
     if (!async) {
       // sync version
+      ctx->env()->PrintSyncTrace();
       Process(work_req);
       if (CheckError(ctx))
         AfterSync(ctx, args);

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -349,7 +349,9 @@ void SyncProcessRunner::Initialize(Handle<Object> target,
 
 
 void SyncProcessRunner::Spawn(const FunctionCallbackInfo<Value>& args) {
-  SyncProcessRunner p(Environment::GetCurrent(args));
+  Environment* env = Environment::GetCurrent(args);
+  env->PrintSyncTrace();
+  SyncProcessRunner p(env);
   Local<Value> result = p.Run(args[0]);
   args.GetReturnValue().Set(result);
 }

--- a/test/parallel/test-sync-io-option.js
+++ b/test/parallel/test-sync-io-option.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+
+if (process.argv[2] === 'child') {
+  setImmediate(function() {
+    require('fs').readFileSync(__filename);
+    process.exit();
+  });
+
+} else {
+  (function runTest(flags) {
+    var execArgv = [flags.pop()];
+    var args = [__filename, 'child'];
+    var child = spawn(process.execPath, execArgv.concat(args));
+    var cntr = 0;
+
+    child.stdout.on('data', function(chunk) {
+      throw new Error('UNREACHABLE');
+    });
+
+    child.stderr.on('data', function(chunk) {
+      // Prints twice for --trace-sync-io. First for the require() and second
+      // for the fs operation.
+      if (/^WARNING[\s\S]*fs\.readFileSync/.test(chunk.toString()))
+        cntr++;
+    });
+
+    child.on('exit', function() {
+      if (execArgv[0] === '--trace-sync-io')
+        assert.equal(cntr, 2);
+      else if (execArgv[0] === ' ')
+        assert.equal(cntr, 0);
+      else
+        throw new Error('UNREACHABLE');
+
+      if (flags.length > 0)
+        setImmediate(runTest, flags);
+    });
+  }(['--trace-sync-io', ' ']));
+}
+


### PR DESCRIPTION
Use the --warn-on-sync flag to print a stack trace whenever a sync
method is used. (e.g. fs.readFileSync()) It does not track if the
warning has occurred as a specific location in the past and so will
print the warning every time the function is used.

This does not print the warning for the first synchronous execution of
the script. This will allow all the require(), etc. statements to run
that are necessary to prepare the environment.

NOTE: I believe I've addressed all applicable sync calls that should warn the user. I will not be enabling the warning for the `'net'` module's `.listen()` calls that exclude the callback. Because the calls are actually synchronous under the hood and we simply queue the callback asynchronously to be run. It also appears to be the same for `http.{get,request}()`. Also calls to any stream's `.write()` are still async even if the callback is excluded.

Opening this up now so we can have further discussion.