### PR TITLE
doc: note that fork() and exec() are unrelated to Unix system calls, resolves #224

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -586,7 +586,8 @@ if it runs longer than `timeout` milliseconds. The child process is killed with
 amount of data (in bytes) allowed on stdout or stderr - if this value is
 exceeded then the child process is killed.
 
-`child_process.exec()` is unrelated to the `exec()` system call in Unix-like operating systems.
+Unlike the `exec()` POSIX system call, `child_process.exec()` does not replace
+the existing process and uses a shell to execute the command.
 
 ### child_process.execFile(file[, args][, options][, callback])
 
@@ -646,7 +647,8 @@ done with care and by default will talk over the fd represented an
 environmental variable `NODE_CHANNEL_FD` on the child process. The input and
 output on this fd is expected to be line delimited JSON objects.
 
-`child_process.fork()` is unrelated to the `fork()` system call in Unix-like operating systems.
+Unlike the `fork()` POSIX system call, `child_process.fork()` does not clone the
+current process.
 
 ## Synchronous Process Creation
 

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -586,8 +586,8 @@ if it runs longer than `timeout` milliseconds. The child process is killed with
 amount of data (in bytes) allowed on stdout or stderr - if this value is
 exceeded then the child process is killed.
 
-Unlike the `exec()` POSIX system call, `child_process.exec()` does not replace
-the existing process and uses a shell to execute the command.
+*Note: Unlike the `exec()` POSIX system call, `child_process.exec()` does not replace
+the existing process and uses a shell to execute the command.*
 
 ### child_process.execFile(file[, args][, options][, callback])
 
@@ -647,8 +647,8 @@ done with care and by default will talk over the fd represented an
 environmental variable `NODE_CHANNEL_FD` on the child process. The input and
 output on this fd is expected to be line delimited JSON objects.
 
-Unlike the `fork()` POSIX system call, `child_process.fork()` does not clone the
-current process.
+*Note: Unlike the `fork()` POSIX system call, `child_process.fork()` does not clone the
+current process.*
 
 ## Synchronous Process Creation
 

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -586,6 +586,7 @@ if it runs longer than `timeout` milliseconds. The child process is killed with
 amount of data (in bytes) allowed on stdout or stderr - if this value is
 exceeded then the child process is killed.
 
+`child_process.exec()` is unrelated to the `exec()` system call in Unix-like operating systems.
 
 ### child_process.execFile(file[, args][, options][, callback])
 
@@ -644,6 +645,8 @@ created for the child rather than the current `iojs` executable. This should be
 done with care and by default will talk over the fd represented an
 environmental variable `NODE_CHANNEL_FD` on the child process. The input and
 output on this fd is expected to be line delimited JSON objects.
+
+`child_process.fork()` is unrelated to the `fork()` system call in Unix-like operating systems.
 
 ## Synchronous Process Creation
 


### PR DESCRIPTION
This is a conservative attempt to resolve #224.