### PR TITLE
repl: remove unnecessary check for globals

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -624,7 +624,7 @@ REPLServer.prototype.complete = function(line, callback) {
           completionGroupsLoaded();
         } else {
           this.eval('.scope', this.context, 'repl', function(err, globals) {
-            if (err || !globals || !Array.isArray(globals)) {
+            if (err || !Array.isArray(globals)) {
               addStandardGlobals(completionGroups, filter);
             } else if (Array.isArray(globals[0])) {
               // Add grouped globals


### PR DESCRIPTION
Sorry for making this at my previous commit, removed the `!globals`, thanks @cjihrig 

/cc @indutny 