### PR TITLE
lib: add console.{group,groupCollapsed,groupEnd}()

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -72,6 +72,21 @@ object. This is useful for inspecting large complicated objects. Defaults to
 - `colors` - if `true`, then the output will be styled with ANSI color codes.
 Defaults to `false`. Colors are customizable, see below.
 
+### console.group([data][, ...])
+
+Starts a new logging group with an optional title. All console output that occurs 
+after calling this method and calling `console.groupEnd` has the same 
+indent level.
+
+### console.groupCollapsed([data][, ...])
+
+Same as `console.group`.
+
+### console.groupEnd()
+
+Closes the most recently created logging group that previously created with 
+`console.group` or `console.groupCollapsed`.
+
 ### console.time(label)
 
 Used to calculate the duration of a specific operation. To start a timer, call

--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -84,8 +84,8 @@ Same as `console.group`.
 
 ### console.groupEnd()
 
-Closes the most recently created logging group that previously created with 
-`console.group` or `console.groupCollapsed`.
+Closes the most recent logging group that was created with `console.group` or
+`console.groupCollapsed`.
 
 ### console.time(label)
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -25,6 +25,8 @@ function Console(stdout, stderr) {
   Object.defineProperty(this, '_times', prop);
   prop.value = 0;
   Object.defineProperty(this, '_group', prop);
+  prop.value = '';
+  Object.defineProperty(this, '_prefix', prop);
 
   // bind the prototype functions to this Console instance
   var keys = Object.keys(Console.prototype);
@@ -35,8 +37,8 @@ function Console(stdout, stderr) {
 }
 
 Console.prototype.log = function() {
-  this._stdout.write(util.format.apply(this, arguments).replace(/^/gm,
-          Array(this._group * 2 + 1).join(' ')) + '\n');
+  this._stdout.write((this._group ? util.format.apply(this, arguments).replace(
+          /^/gm, this._prefix) : util.format.apply(this, arguments)) + '\n');
 };
 
 
@@ -44,8 +46,8 @@ Console.prototype.info = Console.prototype.log;
 
 
 Console.prototype.warn = function() {
-  this._stderr.write(util.format.apply(this, arguments).replace(/^/gm,
-          Array(this._group * 2 + 1).join(' ')) + '\n');
+  this._stderr.write((this._group ? util.format.apply(this, arguments).replace(
+          /^/gm, this._prefix) : util.format.apply(this, arguments)) + '\n');
 };
 
 
@@ -53,9 +55,10 @@ Console.prototype.error = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object, options) {
-  this._stdout.write(util.inspect(object, util._extend({
-    customInspect: false
-  }, options)).replace(/^/gm, Array(this._group * 2 + 1).join(' ')) + '\n');
+  this._stdout.write((this._group ? util.inspect(object, util._extend({
+        customInspect: false }, options)).replace(/^/gm, this._prefix) :
+          util.inspect(object, util._extend({ customInspect: false },
+              options)).replace(/^/gm, this._prefix)) + '\n');
 };
 
 
@@ -64,6 +67,7 @@ Console.prototype.group = function() {
     this.log.apply(this, arguments);
   }
   this._group++;
+  this._prefix = '  '.repeat(this._group);
 };
 
 
@@ -75,6 +79,7 @@ Console.prototype.groupCollapsed = function() {
 Console.prototype.groupEnd = function() {
   if ( this._group > 0 ) {
     this._group--;
+    this._prefix = (this._group ? '  '.repeat(this._group) : '');
   }
 };
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -23,6 +23,8 @@ function Console(stdout, stderr) {
   Object.defineProperty(this, '_stderr', prop);
   prop.value = new Map();
   Object.defineProperty(this, '_times', prop);
+  prop.value = 0;
+  Object.defineProperty(this, '_group', prop);
 
   // bind the prototype functions to this Console instance
   var keys = Object.keys(Console.prototype);
@@ -33,7 +35,8 @@ function Console(stdout, stderr) {
 }
 
 Console.prototype.log = function() {
-  this._stdout.write(util.format.apply(this, arguments) + '\n');
+  this._stdout.write(util.format.apply(this, arguments).replace(/^/gm,
+          Array(this._group * 2 + 1).join(' ')) + '\n');
 };
 
 
@@ -41,7 +44,8 @@ Console.prototype.info = Console.prototype.log;
 
 
 Console.prototype.warn = function() {
-  this._stderr.write(util.format.apply(this, arguments) + '\n');
+  this._stderr.write(util.format.apply(this, arguments).replace(/^/gm,
+          Array(this._group * 2 + 1).join(' ')) + '\n');
 };
 
 
@@ -51,7 +55,27 @@ Console.prototype.error = Console.prototype.warn;
 Console.prototype.dir = function(object, options) {
   this._stdout.write(util.inspect(object, util._extend({
     customInspect: false
-  }, options)) + '\n');
+  }, options)).replace(/^/gm, Array(this._group * 2 + 1).join(' ')) + '\n');
+};
+
+
+Console.prototype.group = function() {
+  if (arguments.length) {
+    this.log.apply(this, arguments);
+  }
+  this._group++;
+};
+
+
+Console.prototype.groupCollapsed = function() {
+  this.group.apply(this, arguments);
+};
+
+
+Console.prototype.groupEnd = function() {
+  if ( this._group > 0 ) {
+    this._group--;
+  }
 };
 
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -55,10 +55,9 @@ Console.prototype.error = Console.prototype.warn;
 
 
 Console.prototype.dir = function(object, options) {
-  this._stdout.write((this._group ? util.inspect(object, util._extend({
-        customInspect: false }, options)).replace(/^/gm, this._prefix) :
-          util.inspect(object, util._extend({ customInspect: false },
-              options)).replace(/^/gm, this._prefix)) + '\n');
+  var str = util.inspect(object, util._extend({customInspect: false}, options));
+  this._stdout.write((this._group ?
+          str.replace(/^/gm, this._prefix) : str) + '\n');
 };
 
 
@@ -77,7 +76,7 @@ Console.prototype.groupCollapsed = function() {
 
 
 Console.prototype.groupEnd = function() {
-  if ( this._group > 0 ) {
+  if (this._group) {
     this._group--;
     this._prefix = (this._group ? '  '.repeat(this._group) : '');
   }

--- a/test/parallel/test-console-group.js
+++ b/test/parallel/test-console-group.js
@@ -1,0 +1,67 @@
+var common = require('../common');
+var assert = require('assert');
+
+assert.ok(process.stdout.writable);
+assert.ok(process.stderr.writable);
+// Support legacy API
+assert.equal('number', typeof process.stdout.fd);
+assert.equal('number', typeof process.stderr.fd);
+
+assert.doesNotThrow(function () {
+  console.group('label');
+  console.groupEnd();
+});
+
+assert.doesNotThrow(function () {
+    console.groupCollapsed('label');
+    console.groupEnd();
+});
+
+// test multiple calls to console.groupEnd()
+assert.doesNotThrow(function () {
+    console.groupEnd();
+    console.groupEnd();
+    console.groupEnd();
+});
+
+var stdout_write = global.process.stdout.write;
+var strings = [];
+global.process.stdout.write = function(string) {
+  strings.push(string);
+};
+console._stderr = process.stdout;
+
+// test console.group(), console.groupCollapsed() and console.groupEnd()
+console.log('foo');
+console.group('bar');
+console.log('foo bar');
+console.groupEnd();
+console.groupCollapsed('group 1');
+console.log('log');
+console.warn('warn');
+console.error('error');
+console.dir({ foo: true });
+console.group('group 2');
+console.log('foo bar hop');
+console.log('line 1\nline 2\nline 3');
+console.groupEnd();
+console.log('end 2');
+console.groupEnd();
+console.log('end 1');
+
+global.process.stdout.write = stdout_write;
+
+assert.equal('foo\n', strings.shift());
+assert.equal('bar\n', strings.shift());
+assert.equal('  foo bar\n', strings.shift());
+assert.equal("group 1\n", strings.shift());
+assert.equal('  log\n', strings.shift());
+assert.equal('  warn\n', strings.shift());
+assert.equal('  error\n', strings.shift());
+assert.equal('  { foo: true }\n', strings.shift());
+assert.equal('  group 2\n', strings.shift());
+assert.equal('    foo bar hop\n', strings.shift());
+assert.equal('    line 1\n    line 2\n    line 3\n', strings.shift());
+assert.equal('  end 2\n', strings.shift());
+assert.equal('end 1\n', strings.shift());
+assert.equal(strings.length, 0);


### PR DESCRIPTION
Implements nested console groups to match browser console API:
 * `console.group()`
 * `console.groupCollapsed()`
 * `console.groupEnd()`

Notes:
* Starting a new group prefixes each line of output with two-spaces per group/indent level. 
* `console` API documentation is updated to include new functions.
* Test case `test-console-group.js` is included.
* `console.groupCollapsed()` is aliased to `console.group()` with a wrapper function so that  external gui debuggers can handle it correctly. For example `node-inspector`.