### PR TITLE
core: set PROVIDER type as Persistent class id

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -17,7 +17,8 @@ inline AsyncWrap::AsyncWrap(Environment* env,
                             v8::Handle<v8::Object> object,
                             ProviderType provider,
                             AsyncWrap* parent)
-    : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1) {
+    : BaseObject(env, object, provider),
+      bits_(static_cast<uint32_t>(provider) << 1) {
   // Check user controlled flag to see if the init callback should run.
   if (!env->using_asyncwrap())
     return;

--- a/src/base-object-inl.h
+++ b/src/base-object-inl.h
@@ -10,10 +10,15 @@
 
 namespace node {
 
-inline BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
+inline BaseObject::BaseObject(Environment* env,
+                              v8::Local<v8::Object> handle,
+                              const uint16_t p_id)
     : handle_(env->isolate(), handle),
       env_(env) {
   CHECK_EQ(false, handle.IsEmpty());
+  // Shift value 8 bits over to try avoiding conflict with anything else.
+  if (p_id != 0)
+    handle_.SetWrapperClassId(p_id << 8);
 }
 
 

--- a/src/base-object.h
+++ b/src/base-object.h
@@ -9,7 +9,9 @@ class Environment;
 
 class BaseObject {
  public:
-  BaseObject(Environment* env, v8::Local<v8::Object> handle);
+  BaseObject(Environment* env,
+             v8::Local<v8::Object> handle,
+             const uint16_t p_id = 0);
   virtual ~BaseObject();
 
   // Returns the wrapped object.  Returns an empty handle when


### PR DESCRIPTION
Pass along the PROVIDER type, that is already passed to AsyncWrap, along
to BaseObject to set the handle_'s class id. This will allow all
Persistents to be transversed and uniquely identified by what type they
are using APIs such as v8::PersistentHandleVisitor.

R=@bnoordhuis 