### PR TITLE
tls: make server not use DHE in less than 1024bits for fix agaist Logjam Attack

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -183,8 +183,10 @@ automatically set as a listener for the [secureConnection][] event.  The
 
   - `dhparam`: A string or `Buffer` containing Diffie Hellman parameters,
     required for Perfect Forward Secrecy. Use `openssl dhparam` to create it.
-    If omitted or invalid, it is silently discarded and DHE ciphers won't be
-    available.
+    Its key length should be greater than or equal to 1024 bits, otherwise
+    it throws an error. It is strongly recommended to use 2048 bits or
+    more for stronger security. If omitted or invalid, it is silently
+    discarded and DHE ciphers won't be available.
 
   - `handshakeTimeout`: Abort the connection if the SSL/TLS handshake does not
     finish in this many milliseconds. The default is 120 seconds.

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -757,6 +757,12 @@ void SecureContext::SetDHParam(const FunctionCallbackInfo<Value>& args) {
   if (dh == nullptr)
     return;
 
+  int keylen = BN_num_bits(dh->p);
+  if (keylen < 1024)
+    return env->ThrowError("DH parameter is less than 1024 bits");
+  else if (keylen < 2048)
+    fprintf(stderr, "WARNING: DH parameter is less than 2048 bits\n");
+
   SSL_CTX_set_options(sc->ctx_, SSL_OP_SINGLE_DH_USE);
   int r = SSL_CTX_set_tmp_dh(sc->ctx_, dh);
   DH_free(dh);

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -62,8 +62,9 @@ function test(keylen, expectedCipher, cb) {
 }
 
 function test512() {
-  test(512, 'DHE-RSA-AES128-SHA256', test1024);
-  ntests++;
+  assert.throws(function() {
+    test(512, 'DHE-RSA-AES128-SHA256', null);
+  }, /DH parameter is less than 1024 bits/);
 }
 
 function test1024() {
@@ -77,12 +78,13 @@ function test2048() {
 }
 
 function testError() {
-  test('error', 'ECDHE-RSA-AES128-SHA256', null);
+  test('error', 'ECDHE-RSA-AES128-SHA256', test512);
   ntests++;
 }
 
-test512();
+test1024();
 
 process.on('exit', function() {
   assert.equal(ntests, nsuccess);
+  assert.equal(ntests, 3);
 });


### PR DESCRIPTION
DHE key lengths less than 1024bits is already weaken as pointed out in https://weakdh.org/ . 1024bits will not be safe in near future. We will extend this up to 2048bits somedays later.

What do about for clients?  We can obtain DHE keylength via `SSL_get_server_tmp_key()` but I think we'd better to have an new options to limit the DHE key size with 1024bits default. Thoughts?

CI results are https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/697/. It looks fine except jenkins, child_process and sync-io-option error.

R= @bnoordhuis @indutny 