### PR TITLE
util: Speed up the common case of formatting a single string.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -13,6 +13,8 @@ exports.format = function(f) {
     return objects.join(' ');
   }
 
+  if (arguments.length === 1) return f;
+
   var i = 1;
   var args = arguments;
   var len = args.length;


### PR DESCRIPTION
This slightly speeds up a common case of formatting a single string.
Used, for example, by `console.log("string")`.