### PR TITLE
doc: path is ignored in url.format

### DIFF
--- a/doc/api/url.markdown
+++ b/doc/api/url.markdown
@@ -85,6 +85,7 @@ Take a parsed URL object, and return a formatted URL string.
 Here's how the formatting process works:
 
 * `href` will be ignored.
+* `path` will be ignored.
 * `protocol` is treated the same with or without the trailing `:` (colon).
   * The protocols `http`, `https`, `ftp`, `gopher`, `file` will be
     postfixed with `://` (colon-slash-slash).


### PR DESCRIPTION
Made it obvious that path is ignored in url.format