### PR TITLE
net: return this from setNoDelay and setKeepAlive

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -464,6 +464,8 @@ algorithm, they buffer data before sending it off. Setting `true` for
 `noDelay` will immediately fire off data each time `socket.write()` is called.
 `noDelay` defaults to `true`.
 
+Returns `socket`.
+
 ### socket.setKeepAlive([enable][, initialDelay])
 
 Enable/disable keep-alive functionality, and optionally set the initial
@@ -474,6 +476,8 @@ Set `initialDelay` (in milliseconds) to set the delay between the last
 data packet received and the first keepalive probe. Setting 0 for
 initialDelay will leave the value unchanged from the default
 (or previous) setting. Defaults to `0`.
+
+Returns `socket`.
 
 ### socket.address()
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -324,23 +324,27 @@ Socket.prototype.setNoDelay = function(enable) {
   if (!this._handle) {
     this.once('connect',
               enable ? this.setNoDelay : this.setNoDelay.bind(this, enable));
-    return;
+    return this;
   }
 
   // backwards compatibility: assume true when `enable` is omitted
   if (this._handle.setNoDelay)
     this._handle.setNoDelay(enable === undefined ? true : !!enable);
+
+  return this;
 };
 
 
 Socket.prototype.setKeepAlive = function(setting, msecs) {
   if (!this._handle) {
     this.once('connect', this.setKeepAlive.bind(this, setting, msecs));
-    return;
+    return this;
   }
 
   if (this._handle.setKeepAlive)
     this._handle.setKeepAlive(setting, ~~(msecs / 1000));
+
+  return this;
 };
 
 

--- a/test/parallel/test-net-persistent-keepalive.js
+++ b/test/parallel/test-net-persistent-keepalive.js
@@ -18,7 +18,8 @@ echoServer.on('listening', function() {
   var clientConnection = new net.Socket();
   // send a keepalive packet after 1000 ms
   // and make sure it persists
-  clientConnection.setKeepAlive(true, 400);
+  var s = clientConnection.setKeepAlive(true, 400);
+  assert.ok(s instanceof net.Socket);
   clientConnection.connect(common.PORT);
   clientConnection.setTimeout(0);
 

--- a/test/parallel/test-net-persistent-nodelay.js
+++ b/test/parallel/test-net-persistent-nodelay.js
@@ -24,7 +24,8 @@ echoServer.on('listening', function() {
   // setNoDelay before the handle is created
   // there is probably a better way to test this
 
-  sock1.setNoDelay();
+  var s = sock1.setNoDelay();
+  assert.ok(s instanceof net.Socket);
   sock1.connect(common.PORT);
   sock1.on('end', function() {
     assert.equal(callCount, 1);


### PR DESCRIPTION
This is the final PR for https://github.com/nodejs/io.js/issues/1657. I found some usage of these methods in `CryptoStream`, but that API is deprecated since 1.0 anyways. Other PRs in this series: https://github.com/nodejs/io.js/pull/1699 and https://github.com/nodejs/io.js/pull/1768.

cc: @evanlucas 