### PR TITLE
path: allow numbers as arguments to .join()

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -10,6 +10,14 @@ function assertPath(path) {
   }
 }
 
+function assertJoinArg(input) {
+  if (typeof input !== 'string' &&
+     (typeof input !== 'number' || isNaN(input))) {
+    throw new TypeError('Arguments to path.join must be strings or numbers');
+  }
+  return input;
+}
+
 // resolves . and .. elements in a path array with directory names there
 // must be no slashes or device names (c:\) in the array
 // (so also no leading and trailing slashes - it does not distinguish
@@ -185,14 +193,7 @@ win32.isAbsolute = function(path) {
 };
 
 win32.join = function() {
-  function f(p) {
-    if (typeof p !== 'string') {
-      throw new TypeError('Arguments to path.join must be strings');
-    }
-    return p;
-  }
-
-  var paths = Array.prototype.filter.call(arguments, f);
+  var paths = Array.prototype.filter.call(arguments, assertJoinArg);
   var joined = paths.join('\\');
 
   // Make sure that the joined path doesn't start with two slashes, because
@@ -462,10 +463,7 @@ posix.isAbsolute = function(path) {
 posix.join = function() {
   var path = '';
   for (var i = 0; i < arguments.length; i++) {
-    var segment = arguments[i];
-    if (typeof segment !== 'string') {
-      throw new TypeError('Arguments to path.join must be strings');
-    }
+    var segment = assertJoinArg(arguments[i]);
     if (segment) {
       if (!path) {
         path += segment;

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -190,7 +190,8 @@ var joinTests =
      [['/', '//foo'], '/foo'],
      [['/', '', '/foo'], '/foo'],
      [['', '/', 'foo'], '/foo'],
-     [['', '/', '/foo'], '/foo']
+     [['', '/', '/foo'], '/foo'],
+     [['', '/', '/foo', 7], '/foo/7']
     ];
 
 // Windows-specific join tests
@@ -263,11 +264,10 @@ function fail(fn) {
 
   assert.throws(function() {
     fn.apply(null, args);
-  }, TypeError);
+  }, TypeError, args + ' threw TypeError');
 }
 
 typeErrorTests.forEach(function(test) {
-  fail(path.join, test);
   fail(path.resolve, test);
   fail(path.normalize, test);
   fail(path.isAbsolute, test);
@@ -284,6 +284,11 @@ typeErrorTests.forEach(function(test) {
   // undefined is a valid value as the second argument to basename
   if (test !== undefined) {
     fail(path.basename, 'foo', test);
+  }
+
+  // numbers are valid arguments for join
+  if (typeof test !== 'number' || isNaN(test)) {
+    fail(path.join, test);
   }
 });
 


### PR DESCRIPTION
Hi! This allows numbers to be provided as arguments in addition to strings when creating paths with `path.join()`. Coercing numbers to strings instead of throwing TypeError.

Hoping this will revive the somewhat stale discussion in #1260.