### PR TITLE
build: avoid passing empty strings to build flags

### DIFF
--- a/configure
+++ b/configure
@@ -690,7 +690,8 @@ def configure_library(lib, output):
     if default_libpath:
       default_libpath = '-L' + default_libpath
     (pkg_libs, pkg_cflags, pkg_libpath) = pkg_config(lib)
-    cflags = pkg_cflags.split('-I') if pkg_cflags else default_cflags
+    # Remove empty strings from the list of include_dirs
+    cflags = filter(None, pkg_cflags.split('-I')) if pkg_cflags else default_cflags
     libs = pkg_libs if pkg_libs else default_lib
     libpath = pkg_libpath if pkg_libpath else default_libpath
 
@@ -846,10 +847,12 @@ def configure_intl(o):
       sys.exit(1)
     (libs, cflags, libpath) = pkgicu
     # libpath provides linker path which may contain spaces
-    o['libraries'] += [libpath]
+    if libpath:
+      o['libraries'] += [libpath]
     # safe to split, cannot contain spaces
     o['libraries'] += libs.split()
-    o['cflags'] += cflags.split()
+    if cflags:
+      o['cflags'] += filter(None, cflags.split('-I'))
     # use the "system" .gyp
     o['variables']['icu_gyp_path'] = 'tools/icu/icu-system.gyp'
     return

--- a/configure
+++ b/configure
@@ -691,7 +691,10 @@ def configure_library(lib, output):
       default_libpath = '-L' + default_libpath
     (pkg_libs, pkg_cflags, pkg_libpath) = pkg_config(lib)
     # Remove empty strings from the list of include_dirs
-    cflags = filter(None, pkg_cflags.split('-I')) if pkg_cflags else default_cflags
+    if pkg_cflags:
+      cflags = filter(None, map(str.strip, pkg_cflags.split('-I')))
+    else:
+      cflags = default_cflags
     libs = pkg_libs if pkg_libs else default_lib
     libpath = pkg_libpath if pkg_libpath else default_libpath
 
@@ -852,7 +855,7 @@ def configure_intl(o):
     # safe to split, cannot contain spaces
     o['libraries'] += libs.split()
     if cflags:
-      o['cflags'] += filter(None, cflags.split('-I'))
+      o['include_dirs'] += filter(None, map(str.strip, cflags.split('-I')))
     # use the "system" .gyp
     o['variables']['icu_gyp_path'] = 'tools/icu/icu-system.gyp'
     return


### PR DESCRIPTION
While checking the return values from icu-i18n, we didn't validate the content (enough) before passing it to the build system. Also make cflags parsing more robust by avoiding empty strings.

The reason we're introducing filtering is to avoid empty strings which might occur for other reasons (I found deviations between the systems I've been testing on and the stuff from arch linux). When you pass input to `.split()` it stops doing the "convenience stuff";
```python
>>> '-I/tmp/foo -I/bar/baz  -I'.split('-I')
['', '/tmp/foo ', '/bar/baz  ', '']
>>> filter(None, _)
['/tmp/foo ', '/bar/baz  ']
```
Fixes: https://github.com/nodejs/io.js/issues/1787

/R=@bnoordhuis, @alferpal