### PR TITLE
os: add homedir()

### DIFF
--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -10,6 +10,10 @@ Use `require('os')` to access this module.
 
 Returns the operating system's default directory for temporary files.
 
+## os.homedir()
+
+Returns the home directory of the current user.
+
 ## os.endianness()
 
 Returns the endianness of the CPU. Possible values are `'BE'` for big endian

--- a/lib/os.js
+++ b/lib/os.js
@@ -13,6 +13,8 @@ exports.cpus = binding.getCPUs;
 exports.type = binding.getOSType;
 exports.release = binding.getOSRelease;
 exports.networkInterfaces = binding.getInterfaceAddresses;
+exports.homedir = binding.getHomeDirectory;
+
 
 exports.arch = function() {
   return process.arch;

--- a/test/common.js
+++ b/test/common.js
@@ -10,6 +10,7 @@ exports.fixturesDir = path.join(exports.testDir, 'fixtures');
 exports.libDir = path.join(exports.testDir, '../lib');
 exports.tmpDirName = 'tmp';
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
+exports.isWindows = process.platform === 'win32';
 
 if (process.env.TEST_THREAD_ID) {
   // Distribute ports in parallel tests

--- a/test/parallel/test-os-homedir-no-envvar.js
+++ b/test/parallel/test-os-homedir-no-envvar.js
@@ -1,0 +1,30 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var cp = require('child_process');
+var os = require('os');
+var path = require('path');
+
+
+if (process.argv[2] === 'child') {
+  if (common.isWindows)
+    assert.equal(process.env.USERPROFILE, undefined);
+  else
+    assert.equal(process.env.HOME, undefined);
+
+  var home = os.homedir();
+
+  assert.ok(typeof home === 'string');
+  assert.ok(home.indexOf(path.sep) !== -1);
+} else {
+  if (common.isWindows)
+    delete process.env.USERPROFILE;
+  else
+    delete process.env.HOME;
+
+  var child = cp.spawnSync(process.execPath, [__filename, 'child'], {
+    env: process.env
+  });
+
+  assert.equal(child.status, 0);
+}

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -2,12 +2,13 @@
 var common = require('../common');
 var assert = require('assert');
 var os = require('os');
+var path = require('path');
 
 
 process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
-if (process.platform === 'win32') {
+if (common.isWindows) {
   assert.equal(os.tmpdir(), '/temp');
   process.env.TEMP = '';
   assert.equal(os.tmpdir(), '/tmp');
@@ -101,3 +102,22 @@ switch (platform) {
 
 var EOL = os.EOL;
 assert.ok(EOL.length > 0);
+
+
+var home = os.homedir();
+
+console.log('homedir = ' + home);
+assert.ok(typeof home === 'string');
+assert.ok(home.indexOf(path.sep) !== -1);
+
+if (common.isWindows && process.env.USERPROFILE) {
+  assert.equal(home, process.env.USERPROFILE);
+  delete process.env.USERPROFILE;
+  assert.ok(os.homedir().indexOf(path.sep) !== -1);
+  process.env.USERPROFILE = home;
+} else if (!common.isWindows && process.env.HOME) {
+  assert.equal(home, process.env.HOME);
+  delete process.env.HOME;
+  assert.ok(os.homedir().indexOf(path.sep) !== -1);
+  process.env.HOME = home;
+}


### PR DESCRIPTION
Do not land this yet.

This PR adds `os.homedir()`, which calls libuv's `uv_os_homedir()` to retrieve the current user's home directory. This is an alternative to #1670. This PR currently consists of two commits. 6887116da24dbd02f088318c84df63439f442c58 is the libuv update, which has not landed in io.js yet. This commit should be removed once a proper update is in place. e7e5992113a00e18005ef37d1eb820e5321c465b is the io.js update.