### PR TITLE
tools: don't use global Buffer and add linter rule for it

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ test/addons/doc-*/
 test/fixtures
 test/**/node_modules
 test/parallel/test-fs-non-number-arguments-throw.js
+test/disabled

--- a/.eslintrc
+++ b/.eslintrc
@@ -39,14 +39,9 @@ rules:
   # Stylistic Issues
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#stylistic-issues
   ## use single quote, we can use double quote when escape chars
-  quotes:
-    - 2
-    - "single"
-    - "avoid-escape"
+  quotes: [2, "single", "avoid-escape"]
   ## 2 space indentation
-  indent:
-    - 2
-    - 2
+  indent: [2, 2]
   ## add space after comma
   ## set to 'warn' because of https://github.com/eslint/eslint/issues/2408
   comma-spacing: 1
@@ -63,35 +58,40 @@ rules:
   ## require parens for Constructor
   new-parens: 2
   ## max 80 length
-  max-len:
-    - 2
-    - 80
-    - 2
+  max-len: [2, 80, 2]
 
   # Strict Mode
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#strict-mode
   ## 'use strict' on top
-  strict:
-    - 2
-    - "global"
+  strict: [2, "global"]
+
+  # Variables
+  # list: https://github.com/eslint/eslint/tree/master/docs/rules#variables
+  ## disallow use of undefined variables (globals)
+  no-undef: 2
+
+  # Custom rules in tools/eslint-rules
+  require-buffer: 2
 
 # Global scoped method and vars
 globals:
-  DTRACE_HTTP_CLIENT_REQUEST: true
-  LTTNG_HTTP_CLIENT_REQUEST: true
-  COUNTER_HTTP_CLIENT_REQUEST: true
-  DTRACE_HTTP_CLIENT_RESPONSE: true
-  LTTNG_HTTP_CLIENT_RESPONSE: true
-  COUNTER_HTTP_CLIENT_RESPONSE: true
-  DTRACE_HTTP_SERVER_REQUEST: true
-  LTTNG_HTTP_SERVER_REQUEST: true
-  COUNTER_HTTP_SERVER_REQUEST: true
-  DTRACE_HTTP_SERVER_RESPONSE: true
-  LTTNG_HTTP_SERVER_RESPONSE: true
-  COUNTER_HTTP_SERVER_RESPONSE: true
-  DTRACE_NET_STREAM_END: true
-  LTTNG_NET_STREAM_END: true
-  COUNTER_NET_SERVER_CONNECTION_CLOSE: true
-  DTRACE_NET_SERVER_CONNECTION: true
-  LTTNG_NET_SERVER_CONNECTION: true
-  COUNTER_NET_SERVER_CONNECTION: true
+  DTRACE_HTTP_CLIENT_REQUEST           : false
+  LTTNG_HTTP_CLIENT_REQUEST            : false
+  COUNTER_HTTP_CLIENT_REQUEST          : false
+  DTRACE_HTTP_CLIENT_RESPONSE          : false
+  LTTNG_HTTP_CLIENT_RESPONSE           : false
+  COUNTER_HTTP_CLIENT_RESPONSE         : false
+  DTRACE_HTTP_SERVER_REQUEST           : false
+  LTTNG_HTTP_SERVER_REQUEST            : false
+  COUNTER_HTTP_SERVER_REQUEST          : false
+  DTRACE_HTTP_SERVER_RESPONSE          : false
+  LTTNG_HTTP_SERVER_RESPONSE           : false
+  COUNTER_HTTP_SERVER_RESPONSE         : false
+  DTRACE_NET_STREAM_END                : false
+  LTTNG_NET_STREAM_END                 : false
+  COUNTER_NET_SERVER_CONNECTION_CLOSE  : false
+  DTRACE_NET_SERVER_CONNECTION         : false
+  LTTNG_NET_SERVER_CONNECTION          : false
+  COUNTER_NET_SERVER_CONNECTION        : false
+  escape                               : false
+  unescape                             : false

--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ bench-idle:
 	./$(NODE_EXE) benchmark/idle_clients.js &
 
 jslint:
-	./$(NODE_EXE) tools/eslint/bin/eslint.js src lib test --reset --quiet
+	./$(NODE_EXE) tools/eslint/bin/eslint.js src lib test --rulesdir tools/eslint-rules --reset --quiet
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -9,6 +9,7 @@ const repl = Module.requireRepl();
 const inherits = util.inherits;
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const Buffer = require('buffer').Buffer;
 
 exports.start = function(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -13,6 +13,7 @@ const freeParser = common.freeParser;
 const debug = common.debug;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const Agent = require('_http_agent');
+const Buffer = require('buffer').Buffer;
 
 
 function ClientRequest(options, cb) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -4,6 +4,7 @@ const assert = require('assert').ok;
 const Stream = require('stream');
 const timers = require('timers');
 const util = require('util');
+const Buffer = require('buffer').Buffer;
 const common = require('_http_common');
 
 const CRLF = common.CRLF;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -5,6 +5,7 @@ Readable.ReadableState = ReadableState;
 
 const EE = require('events').EventEmitter;
 const Stream = require('stream');
+const Buffer = require('buffer').Buffer;
 const util = require('util');
 const debug = util.debuglog('stream');
 var StringDecoder;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -9,6 +9,7 @@ Writable.WritableState = WritableState;
 
 const util = require('util');
 const Stream = require('stream');
+const Buffer = require('buffer').Buffer;
 
 util.inherits(Writable, Stream);
 

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -7,6 +7,7 @@ const tls = require('tls');
 const util = require('util');
 const common = require('_tls_common');
 const debug = util.debuglog('tls-legacy');
+const Buffer = require('buffer').Buffer;
 const Timer = process.binding('timer_wrap').Timer;
 var Connection = null;
 try {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -8,6 +8,7 @@ const util = require('util');
 const listenerCount = require('events').listenerCount;
 const common = require('_tls_common');
 const StreamWrap = require('_stream_wrap').StreamWrap;
+const Buffer = require('buffer').Buffer;
 const Duplex = require('stream').Duplex;
 const debug = util.debuglog('tls');
 const Timer = process.binding('timer_wrap').Timer;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -27,6 +27,7 @@
 // UTILITY
 const compare = process.binding('buffer').compare;
 const util = require('util');
+const Buffer = require('buffer').Buffer;
 const pSlice = Array.prototype.slice;
 
 // 1. The assert module provides functions that throw

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-buffer */
 'use strict';
 
 const binding = process.binding('buffer');

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -6,6 +6,7 @@ const constants = require('constants');
 
 const uv = process.binding('uv');
 const spawn_sync = process.binding('spawn_sync');
+const Buffer = require('buffer').Buffer;
 const Pipe = process.binding('pipe_wrap').Pipe;
 const child_process = require('internal/child_process');
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -15,6 +15,7 @@ try {
   throw new Error('node.js not compiled with openssl crypto support.');
 }
 
+const Buffer = require('buffer').Buffer;
 const constants = require('constants');
 const stream = require('stream');
 const util = require('util');

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const Buffer = require('buffer').Buffer;
 const util = require('util');
 const events = require('events');
 const constants = require('constants');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -10,6 +10,7 @@ const pathModule = require('path');
 const binding = process.binding('fs');
 const constants = require('constants');
 const fs = exports;
+const Buffer = require('buffer').Buffer;
 const Stream = require('stream').Stream;
 const EventEmitter = require('events').EventEmitter;
 const FSReqWrap = binding.FSReqWrap;

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const StringDecoder = require('string_decoder').StringDecoder;
+const Buffer = require('buffer').Buffer;
 const EventEmitter = require('events').EventEmitter;
 const net = require('net');
 const dgram = require('dgram');

--- a/lib/internal/smalloc.js
+++ b/lib/internal/smalloc.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const smalloc = process.binding('smalloc');
+const Buffer = require('buffer').Buffer;
 const kMaxLength = smalloc.kMaxLength;
 const kMinType = smalloc.kMinType;
 const kMaxType = smalloc.kMaxType;

--- a/lib/net.js
+++ b/lib/net.js
@@ -8,6 +8,7 @@ const assert = require('assert');
 const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
 
+const Buffer = require('buffer').Buffer;
 const TTYWrap = process.binding('tty_wrap');
 const TCP = process.binding('tcp_wrap').TCP;
 const Pipe = process.binding('pipe_wrap').Pipe;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const QueryString = exports;
+const Buffer = require('buffer').Buffer;
 
 
 function charCode(c) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -10,6 +10,7 @@ const kHistorySize = 30;
 
 const util = require('util');
 const inherits = util.inherits;
+const Buffer = require('buffer').Buffer;
 const EventEmitter = require('events').EventEmitter;
 
 

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Buffer = require('buffer').Buffer;
+
 function assertEncoding(encoding) {
   // Do not cache `Buffer.isEncoding`, some modules monkey-patch it to support
   // additional encodings

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -4,6 +4,7 @@ const net = require('net');
 const url = require('url');
 const util = require('util');
 const binding = process.binding('crypto');
+const Buffer = require('buffer').Buffer;
 
 // Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
 // every {CLIENT_RENEG_WINDOW} seconds. An error event is emitted if more

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const uv = process.binding('uv');
+const Buffer = require('buffer').Buffer;
 const Debug = require('vm').runInDebugContext('Debug');
 const internalUtil = require('internal/util');
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Buffer = require('buffer').Buffer;
 const Transform = require('_stream_transform');
 const binding = process.binding('zlib');
 const util = require('util');

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,3 +3,10 @@
 rules:
   ## allow unreachable code
   no-unreachable: 0
+  ## allow undeclared variables
+  no-undef: 0
+  ## allow global Buffer usage
+  require-buffer: 0
+
+globals:
+  gc: false

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -106,17 +106,13 @@ function checkResults(expected_results, results) {
     var actual = results[k],
         expected = expected_results[k];
 
-    if (typeof expected === 'function') {
-      expected(r[k]);
-    } else {
-      var msg = (expected[1] || '') +
-          (' [expected: ' + expected[0] + ' / actual: ' + actual + ']');
+    var msg = (expected[1] || '') +
+        (' [expected: ' + expected[0] + ' / actual: ' + actual + ']');
 
-      if (expected && expected.length) {
-        assert.equal(actual, expected[0], msg);
-      } else {
-        assert.equal(actual, expected, msg);
-      }
+    if (expected && expected.length) {
+      assert.equal(actual, expected[0], msg);
+    } else {
+      assert.equal(actual, expected, msg);
     }
   }
 }

--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -106,16 +106,12 @@ function checkResults(expected_results, results) {
     var actual = results[k],
         expected = expected_results[k];
 
-    if (typeof expected === 'function') {
-      expected(r[k]);
+    var msg = (expected[1] || '') +
+        (' [expected: ' + expected[0] + ' / actual: ' + actual + ']');
+    if (expected && expected.length) {
+      assert.equal(actual, expected[0], msg);
     } else {
-      var msg = (expected[1] || '') +
-          (' [expected: ' + expected[0] + ' / actual: ' + actual + ']');
-      if (expected && expected.length) {
-        assert.equal(actual, expected[0], msg);
-      } else {
-        assert.equal(actual, expected, msg);
-      }
+      assert.equal(actual, expected, msg);
     }
   }
 }

--- a/test/pummel/test-net-timeout.js
+++ b/test/pummel/test-net-timeout.js
@@ -79,7 +79,7 @@ process.on('exit', function() {
   assert.ok(starttime != null);
   assert.ok(timeouttime != null);
 
-  diff = timeouttime - starttime;
+  var diff = timeouttime - starttime;
   console.log('diff = ' + diff);
 
   assert.ok(timeout < diff);

--- a/tools/eslint-rules/require-buffer.js
+++ b/tools/eslint-rules/require-buffer.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const msg = "Use const Buffer = require('buffer').Buffer; on top of this file";
+
+module.exports = function(context) {
+  return {
+    "Program:exit": function() {
+      context.getScope().through.forEach(function(ref) {
+        if (ref.identifier.name === 'Buffer') {
+            context.report(ref.identifier, msg);
+        }
+      });
+    }
+  }
+}

--- a/tools/eslint-rules/require-buffer.js
+++ b/tools/eslint-rules/require-buffer.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const msg = "Use const Buffer = require('buffer').Buffer; on top of this file";
+const msg = 'Use const Buffer = require(\'buffer\').Buffer; ' +
+            'at the beginning of this file';
 
 module.exports = function(context) {
   return {
-    "Program:exit": function() {
+    'Program:exit': function() {
       context.getScope().through.forEach(function(ref) {
         if (ref.identifier.name === 'Buffer') {
             context.report(ref.identifier, msg);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -181,7 +181,7 @@ goto jslint
 :jslint
 if not defined jslint goto exit
 echo running jslint
-%config%\iojs tools\eslint\bin\eslint.js src lib test --reset --quiet
+%config%\iojs tools\eslint\bin\eslint.js src lib test --rulesdir tools\eslint-rules --reset --quiet
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION
This does a few things to the linter configuration:

- instead of relying on the predefined `node` environment, specify all our globals manually and as read-only.
- enable [`no-undef`](http://eslint.org/docs/rules/no-undef) to error on undefined variable access.
- add `globalReturn` which allows to return from the top scope. This was implied by the `node` option before.

A number of tests intentionally use undefined globals to trigger an error or set globals (in the `vm` tests). I had to exclude those tests with an `eslint-disable` comment. If these comments are too noisy, we could alternatively disable that rule for all tests.

I might have missed a few globals from the v8 environment. `Object.keys(global)` doesn't list many of them, presumably because they are unenumerable. Any better ideas on how to discover globals?

cc: @Fishrock123 @domenic