### PR TITLE
Speed up require(), phase 1 and 2

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -6,6 +6,7 @@ const runInThisContext = require('vm').runInThisContext;
 const assert = require('assert').ok;
 const fs = require('fs');
 const path = require('path');
+const internalModuleStat = process.binding('fs').internalModuleStat;
 
 
 // If obj.hasOwnProperty has been overridden, then calling
@@ -56,13 +57,6 @@ const debug = Module._debug;
 //   -> a.<ext>
 //   -> a/index.<ext>
 
-function statPath(path) {
-  try {
-    return fs.statSync(path);
-  } catch (ex) {}
-  return false;
-}
-
 // check if the directory is a package.json dir
 const packageMainCache = {};
 
@@ -94,7 +88,7 @@ function tryPackage(requestPath, exts) {
   if (!pkg) return false;
 
   var filename = path.resolve(requestPath, pkg);
-  return tryFile(filename, null) || tryExtensions(filename, exts) ||
+  return tryFile(filename) || tryExtensions(filename, exts) ||
          tryExtensions(path.resolve(filename, 'index'), exts);
 }
 
@@ -104,18 +98,19 @@ function tryPackage(requestPath, exts) {
 Module._realpathCache = {};
 
 // check if the file exists and is not a directory
-function tryFile(requestPath, stats) {
-  stats = stats || statPath(requestPath);
-  if (stats && !stats.isDirectory()) {
-    return fs.realpathSync(requestPath, Module._realpathCache);
-  }
-  return false;
+function tryFile(requestPath) {
+  const rc = internalModuleStat(requestPath);
+  return rc === 0 && toRealPath(requestPath);
+}
+
+function toRealPath(requestPath) {
+  return fs.realpathSync(requestPath, Module._realpathCache);
 }
 
 // given a path check a the file exists with any of the set extensions
 function tryExtensions(p, exts) {
   for (var i = 0, EL = exts.length; i < EL; i++) {
-    var filename = tryFile(p + exts[i], null);
+    var filename = tryFile(p + exts[i]);
 
     if (filename) {
       return filename;
@@ -150,11 +145,10 @@ Module._findPath = function(request, paths) {
     var filename;
 
     if (!trailingSlash) {
-      var stats = statPath(basePath);
-      // try to join the request to the path
-      filename = tryFile(basePath, stats);
-
-      if (!filename && stats && stats.isDirectory()) {
+      const rc = internalModuleStat(basePath);
+      if (rc === 0) {  // File.
+        filename = toRealPath(basePath);
+      } else if (rc === 1) {  // Directory.
         filename = tryPackage(basePath, exts);
       }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -6,6 +6,7 @@ const runInThisContext = require('vm').runInThisContext;
 const assert = require('assert').ok;
 const fs = require('fs');
 const path = require('path');
+const internalModuleReadFile = process.binding('fs').internalModuleReadFile;
 const internalModuleStat = process.binding('fs').internalModuleStat;
 
 
@@ -65,10 +66,10 @@ function readPackage(requestPath) {
     return packageMainCache[requestPath];
   }
 
-  try {
-    var jsonPath = path.resolve(requestPath, 'package.json');
-    var json = fs.readFileSync(jsonPath, 'utf8');
-  } catch (e) {
+  var jsonPath = path.resolve(requestPath, 'package.json');
+  var json = internalModuleReadFile(jsonPath);
+
+  if (json === undefined) {
     return false;
   }
 


### PR DESCRIPTION
Replace calls to fs.statSync() with an internal variant that does not
create Error or Stat objects that put strain on the garbage collector.

Replace calls to fs.readFileSync() with an internal variant that does
not create Error objects on failure and is a bit speedier in general.

A secondary benefit is that it improves start-up times in the debugger
because it no longer emits thousands of exception debug events.

On a medium-sized application[0], this commit and its predecessor reduce
start-up times from about 1.5s to 0.5s and reduce the number of start-up
exceptions from ~6100 to 32, half of them internal to the application.

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/712/

R=@trevnorris?