### PR TITLE
zlib: prevent uncaught exception in zlibBuffer

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -209,10 +209,16 @@ function zlibBuffer(engine, buffer, callback) {
   }
 
   function onEnd() {
-    var buf = Buffer.concat(buffers, nread);
+    var buf;
+    var err = null;
+    try {
+      buf = Buffer.concat(buffers, nread);
+    } catch (e) {
+      err = e;
+    }
     buffers = [];
-    callback(null, buf);
     engine.close();
+    callback(err, buf);
   }
 }
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -4,6 +4,9 @@ const Transform = require('_stream_transform');
 const binding = process.binding('zlib');
 const util = require('util');
 const assert = require('assert').ok;
+const kMaxLength = process.binding('smalloc').kMaxLength;
+const kRangeErrorMessage = 'Cannot create final Buffer. ' +
+    'It would be larger than 0x' + kMaxLength.toString(16) + ' bytes.';
 
 // zlib doesn't provide these, so kludge them in following the same
 // const naming scheme zlib uses.
@@ -211,11 +214,13 @@ function zlibBuffer(engine, buffer, callback) {
   function onEnd() {
     var buf;
     var err = null;
-    try {
+
+    if (nread >= kMaxLength) {
+      err = new RangeError(kRangeErrorMessage);
+    } else {
       buf = Buffer.concat(buffers, nread);
-    } catch (e) {
-      err = e;
     }
+
     buffers = [];
     engine.close();
     callback(err, buf);
@@ -529,6 +534,11 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
 
     if (this._hadError) {
       throw error;
+    }
+
+    if (nread >= kMaxLength) {
+      this.close();
+      throw new RangeError(kRangeErrorMessage);
     }
 
     var buf = Buffer.concat(buffers, nread);

--- a/test/parallel/test-regress-GH-io-1811.js
+++ b/test/parallel/test-regress-GH-io-1811.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require('assert');
+
+// Change kMaxLength for zlib to trigger the error
+// without having to allocate 1GB of buffers
+const smalloc = process.binding('smalloc');
+smalloc.kMaxLength = 128;
+const zlib = require('zlib');
+smalloc.kMaxLength = 0x3fffffff;
+
+const encoded = new Buffer('H4sIAAAAAAAAA0tMHFgAAIw2K/GAAAAA', 'base64');
+
+// Async
+zlib.gunzip(encoded, function(err) {
+  assert.ok(err instanceof RangeError);
+});
+
+// Sync
+assert.throws(function() {
+  zlib.gunzipSync(encoded);
+}, RangeError);


### PR DESCRIPTION
If the final buffer needs to be larger than kMaxLength, the concatenation fails and there is no way to catch the error:

```
buffer.js:173
    throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
          ^
RangeError: Attempt to allocate Buffer larger than maximum size: 0x3fffffff bytes
    at checked (buffer.js:173:11)
    at fromNumber (buffer.js:56:51)
    at new Buffer (buffer.js:41:5)
    at Function.Buffer.concat (buffer.js:263:16)
    at Gunzip.onEnd (zlib.js:212:22)
    at emitNone (events.js:72:20)
    at Gunzip.emit (events.js:163:7)
    at endReadableNT (_stream_readable.js:890:12)
    at doNTCallback2 (node.js:437:9)
    at process._tickCallback (node.js:351:17)
```

Testcase : https://gist.github.com/targos/643a802e0ed4fa60f3bd