### PR TITLE
src: fix module search path for preload modules

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -508,6 +508,20 @@ Module.requireRepl = function() {
   return Module._load('internal/repl', '.');
 };
 
+Module._preloadModules = function(requests) {
+  if (!Array.isArray(requests))
+    return;
+
+  // Preloaded modules have a dummy parent module which is deemed to exist
+  // in the current working directory. This seeds the search path for
+  // preloaded modules.
+  var parent = new Module('internal/preload', null);
+  parent.paths = Module._nodeModulePaths(process.cwd());
+  requests.forEach(function(request) {
+    Module._load(request, parent, false);
+  });
+};
+
 Module._initPaths();
 
 // backwards compatibility

--- a/src/node.js
+++ b/src/node.js
@@ -858,10 +858,7 @@
   // Load preload modules
   startup.preloadModules = function() {
     if (process._preload_modules) {
-      var Module = NativeModule.require('module');
-      process._preload_modules.forEach(function(module) {
-        Module._load(module);
-      });
+      NativeModule.require('module')._preloadModules(process._preload_modules);
     }
   };
 

--- a/test/fixtures/cluster-preload.js
+++ b/test/fixtures/cluster-preload.js
@@ -1,3 +1,12 @@
+var assert = require('assert');
+
+// https://github.com/nodejs/io.js/issues/1803
+// this module is used as a preload module. It should have a parent with the
+// module search paths initialized from the current working directory
+assert.ok(module.parent);
+var expectedPaths = require('module')._nodeModulePaths(process.cwd());
+assert.deepEqual(module.parent.paths, expectedPaths);
+
 var cluster = require('cluster');
 cluster.isMaster || process.exit(42 + cluster.worker.id); // +42 to distinguish
 // from exit(1) for other random reasons


### PR DESCRIPTION
When the preload module is not a abs/relative path, we should use
the standard search mechanism of looking into the node_modules folders
outwards. The current working directory is deemed to be the 'requiring
module', i.e. parent. The search path starts from cwd outwards.

Fixes: #1803