### PR TITLE
src: hide InitializeICUDirectory symbol

### DIFF
--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -8,7 +8,7 @@
 namespace node {
 namespace i18n {
 
-NODE_EXTERN bool InitializeICUDirectory(const char* icu_data_path);
+bool InitializeICUDirectory(const char* icu_data_path);
 
 }  // namespace i18n
 }  // namespace node


### PR DESCRIPTION
Exporting it seems like an oversight.  It's not safe to call once
V8 is running so there doesn't seem to be a point in exporting it
to add-ons.  Un-export it.

R=@srl295?