### PR TITLE
src: remove old code

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -578,12 +578,6 @@
         var tty = NativeModule.require('tty');
         stream = new tty.WriteStream(fd);
         stream._type = 'tty';
-
-        // Hack to have stream not keep the event loop alive.
-        // See https://github.com/joyent/node/issues/1726
-        if (stream._handle && stream._handle.unref) {
-          stream._handle.unref();
-        }
         break;
 
       case 'FILE':
@@ -600,20 +594,7 @@
           readable: false,
           writable: true
         });
-
-        // FIXME Should probably have an option in net.Socket to create a
-        // stream from an existing fd which is writable only. But for now
-        // we'll just add this hack and set the `readable` member to false.
-        // Test: ./node test/fixtures/echo.js < /etc/passwd
-        stream.readable = false;
-        stream.read = null;
         stream._type = 'pipe';
-
-        // FIXME Hack to have stream not keep the event loop alive.
-        // See https://github.com/joyent/node/issues/1726
-        if (stream._handle && stream._handle.unref) {
-          stream._handle.unref();
-        }
         break;
 
       default:


### PR DESCRIPTION
The `Socket` writable-only change was added and implemented in the
constructor around 5885f464f0ad372efa7e, but this was never removed.

The libev counter issue is no longer prudent; the test remains in
`test/sequential/test-regress-GH-1726`.