### PR TITLE
smalloc: deprecate whole module

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -3,6 +3,7 @@
 const binding = process.binding('buffer');
 const smalloc = process.binding('smalloc');
 const util = require('util');
+const internalUtil = require('internal/util');
 const alloc = smalloc.alloc;
 const truncate = smalloc.truncate;
 const sliceOnto = smalloc.sliceOnto;
@@ -504,16 +505,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
 
   // XXX legacy write(string, encoding, offset, length) - remove in v0.13
   } else {
-    if (!writeWarned) {
-      if (process.throwDeprecation)
-        throw new Error(writeMsg);
-      else if (process.traceDeprecation)
-        console.trace(writeMsg);
-      else
-        console.error(writeMsg);
-      writeWarned = true;
-    }
-
+    writeWarned = internalUtil.printDeprecationMessage(writeMsg, writeWarned);
     var swap = encoding;
     encoding = offset;
     offset = length >>> 0;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -19,7 +19,7 @@ const Readable = Stream.Readable;
 const Writable = Stream.Writable;
 
 const kMinPoolSpace = 128;
-const kMaxLength = require('smalloc').kMaxLength;
+const kMaxLength = require('internal/smalloc').kMaxLength;
 
 const O_APPEND = constants.O_APPEND || 0;
 const O_CREAT = constants.O_CREAT || 0;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.printDeprecationMessage = function(msg, warned) {
+  if (process.noDeprecation)
+    return true;
+
+  if (warned)
+    return warned;
+
+  if (process.throwDeprecation)
+    throw new Error(msg);
+  else if (process.traceDeprecation)
+    console.trace(msg);
+  else
+    console.error(msg);
+
+  return true;
+};

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -61,8 +61,7 @@ exports.writer = util.inspect;
 exports._builtinLibs = ['assert', 'buffer', 'child_process', 'cluster',
   'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net',
   'os', 'path', 'punycode', 'querystring', 'readline', 'stream',
-  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib',
-  'smalloc'];
+  'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'];
 
 
 const BLOCK_SCOPED_ERROR = 'Block-scoped declarations (let, ' +

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -1,27 +1,6 @@
 'use strict';
 
-const smalloc = require('internal/smalloc');
-const deprecate = require('util').deprecate;
+const util = require('internal/util');
 
-exports.alloc =
-    deprecate(smalloc.alloc, 'smalloc.alloc: Deprecated, use typed arrays');
-
-exports.copyOnto =
-    deprecate(smalloc.copyOnto,
-              'smalloc.copyOnto: Deprecated, use typed arrays');
-
-exports.dispose =
-    deprecate(smalloc.dispose,
-              'smalloc.dispose: Deprecated, use typed arrays');
-
-exports.hasExternalData =
-    deprecate(smalloc.hasExternalData,
-              'smalloc.hasExternalData: Deprecated, use typed arrays');
-
-Object.defineProperty(exports, 'kMaxLength', {
-  enumerable: true, value: smalloc.kMaxLength, writable: false
-});
-
-Object.defineProperty(exports, 'Types', {
-  enumerable: true, value: Object.freeze(smalloc.Types), writable: false
-});
+module.exports = require('internal/smalloc');
+util.printDeprecationMessage('smalloc is deprecated.');

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -1,13 +1,10 @@
 'use strict';
 
-const util = require('util');
+const util = require('internal/util');
 
 // the sys module was renamed to 'util'.
 // this shim remains to keep old programs working.
 // sys is deprecated and shouldn't be used
 
-const setExports = util.deprecate(function() {
-  module.exports = util;
-}, 'sys is deprecated. Use util instead.');
-
-setExports();
+module.exports = require('util');
+util.printDeprecationMessage('sys is deprecated. Use util instead.');

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@
 
 const uv = process.binding('uv');
 const Debug = require('vm').runInDebugContext('Debug');
+const internalUtil = require('internal/util');
 
 const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
@@ -63,16 +64,7 @@ exports.deprecate = function(fn, msg) {
 
   var warned = false;
   function deprecated() {
-    if (!warned) {
-      if (process.throwDeprecation) {
-        throw new Error(msg);
-      } else if (process.traceDeprecation) {
-        console.trace(msg);
-      } else {
-        console.error(msg);
-      }
-      warned = true;
-    }
+    warned = internalUtil.printDeprecationMessage(msg, warned);
     return fn.apply(this, arguments);
   }
 

--- a/node.gyp
+++ b/node.gyp
@@ -73,6 +73,7 @@
       'lib/internal/freelist.js',
       'lib/internal/smalloc.js',
       'lib/internal/repl.js',
+      'lib/internal/util.js',
     ],
   },
 


### PR DESCRIPTION
It makes no sense to allow people use constants from `smalloc`, since it will be removed completely eventually.

R=@bnoordhuis 