### PR TITLE
http/net: fix catching immediate connect errors

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -768,8 +768,30 @@ function afterWrite(status, handle, req, err) {
     req.cb.call(self);
 }
 
-
+function connectExFn(self, ex) {
+  self._destroy(ex);
+}
 function connect(self, address, port, addressType, localAddress, localPort) {
+  _connect(
+    self,
+    address,
+    port,
+    addressType,
+    localAddress,
+    localPort,
+    connectExFn
+  );
+}
+
+function _connect(
+  self,
+  address,
+  port,
+  addressType,
+  localAddress,
+  localPort,
+  exFn
+) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
 
@@ -800,7 +822,7 @@ function connect(self, address, port, addressType, localAddress, localPort) {
 
     if (err) {
       var ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
-      self._destroy(ex);
+      exFn(self, ex);
       return;
     }
   }
@@ -832,7 +854,7 @@ function connect(self, address, port, addressType, localAddress, localPort) {
     }
 
     var ex = exceptionWithHostPort(err, 'connect', address, port, details);
-    self._destroy(ex);
+    exFn(self, ex);
   }
 }
 
@@ -898,7 +920,6 @@ Socket.prototype.connect = function(options, cb) {
   return self;
 };
 
-
 function lookupAndConnect(self, options) {
   const dns = require('dns');
   var host = options.host || 'localhost';
@@ -924,7 +945,15 @@ function lookupAndConnect(self, options) {
   // TODO(evanlucas) should we hot path this for localhost?
   var addressType = exports.isIP(host);
   if (addressType) {
-    connect(self, host, port, addressType, localAddress, localPort);
+    _connect(
+      self,
+      host,
+      port,
+      addressType,
+      localAddress,
+      localPort,
+      connectTickError
+    );
     return;
   }
 
@@ -959,16 +988,27 @@ function lookupAndConnect(self, options) {
       err.host = options.host;
       err.port = options.port;
       err.message = err.message + ' ' + options.host + ':' + options.port;
-      process.nextTick(connectErrorNT, self, err);
+      connectTickError(self, err);
     } else {
       self._unrefTimer();
-      connect(self,
+      _connect(self,
               ip,
               port,
               addressType,
               localAddress,
-              localPort);
+              localPort,
+              connectTickError);
     }
+  });
+}
+
+
+function connectTickError(self, err) {
+  // wow...http client onSocket registers on processNextTick
+  // but this registering is executed after this nextTick function.
+  // so we need to wrap it in one more nextTick :|
+  process.nextTick(function() {
+    process.nextTick(connectErrorNT, self, err);
   });
 }
 


### PR DESCRIPTION
When creating a standard http client request the agent is calling
net.createConnection. The agent will then defer installing error
handling to nextTick(). If there is any immediate error in
createConnection iojs will bail with an uncaught error. There is already
one error situation which is handled in a special way (i.e. throwing
error is deferred so the standard error handler may catch it). However
there are more situations where this may happen: Namely in the connect()
function.

Due to a locally changed ip address I was getting the following error and the iojs bailed out (which should not happen as error management was in place):

```
events.js:141
      throw er; // Unhandled 'error' event
            ^
Error: connect EHOSTDOWN 192.168.1.11:80 - Local (192.168.1.10:54125)
    at Object.exports._errnoException (util.js:846:11)
    at exports._exceptionWithHostPort (util.js:869:20)
    at connect (net.js:840:14)
    at lookupAndConnect (net.js:933:5)
    at Socket.connect (net.js:902:5)
    at Agent.exports.connect.exports.createConnection (net.js:61:35)
    at Agent.createSocket (_http_agent.js:177:16)
    at Agent.addRequest (_http_agent.js:147:23)
    at new ClientRequest (_http_client.js:132:16)
    at Object.exports.request (http.js:30:10)
```

I am still unsure why I am the only one facing this problem and maybe the pull request is entirely bogus. The error situation seems pretty common to me (and that's why I am surprised): My dhcp assigned my dev machine a new address and connecting to the old, hardcoded ip address is now failing with an ETIMEOUT (as expected). However another, slightly (few seconds) deferred request (while the first one is still working) will trigger an immediate EHOSTDOWN/EHOSTUNREACH error for me which cannot be caught using request.on("error", fn).

I can 100% reproduce this with iojs 2.1 and master using the following gist:

https://gist.github.com/m0ppers/3709f7d87b73be9aca7b

I am on osx yosemite.

The wrapped nextTick, nextTick thing is of course totally evil. However I cannot seem to fix it otherwise. The root cause IMHO is the deferred error management in the http client. I don't know the reason for it and left it untouched but IMHO this should be the real fix.

It has been introduced with this commit (which makes me even more unsure as this is years ago):

https://github.com/joyent/node/commit/7c87e092fb97ab293e19b21a8b07f622c80c68b3

Can somebody reproduce the problem? Am missing something? Does somebody have a better fix (nextTick(nextTick()))? :S