### PR TITLE
v8: reimplement `getHeapStatistics`

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -15,11 +15,8 @@
 'use strict';
 
 const v8binding = process.binding('v8');
-const smalloc = require('internal/smalloc');
 
-const heapStatisticsBuffer =
-    smalloc.alloc(v8binding.kHeapStatisticsBufferLength,
-                  v8binding.kHeapStatisticsBufferType);
+const buffer = v8binding.getHeapStatisticsBuffer();
 
 const kTotalHeapSizeIndex = v8binding.kTotalHeapSizeIndex;
 const kTotalHeapSizeExecutableIndex = v8binding.kTotalHeapSizeExecutableIndex;
@@ -28,9 +25,7 @@ const kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
 const kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
 
 exports.getHeapStatistics = function() {
-  var buffer = heapStatisticsBuffer;
-
-  v8binding.getHeapStatistics(buffer);
+  v8binding.getHeapStatistics();
 
   return {
     'total_heap_size': buffer[kTotalHeapSizeIndex],

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -177,6 +177,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       using_asyncwrap_(false),
       printed_error_(false),
       trace_sync_io_(false),
+      heap_stats_buffer_(nullptr),
       debugger_agent_(this),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
@@ -198,6 +199,10 @@ inline Environment::~Environment() {
   ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
 #undef V
   isolate_data()->Put();
+
+  if (heap_stats_buffer_ != nullptr) {
+    free(heap_stats_buffer_);
+  }
 }
 
 inline void Environment::CleanupHandles() {
@@ -329,6 +334,15 @@ inline void Environment::set_printed_error(bool value) {
 inline void Environment::set_trace_sync_io(bool value) {
   trace_sync_io_ = value;
 }
+
+inline void* Environment::heap_stats_buffer() const {
+  return heap_stats_buffer_;
+}
+
+inline void Environment::set_heap_stats_buffer(void* buffer) {
+  heap_stats_buffer_ = buffer;
+}
+
 
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {
   return ContainerOf(&Environment::cares_timer_handle_, handle);

--- a/src/env.h
+++ b/src/env.h
@@ -420,6 +420,9 @@ class Environment {
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
 
+  inline void* heap_stats_buffer() const;
+  inline void set_heap_stats_buffer(void* buffer);
+
   void PrintSyncTrace() const;
   inline void set_trace_sync_io(bool value);
 
@@ -510,6 +513,7 @@ class Environment {
   bool using_asyncwrap_;
   bool printed_error_;
   bool trace_sync_io_;
+  void* heap_stats_buffer_;
   debugger::Agent debugger_agent_;
 
   HandleWrapQueue handle_wrap_queue_;

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -7,6 +7,7 @@
 
 namespace node {
 
+using v8::ArrayBuffer;
 using v8::Context;
 using v8::ExternalArrayType;
 using v8::Function;
@@ -18,6 +19,7 @@ using v8::Local;
 using v8::Object;
 using v8::String;
 using v8::Uint32;
+using v8::Uint32Array;
 using v8::V8;
 using v8::Value;
 
@@ -32,30 +34,42 @@ using v8::Value;
 static const size_t kHeapStatisticsBufferLength = HEAP_STATISTICS_PROPERTIES(V);
 #undef V
 
-static const ExternalArrayType kHeapStatisticsBufferType =
-    v8::kExternalUint32Array;
-
 void GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args.Length() == 1 && args[0]->IsObject());
-
   Isolate* isolate = args.GetIsolate();
+  Environment* env = Environment::GetCurrent(isolate);
   HeapStatistics s;
   isolate->GetHeapStatistics(&s);
-  Local<Object> obj = args[0].As<Object>();
+
   uint32_t* data =
-      static_cast<uint32_t*>(obj->GetIndexedPropertiesExternalArrayData());
+      static_cast<uint32_t*>(env->heap_stats_buffer());
 
   CHECK_NE(data, nullptr);
-  ASSERT_EQ(obj->GetIndexedPropertiesExternalArrayDataType(),
-            kHeapStatisticsBufferType);
-  ASSERT_EQ(obj->GetIndexedPropertiesExternalArrayDataLength(),
-            kHeapStatisticsBufferLength);
 
 #define V(i, name, _)                                                         \
   data[i] = static_cast<uint32_t>(s.name());
 
   HEAP_STATISTICS_PROPERTIES(V)
 #undef V
+}
+
+void GetHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Environment* env = Environment::GetCurrent(isolate);
+
+  void* buffer = env->heap_stats_buffer();
+
+  if (buffer == nullptr) {
+    buffer = malloc(kHeapStatisticsBufferLength * sizeof(uint32_t));
+    env->set_heap_stats_buffer(buffer);
+  }
+
+  Local<ArrayBuffer> ab = ArrayBuffer::New(isolate,
+      buffer, kHeapStatisticsBufferLength * sizeof(uint32_t));
+
+  Local<Uint32Array> array =
+      Uint32Array::New(ab, 0, kHeapStatisticsBufferLength);
+
+  args.GetReturnValue().Set(array);
 }
 
 
@@ -77,17 +91,8 @@ void InitializeV8Bindings(Handle<Object> target,
                           Handle<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "getHeapStatistics", GetHeapStatistics);
+  env->SetMethod(target, "getHeapStatisticsBuffer", GetHeapStatisticsBuffer);
   env->SetMethod(target, "setFlagsFromString", SetFlagsFromString);
-
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
-                                    "kHeapStatisticsBufferLength"),
-              Uint32::NewFromUnsigned(env->isolate(),
-                                      kHeapStatisticsBufferLength));
-
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
-                                    "kHeapStatisticsBufferType"),
-              Uint32::NewFromUnsigned(env->isolate(),
-                                      kHeapStatisticsBufferType));
 
 #define V(i, _, name)                                                         \
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \


### PR DESCRIPTION
Reimplement `getHeapStatistics` without `smalloc` as it is going to be removed soon.

R=@trevnorris @bnoordhuis 