### PR TITLE
Revert "core: set PROVIDER type as Persistent class id"

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -17,8 +17,7 @@ inline AsyncWrap::AsyncWrap(Environment* env,
                             v8::Handle<v8::Object> object,
                             ProviderType provider,
                             AsyncWrap* parent)
-    : BaseObject(env, object, provider),
-      bits_(static_cast<uint32_t>(provider) << 1) {
+    : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1) {
   // Check user controlled flag to see if the init callback should run.
   if (!env->using_asyncwrap())
     return;

--- a/src/base-object-inl.h
+++ b/src/base-object-inl.h
@@ -10,15 +10,10 @@
 
 namespace node {
 
-inline BaseObject::BaseObject(Environment* env,
-                              v8::Local<v8::Object> handle,
-                              const uint16_t class_id)
+inline BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> handle)
     : handle_(env->isolate(), handle),
       env_(env) {
   CHECK_EQ(false, handle.IsEmpty());
-  // Shift value 8 bits over to try avoiding conflict with anything else.
-  if (class_id != 0)
-    handle_.SetWrapperClassId(class_id << 8);
 }
 
 

--- a/src/base-object.h
+++ b/src/base-object.h
@@ -9,9 +9,7 @@ class Environment;
 
 class BaseObject {
  public:
-  BaseObject(Environment* env,
-             v8::Local<v8::Object> handle,
-             const uint16_t class_id = 0);
+  BaseObject(Environment* env, v8::Local<v8::Object> handle);
   virtual ~BaseObject();
 
   // Returns the wrapped object.  Returns an empty handle when


### PR DESCRIPTION
This reverts commit 3c44100558b4e9e48e0e711e38acc91e0f870a9f.

Reverted for breaking node-heapdump[0].

AsyncWrap assigns a class id but does not set a v8::RetainedObjectInfo
provider callback with v8::HeapProfiler::SetWrapperClassInfoProvider().
The result is a null pointer dereference when taking a heap snapshot.

It can probably be solved by setting a generic provider callback inside
the AsyncWrap constructor but that may have performance ramifications
that need to be investigated first.  I move to revert it for now.

[0] https://github.com/bnoordhuis/node-heapdump

R=@trevnorris