### PR TITLE
test,win: speedup tls-server-verify

### DIFF
--- a/deps/openssl/openssl/apps/app_rand.c
+++ b/deps/openssl/openssl/apps/app_rand.c
@@ -124,10 +124,16 @@ int app_RAND_load_file(const char *file, BIO *bio_e, int dont_warn)
     char buffer[200];
 
 #ifdef OPENSSL_SYS_WINDOWS
-    BIO_printf(bio_e, "Loading 'screen' into random state -");
-    BIO_flush(bio_e);
-    RAND_screen();
-    BIO_printf(bio_e, " done\n");
+    /*
+     * allocate 2 to dont_warn not to use RAND_screen() via
+     * -no_rand_screen option in s_client
+     */
+    if (dont_warn != 2) {
+      BIO_printf(bio_e, "Loading 'screen' into random state -");
+      BIO_flush(bio_e);
+      RAND_screen();
+      BIO_printf(bio_e, " done\n");
+    }
 #endif
 
     if (file == NULL)

--- a/deps/openssl/openssl/apps/s_client.c
+++ b/deps/openssl/openssl/apps/s_client.c
@@ -236,6 +236,7 @@ static BIO *bio_c_msg = NULL;
 static int c_quiet = 0;
 static int c_ign_eof = 0;
 static int c_brief = 0;
+static int c_no_rand_screen = 0;
 
 #ifndef OPENSSL_NO_PSK
 /* Default PSK identity and key */
@@ -446,6 +447,10 @@ static void sc_usage(void)
                " -keymatexport label   - Export keying material using label\n");
     BIO_printf(bio_err,
                " -keymatexportlen len  - Export len bytes of keying material (default 20)\n");
+#ifdef OPENSSL_SYS_WINDOWS
+    BIO_printf(bio_err,
+               " -no_rand_screen  - Do not use RAND_screen() to initialize random state\n");
+#endif
 }
 
 #ifndef OPENSSL_NO_TLSEXT
@@ -1125,6 +1130,10 @@ int MAIN(int argc, char **argv)
             keymatexportlen = atoi(*(++argv));
             if (keymatexportlen == 0)
                 goto bad;
+#ifdef OPENSSL_SYS_WINDOWS
+        } else if (strcmp(*argv, "-no_rand_screen") == 0) {
+          c_no_rand_screen = 1;
+#endif
         } else {
             BIO_printf(bio_err, "unknown option %s\n", *argv);
             badop = 1;
@@ -1230,7 +1239,7 @@ int MAIN(int argc, char **argv)
     if (!load_excert(&exc, bio_err))
         goto end;
 
-    if (!app_RAND_load_file(NULL, bio_err, 1) && inrand == NULL
+    if (!app_RAND_load_file(NULL, bio_err, ++c_no_rand_screen) && inrand == NULL
         && !RAND_status()) {
         BIO_printf(bio_err,
                    "warning, not much extra random data, consider using the -rand option\n");

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -134,6 +134,9 @@ function runClient(prefix, port, options, cb) {
 
   var args = ['s_client', '-connect', '127.0.0.1:' + port];
 
+  // for the performance issue in s_client on Windows
+  if (process.platform === 'win32')
+    args.push('-no_rand_screen');
 
   console.log(prefix + '  connecting with', options.name);
 

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -307,7 +307,21 @@ function runTest(testIndex) {
     if (tcase.debug) {
       console.error('TLS server running on port ' + common.PORT);
     } else {
-      runNextClient(0);
+      if (tcase.renegotiate) {
+        runNextClient(0);
+      } else {
+        var clientsCompleted = 0;
+        for (var i = 0; i < tcase.clients.length; i++) {
+          runClient(tcase.clients[i], function() {
+            clientsCompleted++;
+            if (clientsCompleted === tcase.clients.length) {
+              server.close();
+              successfulTests++;
+              runTest(testIndex + 1);
+            }
+          });
+        }
+      }
     }
   });
 }


### PR DESCRIPTION
Addresses  https://github.com/nodejs/io.js/issues/1461 (and https://github.com/joyent/node/issues/25279 once ported there).

With the -no-rand-screen changes, the test is now much much faster (less than 1s on my machine). I am not sure however if speeding up a test is a good justification for adding a floating patch in openssl. I added all the commits in here to get more feedback.