### PR TITLE
test: fix test-sync-io-option

### DIFF
--- a/test/parallel/test-sync-io-option.js
+++ b/test/parallel/test-sync-io-option.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const spawn = require('child_process').spawn;
-
+const execFile = require('child_process').execFile;
 
 if (process.argv[2] === 'child') {
   setImmediate(function() {
@@ -14,34 +13,23 @@ if (process.argv[2] === 'child') {
   (function runTest(flags) {
     var execArgv = [flags.pop()];
     var args = [__filename, 'child'];
-    var child = spawn(process.execPath, execArgv.concat(args));
-    var stderr = '';
-
-    child.stdout.on('data', function(chunk) {
-      throw new Error('UNREACHABLE');
-    });
-
-    child.stderr.on('data', function(chunk) {
-      stderr += chunk.toString();
-    });
-
-    child.on('close', function() {
-      var cntr1 = (stderr.match(/WARNING/g) || []).length;
-      var cntr2 = (stderr.match(/fs\.readFileSync/g) || []).length;
-      assert.equal(cntr1, cntr2);
-      if (execArgv[0] === '--trace-sync-io') {
-        // Prints 4 WARNINGS for --trace-sync-io. 1 for each sync call
-        // inside readFileSync
-        assert.equal(cntr1, 4);
-      } else if (execArgv[0] === ' ') {
-        assert.equal(cntr1, 0);
+    var cntr = 0;
+    args = execArgv.concat(args);
+    if (!args[0]) args.shift();
+    execFile(process.execPath, args, function(err, stdout, stderr) {
+      assert.equal(err, null);
+      assert.equal(stdout, '');
+      if (/^WARNING[\s\S]*fs\.readFileSync/.test(stderr))
+        cntr++;
+      if (args[0] === '--trace-sync-io') {
+        assert.equal(cntr, 1);
+      } else if (args[0] === __filename) {
+        assert.equal(cntr, 0);
       } else {
         throw new Error('UNREACHABLE');
       }
-
       if (flags.length > 0)
         setImmediate(runTest, flags);
     });
-  }(['--trace-sync-io', ' ']));
+  }(['--trace-sync-io', '']));
 }
-


### PR DESCRIPTION
This test was failing occasionally both locally and on CI. Switched
from using spawn to execFile for a more reliable test.

Related: https://github.com/nodejs/io.js/issues/1837