### PR TITLE
tools: pass constant to logger instead of string

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1367,7 +1367,7 @@ def Main():
 
   ch = logging.StreamHandler(sys.stdout)
   logger.addHandler(ch)
-  logger.setLevel('INFO')
+  logger.setLevel(logging.INFO)
   if options.logfile:
     fh = logging.FileHandler(options.logfile)
     logger.addHandler(fh)


### PR DESCRIPTION
On a few of our installations (namely CentOS), passing 'INFO' resulted in a silent loglevel. Use a logging constant instead.

/R=@Fishrock123, @rvagg 