### PR TITLE
fs: set encoding on fs.createWriteStream

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -838,7 +838,8 @@ Returns a new WriteStream object (See `Writable Stream`).
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
-default mode `w`.
+default mode `w`. The `encoding` can be `'utf8'`, `'ascii'`, `binary`,
+or `'base64'`.
 
 Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the
 `path` argument and will use the specified file descriptor. This means that no

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1807,6 +1807,9 @@ function WriteStream(path, options) {
     this.pos = this.start;
   }
 
+  if (options.encoding)
+    this.setDefaultEncoding(options.encoding);
+
   if (typeof this.fd !== 'number')
     this.open();
 

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const stream = require('stream');
+const firstEncoding = 'base64';
+const secondEncoding = 'binary';
+
+const examplePath = path.join(common.fixturesDir, 'x.txt');
+const dummyPath = path.join(common.tmpDir, 'x.txt');
+
+const exampleReadStream = fs.createReadStream(examplePath, {
+  encoding: firstEncoding
+});
+
+const dummyWriteStream = fs.createWriteStream(dummyPath, {
+  encoding: firstEncoding
+});
+
+exampleReadStream.pipe(dummyWriteStream).on('finish', function() {
+  const assertWriteStream = new stream.Writable({
+    write: function(chunk, enc, next) {
+      const expected = new Buffer('xyz\n');
+      assert(chunk.equals(expected));
+    }
+  });
+  assertWriteStream.setDefaultEncoding(secondEncoding);
+  fs.createReadStream(dummyPath, {
+    encoding: secondEncoding
+  }).pipe(assertWriteStream);
+});


### PR DESCRIPTION
I just separated https://github.com/nodejs/io.js/pull/1412 .
Much time passed since I proposed the pull request. Sorry.

I would like to introduce the pull request again.

According to the [createWriteStream api docs](https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options), `encoding` option could be found.

```js
{ flags: 'w',
  encoding: null,
  fd: null,
  mode: 0666 }
```

But I set the encoding option to fs.createWriteStream('foo.txt', {encoding: 'utf8'}), the encoding option is ignored. I fixed the problem.

And I added the `encoding` description in this doc. and I fixed test to avoid linter error.
