### PR TITLE
fs: check argument type on createStream method

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -786,7 +786,7 @@ on Unix systems, it never was.
 
 Returns a new ReadStream object (See `Readable Stream`).
 
-`options` is an object with the following defaults:
+`options` is an object or string with the following defaults:
 
     { flags: 'r',
       encoding: null,
@@ -812,6 +812,7 @@ An example to read the last 10 bytes of a file which is 100 bytes long:
 
     fs.createReadStream('sample.txt', {start: 90, end: 99});
 
+If `options` is a string, then it specifies the encoding.
 
 ## Class: fs.ReadStream
 
@@ -828,7 +829,7 @@ Emitted when the ReadStream's file is opened.
 
 Returns a new WriteStream object (See `Writable Stream`).
 
-`options` is an object with the following defaults:
+`options` is an object or string with the following defaults:
 
     { flags: 'w',
       encoding: null,
@@ -844,6 +845,7 @@ Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the
 `path` argument and will use the specified file descriptor. This means that no
 `open` event will be emitted.
 
+If `options` is a string, then it specifies the encoding.
 
 ## Class: fs.WriteStream
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1617,8 +1617,15 @@ function ReadStream(path, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(path, options);
 
+  if (options === undefined)
+    options = {};
+  else if (typeof options === 'string')
+    options = { encoding: options };
+  else if (options === null || typeof options !== 'object')
+    throw new TypeError('options must be a string or an object');
+
   // a little bit bigger buffer and water marks by default
-  options = Object.create(options || {});
+  options = Object.create(options);
   if (options.highWaterMark === undefined)
     options.highWaterMark = 64 * 1024;
 
@@ -1783,7 +1790,14 @@ function WriteStream(path, options) {
   if (!(this instanceof WriteStream))
     return new WriteStream(path, options);
 
-  options = options || {};
+  if (options === undefined)
+    options = {};
+  else if (typeof options === 'string')
+    options = { encoding: options };
+  else if (options === null || typeof options !== 'object')
+    throw new TypeError('options must be a string or an object');
+
+  options = Object.create(options);
 
   Writable.call(this, options);
 

--- a/test/parallel/test-fs-read-stream-encoding.js
+++ b/test/parallel/test-fs-read-stream-encoding.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const stream = require('stream');
+const encoding = 'base64';
+
+const example = path.join(common.fixturesDir, 'x.txt');
+const assertStream = new stream.Writable({
+  write: function(chunk, enc, next) {
+    const expected = new Buffer('xyz');
+    assert(chunk.equals(expected));
+  }
+});
+assertStream.setDefaultEncoding(encoding);
+fs.createReadStream(example, encoding).pipe(assertStream);

--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const example = path.join(common.fixturesDir, 'x.txt');
+
+assert.doesNotThrow(function() { 
+  fs.createReadStream(example, undefined);
+});
+assert.doesNotThrow(function() { 
+  fs.createReadStream(example, 'utf8');
+});
+assert.doesNotThrow(function() { 
+  fs.createReadStream(example, {encoding: 'utf8'});
+});
+
+assert.throws(function() { 
+  fs.createReadStream(example, null); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createReadStream(example, 123); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createReadStream(example, 0); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createReadStream(example, true); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createReadStream(example, false); 
+}, /options must be a string or an object/);

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const example = path.join(common.tmpDir, 'dummy');
+
+assert.doesNotThrow(function() { 
+  fs.createWriteStream(example, undefined);
+});
+assert.doesNotThrow(function() { 
+  fs.createWriteStream(example, 'utf8');
+});
+assert.doesNotThrow(function() { 
+  fs.createWriteStream(example, {encoding: 'utf8'});
+});
+
+assert.throws(function() { 
+  fs.createWriteStream(example, null); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createWriteStream(example, 123); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createWriteStream(example, 0); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createWriteStream(example, true); 
+}, /options must be a string or an object/);
+assert.throws(function() { 
+  fs.createWriteStream(example, false); 
+}, /options must be a string or an object/);


### PR DESCRIPTION
separeted https://github.com/nodejs/io.js/pull/1412

On Node.js v0.12
```javascript
// illegal option but does not throw an Error, just ignore.
fs.createReadStream('foo.txt', 'utf8');

// illegal option but does not throw an Error, just ignore.
fs.createWriteStream('hoge', 'utf8');
```

On io.js v1.6.4
```javascript
// illegal option and throw an Error
fs.createReadStream('foo.txt', 'utf8');

fs.js:1619
  options = Object.create(options || {});
                   ^
TypeError: Object prototype may only be an Object or null: utf8
    at Function.create (native)
    at new ReadStream (fs.js:1619:20)
    at Object.fs.createReadStream (fs.js:1608:10)
    at Object.<anonymous> (/Users/yosuke/go/src/github.com/yosuke-furukawa/fork/io.js/test/parallel/test-fs-write-stream-encoding.js:12:30)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:428:10)
    at Module.load (module.js:335:32)
    at Function.Module._load (module.js:290:12)
    at Function.Module.runMain (module.js:451:10)
    at startup (node.js:124:18)

// illegal option but does not throw an Error, just ignore.
fs.createWriteStream('hoge', 'utf8');
```

I added document and fixed test to avoid linter errors.