### PR TITLE
Revert "http: simplify code and remove unused properties"

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -126,6 +126,12 @@ function parserOnMessageComplete() {
       parser._url = '';
     }
 
+    if (!stream.upgrade)
+      // For upgraded connections, also emit this after parser.execute
+      stream.push(null);
+  }
+
+  if (stream && !parser.incoming._pendings.length) {
     // For emit end event
     stream.push(null);
   }

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -38,6 +38,8 @@ function IncomingMessage(socket) {
 
   this.readable = true;
 
+  this._pendings = [];
+  this._pendingIndex = 0;
   this.upgrade = null;
 
   // request (server) only
@@ -47,7 +49,7 @@ function IncomingMessage(socket) {
   // response (client) only
   this.statusCode = null;
   this.statusMessage = null;
-  this._client = socket; // deprecated
+  this.client = this.socket;
 
   // flag for backwards compatibility grossness.
   this._consuming = false;
@@ -61,16 +63,6 @@ util.inherits(IncomingMessage, Stream.Readable);
 
 exports.IncomingMessage = IncomingMessage;
 
-Object.defineProperty(IncomingMessage.prototype, 'client', {
-  configurable: true,
-  enumerable: true,
-  get: util.deprecate(function() {
-    return this._client;
-  }, 'client is deprecated, use socket or connection instead'),
-  set: util.deprecate(function(val) {
-    this._client = val;
-  }, 'client is deprecated, use socket or connection instead')
-});
 
 IncomingMessage.prototype.setTimeout = function(msecs, callback) {
   if (callback)

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -62,6 +62,7 @@ function OutgoingMessage() {
   this._trailer = '';
 
   this.finished = false;
+  this._hangupClose = false;
   this._headerSent = false;
 
   this.socket = null;


### PR DESCRIPTION
This reverts commit 1eec5f091ab00860539ac2474e47232b31925cea.

See https://github.com/nodejs/io.js/issues/1850 for context, it breaks a feature in request, we probably should have been more careful with something like this.

/cc @targos @mscdex 

I'm heading off to bed soon but if someone else wants to pull this in and push out a quick v2.2.1 then I'd +1 that in my sleep; otherwise I'll do it in the morning.