### PR TITLE
http: revert deprecation of client property

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -47,7 +47,7 @@ function IncomingMessage(socket) {
   // response (client) only
   this.statusCode = null;
   this.statusMessage = null;
-  this._client = socket; // deprecated
+  this.client = socket;
 
   // flag for backwards compatibility grossness.
   this._consuming = false;
@@ -61,16 +61,6 @@ util.inherits(IncomingMessage, Stream.Readable);
 
 exports.IncomingMessage = IncomingMessage;
 
-Object.defineProperty(IncomingMessage.prototype, 'client', {
-  configurable: true,
-  enumerable: true,
-  get: util.deprecate(function() {
-    return this._client;
-  }, 'client is deprecated, use socket or connection instead'),
-  set: util.deprecate(function(val) {
-    this._client = val;
-  }, 'client is deprecated, use socket or connection instead')
-});
 
 IncomingMessage.prototype.setTimeout = function(msecs, callback) {
   if (callback)


### PR DESCRIPTION
Reason: breaks a feature in the request module

See #1850
Replaces #1851

/cc @mscdex 