### PR TITLE
tools: Copying contents of deps/npm to test-npm

### DIFF
--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -16,7 +16,7 @@ rm -rf test-npm
 mkdir test-npm
 
 # make a copy of deps/npm to run the tests on
-cp -r deps/npm/ test-npm/
+cp -r deps/npm/. test-npm/
 
 cd test-npm
 

--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -13,10 +13,9 @@ if [ -z $NODE_EXE ]; then
 fi
 
 rm -rf test-npm
-mkdir test-npm
 
 # make a copy of deps/npm to run the tests on
-cp -r deps/npm/. test-npm/
+cp -r deps/npm test-npm
 
 cd test-npm
 


### PR DESCRIPTION
In Ubuntu, `cp -r deps/npm/ test-npm/` was copying `npm` directory 
under `test-npm` and the structure became `test-npm/npm`. But the test
 requires the contents of `deps/npm` to be under `test-npm`. Using 
`deps/npm/.` fixes it.