### PR TITLE
test: remove unneeded comment task

### DIFF
--- a/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
+++ b/test/parallel/test-http-url.parse-only-support-http-https-protocol.js
@@ -64,5 +64,3 @@ assert.throws(function() {
     return true;
   }
 });
-
-//TODO do I need to test url.parse(notPrococol.example.com)?


### PR DESCRIPTION
The test queried about in the TODO comment would result in a HTTP request to localhost and falls outside of the scope of the test file in which it appears, which tests that protocols other than HTTP and HTTPS throw errors.

ref: #264 