### PR TITLE
debugger: improve ESRCH error message

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1639,7 +1639,16 @@ Interface.prototype.trySpawn = function(cb) {
   } else if (this.args.length === 3) {
     // `node debug -p pid`
     if (this.args[1] === '-p' && /^\d+$/.test(this.args[2])) {
-      process._debugProcess(parseInt(this.args[2], 10));
+      const pid = parseInt(this.args[2], 10);
+      try {
+        process._debugProcess(pid);
+      } catch (e) {
+        if (e.code === 'ESRCH') {
+          console.error(`Target process: ${pid} doesn't exist.`);
+          process.exit(1);
+        }
+        throw e;
+      }
       isRemote = true;
     } else {
       var match = this.args[1].match(/^--port=(\d+)$/);
@@ -1704,8 +1713,8 @@ Interface.prototype.trySpawn = function(cb) {
   function connectError() {
     // If it's failed to connect 10 times then print failed message
     if (connectionAttempts >= 10) {
-      self.stdout.write(' failed, please retry\n');
-      return;
+      console.error(' failed, please retry');
+      process.exit(1);
     }
     setTimeout(attemptConnect, 500);
   }

--- a/test/debugger/test-debugger-pid.js
+++ b/test/debugger/test-debugger-pid.js
@@ -1,0 +1,39 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+var port = common.PORT + 1337;
+var buffer = '';
+var expected = [];
+var scriptToDebug = common.fixturesDir + '/empty.js';
+
+function fail() {
+  assert(0); // `--debug-brk script.js` should not quit
+}
+
+// connect to debug agent
+var interfacer = spawn(process.execPath, ['debug', '-p', '655555']);
+
+console.error(process.execPath, 'debug', '-p', '655555');
+interfacer.stdout.setEncoding('utf-8');
+interfacer.stderr.setEncoding('utf-8');
+var onData = function (data) {
+  data = (buffer + data).split('\n');
+  buffer = data.pop();
+  data.forEach(function(line) {
+    interfacer.emit('line', line);
+  });
+};
+interfacer.stdout.on('data', onData);
+interfacer.stderr.on('data', onData);
+
+interfacer.on('line', function(line) {
+  line = line.replace(/^(debug> *)+/, '');
+  var expected = 'Target process: 655555 doesn\'t exist.';
+  assert.ok(expected == line, 'Got unexpected line: ' + line);
+});
+
+interfacer.on('exit', function (code, signal) {
+  assert.ok(code == 1, 'Got unexpected code: ' + code);
+});


### PR DESCRIPTION
When use `iojs debug -p <pid>` with an invalid pid,
the debugger print internal error message also,
it not enough smart.