### PR TITLE
doc: Fix http.IncomingMessage.socket documentation

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -1068,8 +1068,7 @@ The HTTP response status message (reason phrase). E.G. `OK` or `Internal Server 
 
 The `net.Socket` object associated with the connection.
 
-With HTTPS support, use request.connection.verifyPeer() and
-request.connection.getPeerCertificate() to obtain the client's
+With HTTPS support, use [request.socket.getPeerCertificate()][] to obtain the client's
 authentication details.
 
 
@@ -1098,5 +1097,6 @@ authentication details.
 [socket.setKeepAlive()]: net.html#net_socket_setkeepalive_enable_initialdelay
 [socket.setNoDelay()]: net.html#net_socket_setnodelay_nodelay
 [socket.setTimeout()]: net.html#net_socket_settimeout_timeout_callback
+[request.socket.getPeerCertificate()]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [stream.setEncoding()]: stream.html#stream_stream_setencoding_encoding
 [url.parse()]: url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost


### PR DESCRIPTION
Remove the reference to `net.Socket.verifyPeer()`.
That was removed in ea540c9 (2010) and was missed in the 032f80e (a follow-up documentation update).

Refer to the `net.Socket` instance by the `.socket` property. This avoids unneeded confusion.
`.socket` is the variant that is used internally (and that was mentioned two lines above in the docs).

Add a markdown link to `net.Socket.getPeerCertificate()`.