### PR TITLE
test: fix test-child-process-stdout-flush-exit

### DIFF
--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -18,8 +18,7 @@ if (process.argv[2] === 'child') {
   // spawn self as child
   var child = spawn(process.argv[0], [process.argv[1], 'child']);
 
-  var gotHello = false;
-  var gotBye = false;
+  var stdout = '';
 
   child.stderr.setEncoding('utf8');
   child.stderr.on('data', function(data) {
@@ -30,17 +29,11 @@ if (process.argv[2] === 'child') {
   // check if we receive both 'hello' at start and 'goodbye' at end
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(data) {
-    if (data.slice(0, 6) == 'hello\n') {
-      gotHello = true;
-    } else if (data.slice(data.length - 8) == 'goodbye\n') {
-      gotBye = true;
-    } else {
-      gotBye = false;
-    }
+    stdout += data;
   });
 
-  child.on('close', function(data) {
-    assert(gotHello);
-    assert(gotBye);
-  });
+  child.on('close', common.mustCall(function() {
+    assert.equal(stdout.slice(0, 6), 'hello\n');
+    assert.equal(stdout.slice(stdout.length - 8), 'goodbye\n');
+  }));
 }


### PR DESCRIPTION
Make sure all the stdout data is available before
performing the assertions.

Before this change, I was getting this error from time to time:

```
assert.js:88
  throw new assert.AssertionError({
        ^
AssertionError: false == true
    at ChildProcess.<anonymous> (/usr/home/sgimeno/node/io.js/test/parallel/test-child-process-stdout-flush-exit.js:47:5)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:763:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:210:5)
```