### PR TITLE
on XP and WIN10, execfile fail when path contain "("

### DIFF
--- a/deps/uv/src/win/process.c
+++ b/deps/uv/src/win/process.c
@@ -445,7 +445,7 @@ static WCHAR* search_path(const WCHAR *file,
  * Quotes command line arguments
  * Returns a pointer to the end (next char to be written) of the buffer
  */
-WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target, BOOL isFilePath) {
+WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target) {
   size_t len = wcslen(source);
   size_t i;
   int quote_hit;
@@ -458,14 +458,14 @@ WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target, BOOL isFilePath) {
     return target;
   }
 
-  if (NULL == wcspbrk(source, L" \t\"(")) {
+  if (NULL == wcspbrk(source, L" \t\"")) {
     /* No quotation needed */
     wcsncpy(target, source, len);
     target += len;
     return target;
   }
 
-  if (NULL == wcspbrk(source, L"\"\\(")) {
+  if (NULL == wcspbrk(source, L"\"\\")) {
     /*
      * No embedded double quotes or backlashes, so I can just wrap
      * quote marks around the whole thing.
@@ -507,9 +507,6 @@ WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target, BOOL isFilePath) {
     } else if(source[i - 1] == L'"') {
       quote_hit = 1;
       *(target++) = L'\\';
-    } else if(isFilePath && source[i - 1] == L'(') {
-      quote_hit = 0;
-      *(target++) = L'^';
     } else {
       quote_hit = 0;
     }
@@ -593,7 +590,7 @@ int make_program_args(char** args, int verbatim_arguments, WCHAR** dst_ptr) {
       pos += arg_len - 1;
     } else {
       /* Quote/escape, if needed. */
-      pos = quote_cmd_arg(temp_buffer, pos, arg==args);
+      pos = quote_cmd_arg(temp_buffer, pos);
     }
 
     *pos++ = *(arg + 1) ? L' ' : L'\0';

--- a/deps/uv/test/test-spawn.c
+++ b/deps/uv/test/test-spawn.c
@@ -995,7 +995,7 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
 
 
 int make_program_args(char** args, int verbatim_arguments, WCHAR** dst_ptr);
-WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target, BOOL isFilePath);
+WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target);
 
 TEST_IMPL(argument_escaping) {
   const WCHAR* test_str[] = {
@@ -1032,7 +1032,7 @@ TEST_IMPL(argument_escaping) {
   ASSERT(test_output != NULL);
   for (i = 0; i < count; ++i) {
     test_output[i] = calloc(2 * (wcslen(test_str[i]) + 2), sizeof(WCHAR));
-    quote_cmd_arg(test_str[i], test_output[i], FALSE);
+    quote_cmd_arg(test_str[i], test_output[i]);
     wprintf(L"input : %s\n", test_str[i]);
     wprintf(L"output: %s\n", test_output[i]);
     total_size += wcslen(test_output[i]) + 1;

--- a/deps/uv/test/test-spawn.c
+++ b/deps/uv/test/test-spawn.c
@@ -995,7 +995,7 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
 
 
 int make_program_args(char** args, int verbatim_arguments, WCHAR** dst_ptr);
-WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target);
+WCHAR* quote_cmd_arg(const WCHAR *source, WCHAR *target, BOOL isFilePath);
 
 TEST_IMPL(argument_escaping) {
   const WCHAR* test_str[] = {
@@ -1032,7 +1032,7 @@ TEST_IMPL(argument_escaping) {
   ASSERT(test_output != NULL);
   for (i = 0; i < count; ++i) {
     test_output[i] = calloc(2 * (wcslen(test_str[i]) + 2), sizeof(WCHAR));
-    quote_cmd_arg(test_str[i], test_output[i]);
+    quote_cmd_arg(test_str[i], test_output[i], FALSE);
     wprintf(L"input : %s\n", test_str[i]);
     wprintf(L"output: %s\n", test_output[i]);
     total_size += wcslen(test_output[i]) + 1;


### PR DESCRIPTION
if a filepath contain "(" then execfile will fail. i test it on XP/WIN7/WIN10. only WIN7 could work.

```
var batch = require('child_process');
var fileName = 'C:/nodecode/a(b/abc.bat'; 

var execOption = { 
    encoding: 'utf8',
    timeout: 10000, 
    maxBuffer: 200*1024,
    killSignal: 'SIGTERM',
    cwd: null,
    env: null };

batch.execFile(fileName,null,execOption,function (err,stdout,stderr) {
    console.log('err:',err,'stdout',stdout,'stderr',stderr);
});
```

it will raise error like:
'c:\nodecode\a' 不是内部或外部命令，也不是可运行的程序
或批处理文件。

my resolve way is 
if it is a file path ,then each "(" should change to "^(".

