### PR TITLE
test: remove hardwired references to 'iojs'

### DIFF
--- a/test/debugger/test-debugger-remote.js
+++ b/test/debugger/test-debugger-remote.js
@@ -9,7 +9,7 @@ var expected = [];
 var scriptToDebug = common.fixturesDir + '/empty.js';
 
 function fail() {
-  assert(0); // `iojs --debug-brk script.js` should not quit
+  assert(0); // `--debug-brk script.js` should not quit
 }
 
 // running with debug agent
@@ -37,7 +37,7 @@ interfacer.on('line', function(line) {
   assert.ok(expected == line, 'Got unexpected line: ' + line);
 });
 
-// give iojs time to start up the debugger
+// allow time to start up the debugger
 setTimeout(function() {
   child.removeListener('exit', fail);
   child.kill();

--- a/test/parallel/test-process-argv-0.js
+++ b/test/parallel/test-process-argv-0.js
@@ -9,7 +9,7 @@ console.error('argv=%j', process.argv);
 console.error('exec=%j', process.execPath);
 
 if (process.argv[2] !== 'child') {
-  var child = spawn('./iojs', [__filename, 'child'], {
+  var child = spawn(process.execPath, [__filename, 'child'], {
     cwd: path.dirname(process.execPath)
   });
 

--- a/test/sequential/test-setproctitle.js
+++ b/test/sequential/test-setproctitle.js
@@ -10,6 +10,7 @@ if ('linux freebsd darwin'.indexOf(process.platform) === -1) {
 var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
+var path = require('path');
 
 // The title shouldn't be too long; libuv's uv_set_process_title() out of
 // security considerations no longer overwrites envp, only argv, so the
@@ -25,7 +26,8 @@ exec('ps -p ' + process.pid + ' -o args=', function(error, stdout, stderr) {
   assert.equal(stderr, '');
 
   // freebsd always add ' (procname)' to the process title
-  if (process.platform === 'freebsd') title += ' (iojs)';
+  if (process.platform === 'freebsd')
+    title += ` (${path.basename(process.execPath)})`;
 
   // omitting trailing whitespace and \n
   assert.equal(stdout.replace(/\s+$/, ''), title);


### PR DESCRIPTION
there shouldn't be any references to 'iojs' in the tests (or 'node' either, but they were mostly taken care of already)