### PR TITLE
async-wrap: add provider id and object info cb

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -18,6 +18,11 @@ inline AsyncWrap::AsyncWrap(Environment* env,
                             ProviderType provider,
                             AsyncWrap* parent)
     : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1) {
+  // Only set wrapper class id if object will be Wrap'd.
+  if (object->InternalFieldCount() > 0)
+    // Shift provider value over to prevent id collision.
+    persistent().SetWrapperClassId(NODE_ASYNC_ID_OFFSET + provider);
+
   // Check user controlled flag to see if the init callback should run.
   if (!env->using_asyncwrap())
     return;

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -8,6 +8,8 @@
 
 namespace node {
 
+#define NODE_ASYNC_ID_OFFSET 0xA1C
+
 #define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
   V(NONE)                                                                     \
   V(CARES)                                                                    \
@@ -64,6 +66,8 @@ class AsyncWrap : public BaseObject {
                                             int argc,
                                             v8::Handle<v8::Value>* argv);
 
+  virtual size_t self_size() const = 0;
+
  private:
   inline AsyncWrap();
   inline bool has_async_queue() const;
@@ -73,6 +77,8 @@ class AsyncWrap : public BaseObject {
   // that will be used to call pre/post in MakeCallback.
   uint32_t bits_;
 };
+
+void LoadAsyncWrapperInfo(Environment* env);
 
 }  // namespace node
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -51,6 +51,8 @@ using v8::Value;
 class GetAddrInfoReqWrap : public ReqWrap<uv_getaddrinfo_t> {
  public:
   GetAddrInfoReqWrap(Environment* env, Local<Object> req_wrap_obj);
+
+  size_t self_size() const override { return sizeof(*this); }
 };
 
 GetAddrInfoReqWrap::GetAddrInfoReqWrap(Environment* env,
@@ -66,8 +68,10 @@ static void NewGetAddrInfoReqWrap(const FunctionCallbackInfo<Value>& args) {
 
 
 class GetNameInfoReqWrap : public ReqWrap<uv_getnameinfo_t> {
-  public:
-    GetNameInfoReqWrap(Environment* env, Local<Object> req_wrap_obj);
+ public:
+  GetNameInfoReqWrap(Environment* env, Local<Object> req_wrap_obj);
+
+  size_t self_size() const override { return sizeof(*this); }
 };
 
 GetNameInfoReqWrap::GetNameInfoReqWrap(Environment* env,
@@ -385,6 +389,8 @@ class QueryAWrap: public QueryWrap {
     return 0;
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -422,6 +428,8 @@ class QueryAaaaWrap: public QueryWrap {
     return 0;
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -458,6 +466,8 @@ class QueryCnameWrap: public QueryWrap {
                GetQueryArg());
     return 0;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -497,6 +507,8 @@ class QueryMxWrap: public QueryWrap {
                GetQueryArg());
     return 0;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -547,6 +559,8 @@ class QueryNsWrap: public QueryWrap {
     return 0;
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -582,6 +596,8 @@ class QueryTxtWrap: public QueryWrap {
                GetQueryArg());
     return 0;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -638,6 +654,8 @@ class QuerySrvWrap: public QueryWrap {
     return 0;
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
@@ -691,6 +709,8 @@ class QueryNaptrWrap: public QueryWrap {
                GetQueryArg());
     return 0;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -753,6 +773,8 @@ class QuerySoaWrap: public QueryWrap {
                GetQueryArg());
     return 0;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   void Parse(unsigned char* buf, int len) override {
@@ -819,6 +841,8 @@ class GetHostByAddrWrap: public QueryWrap {
                        GetQueryArg());
     return 0;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   void Parse(struct hostent* host) override {

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -31,6 +31,8 @@ class FSEventWrap: public HandleWrap {
   static void Start(const FunctionCallbackInfo<Value>& args);
   static void Close(const FunctionCallbackInfo<Value>& args);
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   FSEventWrap(Environment* env, Handle<Object> object);
   virtual ~FSEventWrap() override;

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -28,6 +28,8 @@ class JSStream : public StreamBase, public AsyncWrap {
               size_t count,
               uv_stream_t* send_handle) override;
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   JSStream(Environment* env, v8::Handle<v8::Object> obj, AsyncWrap* parent);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3872,6 +3872,7 @@ Environment* CreateEnvironment(Isolate* isolate,
   env->set_process_object(process_object);
 
   SetupProcessObject(env, argc, argv, exec_argc, exec_argv);
+  LoadAsyncWrapperInfo(env);
 
   return env;
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4546,6 +4546,8 @@ class PBKDF2Request : public AsyncWrap {
     error_ = err;
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
   uv_work_t work_req_;
 
  private:
@@ -4775,6 +4777,8 @@ class RandomBytesRequest : public AsyncWrap {
   inline void set_error(unsigned long err) {
     error_ = err;
   }
+
+  size_t self_size() const override { return sizeof(*this); }
 
   uv_work_t work_req_;
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -308,6 +308,8 @@ class Connection : public SSLWrap<Connection>, public AsyncWrap {
   v8::Persistent<v8::String> servername_;
 #endif
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EncIn(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -701,6 +703,8 @@ class Certificate : public AsyncWrap {
   bool VerifySpkac(const char* data, unsigned int len);
   const char* ExportPublicKey(const char* data, int len);
   const char* ExportChallenge(const char* data, int len);
+
+  size_t self_size() const override { return sizeof(*this); }
 
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -73,6 +73,8 @@ class FSReqWrap: public ReqWrap<uv_fs_t> {
   const char* syscall() const { return syscall_; }
   const char* data() const { return data_; }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   FSReqWrap(Environment* env,
             Local<Object> req,

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -22,6 +22,8 @@ class StatWatcher : public AsyncWrap {
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   static void Callback(uv_fs_poll_t* handle,
                        int status,

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -535,6 +535,8 @@ class ZCtx : public AsyncWrap {
     }
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   void Ref() {
     if (++refs_ == 1) {

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -37,6 +37,8 @@ using v8::Value;
 class PipeConnectWrap : public ReqWrap<uv_connect_t> {
  public:
   PipeConnectWrap(Environment* env, Local<Object> req_wrap_obj);
+
+  size_t self_size() const override { return sizeof(*this); }
 };
 
 

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -16,6 +16,8 @@ class PipeWrap : public StreamWrap {
                          v8::Handle<v8::Value> unused,
                          v8::Handle<v8::Context> context);
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   PipeWrap(Environment* env,
            v8::Handle<v8::Object> object,

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -46,6 +46,8 @@ class ProcessWrap : public HandleWrap {
                 constructor->GetFunction());
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {
     // This constructor should not be exposed to public javascript.

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -40,6 +40,8 @@ class SignalWrap : public HandleWrap {
                 constructor->GetFunction());
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {
     // This constructor should not be exposed to public javascript.

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -92,7 +92,7 @@ WriteWrap* WriteWrap::New(Environment* env,
   size_t storage_size = ROUND_UP(sizeof(WriteWrap), kAlignSize) + extra;
   char* storage = new char[storage_size];
 
-  return new(storage) WriteWrap(env, obj, wrap, cb);
+  return new(storage) WriteWrap(env, obj, wrap, cb, storage_size);
 }
 
 

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -48,6 +48,7 @@ class ShutdownWrap : public ReqWrap<uv_shutdown_t>,
   }
 
   inline StreamBase* wrap() const { return wrap_; }
+  size_t self_size() const override { return sizeof(*this); }
 
  private:
   StreamBase* const wrap_;
@@ -66,6 +67,8 @@ class WriteWrap: public ReqWrap<uv_write_t>,
 
   inline StreamBase* wrap() const { return wrap_; }
 
+  size_t self_size() const override { return storage_size_; }
+
   static void NewWriteWrap(const v8::FunctionCallbackInfo<v8::Value>& args) {
     CHECK(args.IsConstructCall());
   }
@@ -76,10 +79,12 @@ class WriteWrap: public ReqWrap<uv_write_t>,
   WriteWrap(Environment* env,
             v8::Local<v8::Object> obj,
             StreamBase* wrap,
-            DoneCb cb)
+            DoneCb cb,
+            size_t storage_size)
       : ReqWrap(env, obj, AsyncWrap::PROVIDER_WRITEWRAP),
         StreamReq<WriteWrap>(cb),
-        wrap_(wrap) {
+        wrap_(wrap),
+        storage_size_(storage_size) {
     Wrap(obj, this);
   }
 
@@ -96,6 +101,7 @@ class WriteWrap: public ReqWrap<uv_write_t>,
   void operator delete(void* ptr) { UNREACHABLE(); }
 
   StreamBase* const wrap_;
+  const size_t storage_size_;
 };
 
 class StreamResource {

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -37,6 +37,7 @@ using v8::Value;
 class TCPConnectWrap : public ReqWrap<uv_connect_t> {
  public:
   TCPConnectWrap(Environment* env, Local<Object> req_wrap_obj);
+  size_t self_size() const override { return sizeof(*this); }
 };
 
 

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -16,6 +16,8 @@ class TCPWrap : public StreamWrap {
 
   uv_tcp_t* UVHandle();
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   TCPWrap(Environment* env, v8::Handle<v8::Object> object, AsyncWrap* parent);
   ~TCPWrap();

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -51,6 +51,8 @@ class TimerWrap : public HandleWrap {
                 constructor->GetFunction());
   }
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   static void New(const FunctionCallbackInfo<Value>& args) {
     // This constructor should not be exposed to public javascript.

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -50,6 +50,8 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
 
   void NewSessionDoneCb();
 
+  size_t self_size() const override { return sizeof(*this); }
+
  protected:
   static const int kClearOutChunkSize = 1024;
 

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -15,6 +15,8 @@ class TTYWrap : public StreamWrap {
 
   uv_tty_t* UVHandle();
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   TTYWrap(Environment* env,
           v8::Handle<v8::Object> object,

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -36,6 +36,7 @@ class SendWrap : public ReqWrap<uv_udp_send_t> {
  public:
   SendWrap(Environment* env, Local<Object> req_wrap_obj, bool have_callback);
   inline bool have_callback() const;
+  size_t self_size() const override { return sizeof(*this); }
  private:
   const bool have_callback_;
 };

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -37,6 +37,8 @@ class UDPWrap: public HandleWrap {
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
   uv_udp_t* UVHandle();
 
+  size_t self_size() const override { return sizeof(*this); }
+
  private:
   UDPWrap(Environment* env, v8::Handle<v8::Object> object, AsyncWrap* parent);
 


### PR DESCRIPTION
Re-add the wrapper class id to AsyncWrap instances so they can be
tracked directly in a heapdump.

Previously the class id was given without setting the heap dump wrapper
class info provider. Causing a segfault when a heapdump was taken. This
has been added, and the label_ set to the given provider name so each
instance can be identified.

R=@bnoordhuis 

For performance testing I ran the following:
```js
var JSStream = process.binding('js_stream').JSStream;
var ITER = 1e7;
var t = process.hrtime();

for (var i = 0; i < ITER; i++)
  new JSStream();

t = process.hrtime(t);
console.log(((t[0] * 1e9 + t[1]) / ITER).toFixed(1) + ' ns/op');
```
It was the most direct way I found to instantiate a new `AsyncWrap` instance from JS. It shows no performance degradation with this patch applied.