### PR TITLE
fs: use `kMaxLength` from binding

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -19,7 +19,7 @@ const Readable = Stream.Readable;
 const Writable = Stream.Writable;
 
 const kMinPoolSpace = 128;
-const kMaxLength = require('internal/smalloc').kMaxLength;
+const kMaxLength = process.binding('smalloc').kMaxLength;
 
 const O_APPEND = constants.O_APPEND || 0;
 const O_CREAT = constants.O_CREAT || 0;


### PR DESCRIPTION
This allows userland modules to evaluate `fs` source
without access to internals.

Fixes: https://github.com/nodejs/io.js/issues/1898

R=@evanlucas 