### PR TITLE
Prevent .gitignore from ignoring debug module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ icu_config.gypi
 
 # various stuff that VC++ produces/uses
 Debug/
+!node_modules/debug/
 Release/
 !doc/blog/**
 *.sln


### PR DESCRIPTION
On case insensitive platforms, the rule was catching the node module
under npm and eslint.

This should fix the issue, and make nodejs/io.js#1899 mergeable.

cc: @othiym23 @Fishrock123 