### PR TITLE
doc: add note about available ECC curves

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -528,8 +528,10 @@ Example (obtaining a shared secret):
 
 ## crypto.createECDH(curve_name)
 
-Creates a Elliptic Curve (EC) Diffie-Hellman key exchange object using a
-predefined curve specified by `curve_name` string.
+Creates an Elliptic Curve (EC) Diffie-Hellman key exchange object using a
+predefined curve specified by the `curve_name` string. On recent releases,
+`openssl ecparam -list_curves` will display the name and description of each 
+available elliptic curve.
 
 ## Class: ECDH
 

--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -530,7 +530,7 @@ Example (obtaining a shared secret):
 
 Creates an Elliptic Curve (EC) Diffie-Hellman key exchange object using a
 predefined curve specified by the `curve_name` string. On recent releases,
-`openssl ecparam -list_curves` will display the name and description of each 
+`openssl ecparam -list_curves` will display the name and description of each
 available elliptic curve.
 
 ## Class: ECDH

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -179,10 +179,9 @@ automatically set as a listener for the [secureConnection][] event.  The
   - `ecdhCurve`: A string describing a named curve to use for ECDH key agreement
     or false to disable ECDH.
 
-    Defaults to `prime256v1`. Consult [RFC 4492] for more details.
-
-    On recent releases, `openssl ecparam -list_curves` will display the name and
-    description of each available elliptic curve.
+    Defaults to `prime256v1` (NIST P-256). On recent releases, `openssl ecparam
+    -list_curves` will display the name and description of each available elliptic
+    curve.
 
   - `dhparam`: A string or `Buffer` containing Diffie Hellman parameters,
     required for Perfect Forward Secrecy. Use `openssl dhparam` to create it.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -181,6 +181,9 @@ automatically set as a listener for the [secureConnection][] event.  The
 
     Defaults to `prime256v1`. Consult [RFC 4492] for more details.
 
+    On recent releases, `openssl ecparam -list_curves` will display the name and
+    description of each available elliptic curve.
+
   - `dhparam`: A string or `Buffer` containing Diffie Hellman parameters,
     required for Perfect Forward Secrecy. Use `openssl dhparam` to create it.
     Its key length should be greater than or equal to 1024 bits, otherwise


### PR DESCRIPTION
Added instructions on how to get the elliptic curves supported by the OpenSSL installation in the `crypto.createECDH()` constructor. Also made a few minor grammar fixes within the same paragraph.