### PR TITLE
doc: add references to crypto.getCurves()

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -539,9 +539,10 @@ Example (obtaining a shared secret):
 ## crypto.createECDH(curve_name)
 
 Creates an Elliptic Curve (EC) Diffie-Hellman key exchange object using a
-predefined curve specified by the `curve_name` string. On recent releases,
-`openssl ecparam -list_curves` will display the name and description of each
-available elliptic curve.
+predefined curve specified by the `curve_name` string. Use [getCurves()][] to
+obtain a list of available curve names. On recent releases,
+`openssl ecparam -list_curves` will also display the name and description of
+each available elliptic curve.
 
 ## Class: ECDH
 
@@ -775,6 +776,7 @@ temporary measure.
 
 [createCipher()]: #crypto_crypto_createcipher_algorithm_password
 [createCipheriv()]: #crypto_crypto_createcipheriv_algorithm_key_iv
+[getCurves()]: #crypto_crypto_getcurves
 [crypto.createDiffieHellman()]: #crypto_crypto_creatediffiehellman_prime_prime_encoding_generator_generator_encoding
 [tls.createSecureContext]: tls.html#tls_tls_createsecurecontext_details
 [diffieHellman.setPublicKey()]: #crypto_diffiehellman_setpublickey_public_key_encoding

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -179,9 +179,10 @@ automatically set as a listener for the [secureConnection][] event.  The
   - `ecdhCurve`: A string describing a named curve to use for ECDH key agreement
     or false to disable ECDH.
 
-    Defaults to `prime256v1` (NIST P-256). On recent releases, `openssl ecparam
-    -list_curves` will display the name and description of each available elliptic
-    curve.
+    Defaults to `prime256v1` (NIST P-256). Use [crypto.getCurves()][] to obtain
+    a list of available curve names. On recent releases,
+    `openssl ecparam -list_curves` will also display the name and description of
+    each available elliptic curve.
 
   - `dhparam`: A string or `Buffer` containing Diffie Hellman parameters,
     required for Perfect Forward Secrecy. Use `openssl dhparam` to create it.
@@ -814,6 +815,7 @@ The numeric representation of the local port.
 [Chrome's 'modern cryptography' setting]: http://www.chromium.org/Home/chromium-security/education/tls#TOC-Deprecation-of-TLS-Features-Algorithms-in-Chrome
 [specific attacks affecting larger AES key sizes]: https://www.schneier.com/blog/archives/2009/07/another_new_aes.html
 [BEAST attacks]: http://blog.ivanristic.com/2011/10/mitigating-the-beast-attack-on-tls.html
+[crypto.getCurves()]: crypto.html#crypto_crypto_getcurves
 [tls.createServer]: #tls_tls_createserver_options_secureconnectionlistener
 [tls.createSecurePair]: #tls_tls_createsecurepair_context_isserver_requestcert_rejectunauthorized
 [tls.TLSSocket]: #tls_class_tls_tlssocket


### PR DESCRIPTION
This adds references to the newly available crypto.getCurves (https://github.com/nodejs/io.js/pull/1914) method where appropriate. I kept the openssl bits as it gives a bit more detail about the curves.

cc: @mscdex
