### PR TITLE
test: fix test-cluster-worker-disconnect

### DIFF
--- a/test/parallel/test-cluster-worker-disconnect.js
+++ b/test/parallel/test-cluster-worker-disconnect.js
@@ -69,10 +69,6 @@ if (cluster.isWorker) {
     checks.worker.emitExit = true;
     checks.worker.died = !alive(worker.process.pid);
     checks.worker.emitDisconnectInsideWorker = code === 42;
-
-    process.nextTick(function() {
-      process.exit(0);
-    });
   });
 
   process.once('exit', function() {


### PR DESCRIPTION
- Make sure the process doesn't exit until both the 'disconnect'
  and 'exit' cluster events are received.
- It tries to fix https://github.com/nodejs/io.js/issues/1757