### PR TITLE
Reduce syscalls on require()

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -129,7 +129,7 @@ const noopDeprecateRequireDot = util.deprecate(function() {},
 Module._findPath = function(request, paths) {
   var exts = Object.keys(Module._extensions);
 
-  if (request.charAt(0) === '/') {
+  if (path.isAbsolute(request)) {
     paths = [''];
   }
 
@@ -142,6 +142,8 @@ Module._findPath = function(request, paths) {
 
   // For each path
   for (var i = 0, PL = paths.length; i < PL; i++) {
+    // Don't search further if path doesn't exist
+    if (paths[i] && internalModuleStat(paths[i]) < 1) continue;
     var basePath = path.resolve(paths[i], request);
     var filename;
 


### PR DESCRIPTION
In some conditions, require makes many useless syscalls trying to find files in non-existent directories.

For example, this is a ```require('moment');``` in one subfolder of my project, the lib/sub/node_modules doesn't even exist.
```
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment\0", 0x7FFF5FBFE5D8, 0x9)          = -1 Err#2
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment.js\0", 0x7FFF5FBFC270, 0x9)               = -1 Err#2
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment.json\0", 0x7FFF5FBFC270, 0x9)             = -1 Err#2
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment.node\0", 0x7FFF5FBFC270, 0x9)             = -1 Err#2
open("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment/package.json\0", 0x0, 0x1B6)                = -1 Err#2
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment/index.js\0", 0x7FFF5FBFE578, 0x1B6)               = -1 Err#2
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment/index.json\0", 0x7FFF5FBFE578, 0x1B6)             = -1 Err#2
stat64("/Users/pierre/Projects/require_test/lib/sub/node_modules/moment/index.node\0", 0x7FFF5FBFE578, 0x1B6)             = -1 Err#2
```

This PR divides by 7 the number of syscalls when requiring a module from a directory without node_modules at the cost of adding 1 from a directory with.

From my tests with a whole process doing only ```require('express')```, I pass from 760 `stat64` to 574 (-25%) and from 106 `open_nocancel` to 58 (45%).
