### PR TITLE
tools: make test-npm work without global npm

### DIFF
--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -30,7 +30,8 @@ export npm_config_tmp="npm-tmp"
 
 # install npm devDependencies and run npm's tests
 ../$NODE_EXE cli.js install --ignore-scripts
-../$NODE_EXE cli.js run-script test-all
+../$NODE_EXE cli.js run-script test-legacy
+../$NODE_EXE cli.js run-script test
 
 # clean up everything one single shot
 cd .. && rm -rf test-npm


### PR DESCRIPTION
Calling the tests independently removes the dependancy on npm internally trying to call `npm run-script` for `test-all`.

R= @othiym23 / @mhdawson?