### PR TITLE
util: display constructor name when inspecting objects

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -167,6 +167,20 @@ function arrayToHash(array) {
 }
 
 
+function getConstructorOf(obj) {
+  while (obj) {
+    var descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
+    if (descriptor !== undefined &&
+        typeof descriptor.value === 'function' &&
+        descriptor.value.name !== '') {
+      return descriptor.value;
+    }
+
+    obj = Object.getPrototypeOf(obj);
+  }
+}
+
+
 function inspectPromise(p) {
   Debug = Debug || require('vm').runInDebugContext('Debug');
   var mirror = Debug.MakeMirror(p, true);
@@ -260,14 +274,17 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
+  var constructor = getConstructorOf(value);
   var base = '', empty = false, braces, formatter;
 
   if (Array.isArray(value)) {
+    if (constructor === Array)
+      constructor = null;
     braces = ['[', ']'];
     empty = value.length === 0;
     formatter = formatArray;
   } else if (value instanceof Set) {
-    braces = ['Set {', '}'];
+    braces = ['{', '}'];
     // With `showHidden`, `length` will display as a hidden property for
     // arrays. For consistency's sake, do the same for `size`, even though this
     // property isn't selected by Object.getOwnPropertyNames().
@@ -276,7 +293,7 @@ function formatValue(ctx, value, recurseTimes) {
     empty = value.size === 0;
     formatter = formatSet;
   } else if (value instanceof Map) {
-    braces = ['Map {', '}'];
+    braces = ['{', '}'];
     // Ditto.
     if (ctx.showHidden)
       keys.unshift('size');
@@ -286,9 +303,11 @@ function formatValue(ctx, value, recurseTimes) {
     // Only create a mirror if the object superficially looks like a Promise.
     var promiseInternals = value instanceof Promise && inspectPromise(value);
     if (promiseInternals) {
-      braces = ['Promise {', '}'];
+      braces = ['{', '}'];
       formatter = formatPromise;
     } else {
+      if (constructor === Object)
+        constructor = null;
       braces = ['{', '}'];
       empty = true;  // No other data than keys.
       formatter = formatObject;
@@ -335,6 +354,10 @@ function formatValue(ctx, value, recurseTimes) {
     formatted = formatPrimitiveNoColor(ctx, raw);
     base = ' ' + '[Boolean: ' + formatted + ']';
   }
+
+  // Add constructor name if available
+  if (base === '' && constructor)
+    braces[0] = constructor.name + ' ' + braces[0];
 
   if (empty === true) {
     return braces[0] + base + braces[1];

--- a/lib/util.js
+++ b/lib/util.js
@@ -178,6 +178,8 @@ function getConstructorOf(obj) {
 
     obj = Object.getPrototypeOf(obj);
   }
+
+  return null;
 }
 
 

--- a/test/parallel/test-sys.js
+++ b/test/parallel/test-sys.js
@@ -17,7 +17,7 @@ assert.equal(new Date('2010-02-14T12:48:40+01:00').toString(),
 assert.equal("'\\n\\u0001'", common.inspect('\n\u0001'));
 
 assert.equal('[]', common.inspect([]));
-assert.equal('{}', common.inspect(Object.create([])));
+assert.equal('Array {}', common.inspect(Object.create([])));
 assert.equal('[ 1, 2 ]', common.inspect([1, 2]));
 assert.equal('[ 1, [ 2, 3 ] ]', common.inspect([1, [2, 3]]));
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -61,7 +61,7 @@ assert.ok(ex.indexOf('[message]') != -1);
 
 // GH-1941
 // should not throw:
-assert.equal(util.inspect(Object.create(Date.prototype)), '{}');
+assert.equal(util.inspect(Object.create(Date.prototype)), 'Date {}');
 
 // GH-1944
 assert.doesNotThrow(function() {
@@ -306,3 +306,44 @@ checkAlignment(function() {
 }());
 checkAlignment(new Set(big_array));
 checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
+
+
+// Test display of constructors
+
+class ObjectSubclass {}
+class ArraySubclass extends Array {}
+class SetSubclass extends Set {}
+class MapSubclass extends Map {}
+class PromiseSubclass extends Promise {}
+
+var x = new ObjectSubclass();
+x.foo = 42;
+assert.equal(util.inspect(x),
+             'ObjectSubclass { foo: 42 }');
+assert.equal(util.inspect(new ArraySubclass(1, 2, 3)),
+             'ArraySubclass [ 1, 2, 3 ]');
+assert.equal(util.inspect(new SetSubclass([1, 2, 3])),
+             'SetSubclass { 1, 2, 3 }');
+assert.equal(util.inspect(new MapSubclass([['foo', 42]])),
+            'MapSubclass { \'foo\' => 42 }');
+assert.equal(util.inspect(new PromiseSubclass(function() {})),
+             'PromiseSubclass { <pending> }');
+
+// Corner cases.
+var x = { constructor: 42 };
+assert.equal(util.inspect(x), '{ constructor: 42 }');
+
+var x = {};
+Object.defineProperty(x, 'constructor', {
+  get: function() {
+    throw new Error('should not access constructor');
+  },
+  enumerable: true
+});
+assert.equal(util.inspect(x), '{ constructor: [Getter] }');
+
+var x = new (function() {});
+assert.equal(util.inspect(x), '{}');
+
+var x = Object.create(null);
+assert.equal(util.inspect(x), '{}');


### PR DESCRIPTION
This feature is inspired by browser devtools. This PR modifies `util.inspect(obj)` to additionally show the name of the function that constructed the object. This often reveals useful information about the object's prototype. In other words, instead of

```js
> new Cls
{}
```

we have

```js
> new Cls
Cls {}
```

This also works with exotic objects:

```js
> class ArrayCls extends Array {}
> new ArrayCls(1, 2, 3)
ArrayCls [ 1, 2, 3 ]
```

The names of "trivial" constructors like `Object` and `Array` are not shown, unless there is a mismatch between the object representation and the prototype:

```js
> Object.create([])
Array {}
```

The constructor displayed is the first function-valued 'constructor' property found by traversing the object and its prototypes. Anonymous functions and non-value descriptors are ignored. Note that cyclic prototypes are illegal so the search always terminates (unless one overrides `getPrototypeOf` with a proxy, but then I would argue you get what you deserve).

---

Display of boxed primitives is unchanged. One could imagine the following:

```js
> class NumberCls extends Number {}
> new NumberCls(0)
[NumberCls: 0]
```

but right now, this will display `[Number: 0]`. This is largely because I am unhappy that the display of boxed primitives is inconsistent with how other exotic objects are displayed (Maps, Sets, Promises). But since boxed primitives are so rarely used this argument is ripe for bikeshedding and I would rather not have that stall the bulk of this feature.