### PR TITLE
net: Fixing error message

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -828,8 +828,9 @@ function connect(self, address, port, addressType, localAddress, localPort) {
   if (err) {
     var sockname = self._getsockname();
     var details;
-
-    if (sockname) {
+    if (sockname &&
+        sockname.address !== undefined &&
+        sockname.port !== undefined) {
       details = sockname.address + ':' + sockname.port;
     }
 
@@ -962,7 +963,9 @@ function lookupAndConnect(self, options) {
       // error event to the next tick.
       err.host = options.host;
       err.port = options.port;
-      err.message = err.message + ' ' + options.host + ':' + options.port;
+      if (options.host !== undefined && options.port !== undefined) {
+        err.message = err.message + ' ' + options.host + ':' + options.port;
+      }
       process.nextTick(connectErrorNT, self, err);
     } else {
       self._unrefTimer();

--- a/test/sequential/test-net-connect-emfile.js
+++ b/test/sequential/test-net-connect-emfile.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+const fs = require('fs');
+
+if (process.platform === 'win32') {
+  console.log('1..0 # Skipped: no RLIMIT_NOFILE on Windows');
+  return;
+}
+
+// Exhaust the file descriptors
+try {
+  while (true) {
+    fs.openSync(__filename, 'r');
+  }
+} catch (err) {
+  assert(err.code === 'EMFILE' || err.code === 'ENFILE');
+}
+
+// Now try to connect. If the `host` is omitted, by default, `localhost` will
+// be used. To actually connect, hostname to IP translation has to happen. So,
+// when `dns` module does lookup, `getaddrinfo` should throw `EMFILE` error.
+//
+// NOTE: We actually don't need a server, because fds are already exhausted.
+// So, `connect` calls will fail.
+net.connect({
+  port: common.PORT
+}).on('error', common.mustCall(function(er) {
+  assert.equal(er.message, 'getaddrinfo EMFILE');
+  assert.equal(er.code, 'EMFILE');
+  assert.equal(er.syscall, 'getaddrinfo');
+  assert.equal(er.port, common.PORT);
+}));
+
+// Again connect to the server with the host option, `127.0.0.1`. We should get
+// `EMFILE` error from `connect` now.
+net.connect({
+  host: common.localhostIPv4,
+  port: common.PORT
+}).on('error', common.mustCall(function(er) {
+  assert.equal(er.message,
+               `connect EMFILE ${common.localhostIPv4}:${common.PORT}`);
+  assert.equal(er.code, 'EMFILE');
+  assert.equal(er.syscall, 'connect');
+  assert.equal(er.port, common.PORT);
+}));


### PR DESCRIPTION
When I was trying to understand the problem in https://github.com/nodejs/io.js/issues/1924, I found out that we show error messages like this

    Error: connect EMFILE 127.0.0.1:8888 - Local (undefined:undefined)

It is because, we ran out of file descriptors and we don't have a valid socket. So, if the return value of `_getsockname` doesn't have valid `address` and `port` properties, we just don't include them in the error message.

---

The problem can be reproduced with the following code

    var net = require('net');

    // Server
    net.createServer().listen(8888, function () {
        console.log('server bound');
    });

    console.log('Launched');

    // Connect to server
    for (var i = 0; i < 10000; i++) {
        net.connect({
            port: 8888
        });
    }

cc: @bnoordhuis 