### PR TITLE
buffer: Fixing the special case in Buffer.concat

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -130,11 +130,6 @@ the list together.
 If the list has no items, or if the totalLength is 0, then it returns a
 zero-length buffer.
 
-If the list has exactly one item, then the first item of the list is
-returned.
-
-If the list has more than one item, then a new Buffer is created.
-
 If totalLength is not provided, it is read from the buffers in the list.
 However, this adds an additional loop to the function, so it is faster
 to provide the length explicitly.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -250,8 +250,6 @@ Buffer.concat = function(list, length) {
 
   if (list.length === 0)
     return new Buffer(0);
-  else if (list.length === 1)
-    return list[0];
 
   if (length === undefined) {
     length = 0;

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -14,7 +14,9 @@ var flatLongLen = Buffer.concat(long, 40);
 
 assert(flatZero.length === 0);
 assert(flatOne.toString() === 'asdf');
-assert(flatOne === one[0]);
+// A special case where concat used to return the first item,
+// if the length is one. This check is to make sure that we don't do that.
+assert(flatOne !== one[0]);
 assert(flatLong.toString() === (new Array(10 + 1).join('asdf')));
 assert(flatLongLen.toString() === (new Array(10 + 1).join('asdf')));
 


### PR DESCRIPTION
PR for https://github.com/nodejs/io.js/issues/1891

If the number of elements to concat is 1, then `Buffer` used to return the only element as it is. But, this is not consistent with `Array`'s `concat` and unintuitive. This patch makes sure that we create a new `Buffer` object always.