### PR TITLE
build: update build targets for io.js

### DIFF
--- a/configure
+++ b/configure
@@ -26,7 +26,7 @@ import nodedownload
 parser = optparse.OptionParser()
 
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux', 'android')
-valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'x32', 'x64')
+valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'x32', 'x64', 'x86')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')
 valid_mips_arch = ('loongson', 'r1', 'r2', 'r6', 'rx')
 valid_mips_fpu = ('fp32', 'fp64', 'fpxx')
@@ -607,6 +607,10 @@ def configure_node(o):
 
   host_arch = host_arch_win() if os.name == 'nt' else host_arch_cc()
   target_arch = options.dest_cpu or host_arch
+  # ia32 is preferred by the build tools (GYP) over x86 even if we prefer the latter
+  # the Makefile resets this to x86 afterward
+  if target_arch == 'x86':
+    target_arch = 'ia32'
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
 

--- a/node.gyp
+++ b/node.gyp
@@ -184,12 +184,15 @@
       'defines': [
         'NODE_ARCH="<(target_arch)"',
         'NODE_PLATFORM="<(OS)"',
-        'NODE_TAG="<(node_tag)"',
         'NODE_V8_OPTIONS="<(node_v8_options)"',
         'NODE_WANT_INTERNALS=1',
       ],
 
+
       'conditions': [
+        [ 'node_tag!=""', {
+          'defines': [ 'NODE_TAG="<(node_tag)"' ],
+        }],
         # No node_main.cc for anything except executable
         [ 'node_target_type!="executable"', {
           'sources!': [

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -12,23 +12,18 @@
 #define NODE_STRINGIFY_HELPER(n) #n
 #endif
 
-#if NODE_VERSION_IS_RELEASE
-# ifndef NODE_TAG
+#ifndef NODE_TAG
+# if NODE_VERSION_IS_RELEASE
 #  define NODE_TAG ""
-# endif
-# define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
-                              NODE_STRINGIFY(NODE_PATCH_VERSION)     \
-                              NODE_TAG
-#else
-# ifndef NODE_TAG
+# else
 #  define NODE_TAG "-pre"
 # endif
+#endif
+
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_PATCH_VERSION)     \
                               NODE_TAG
-#endif
 
 #define NODE_VERSION "v" NODE_VERSION_STRING
 

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -6,7 +6,7 @@
     <ProductVersion>3.5</ProductVersion>
     <ProjectGuid>{1d808ff0-b5a9-4be9-859d-b334b6f48be2}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>iojs-v$(NodeVersion)-$(Platform)</OutputName>
+    <OutputName>iojs-v$(FullVersion)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
@@ -14,25 +14,25 @@
     <NodeVersion Condition=" '$(NodeVersion)' == '' ">0.0.0.0</NodeVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
     <Cultures>en-US</Cultures>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <OutputPath>..\..\..\$(Configuration)\</OutputPath>
+    <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NoPerfCtr=$(NoPerfCtr);NpmSourceDir=..\..\..\deps\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -85,7 +85,7 @@
     <Feature Level="1"
              Id="DocumentationShortcuts"
              Title="Online documentation shortcuts"
-             Description="Add start menu entries that link the the online documentation for io.js $(var.ProductVersion) and the io.js website.">
+             Description="Add start menu entries that link the the online documentation for io.js v$(var.FullVersion) and the io.js website.">
       <ComponentRef Id="DocumentationShortcuts"/>
     </Feature>
 
@@ -225,7 +225,7 @@
                                Type="url"/>
         <util:InternetShortcut Id="DocsShortcut"
                                Name="io.js documentation"
-                               Target="https://iojs.org/dist/v$(var.ProductVersion)/doc/api/"
+                               Target="https://iojs.org/download/$(var.DistTypeDir)/v$(var.FullVersion)/doc/api/"
                                Type="url"/>
       </Component>
     </DirectoryRef>

--- a/tools/osx-codesign.sh
+++ b/tools/osx-codesign.sh
@@ -3,10 +3,9 @@
 set -x
 set -e
 
-if ! [ -n "$SIGN" ] && [ $STEP -eq 1 ]; then
+if [ "X$SIGN" == "X" ]; then
   echo "No SIGN environment var.  Skipping codesign." >&2
   exit 0
 fi
 
 codesign -s "$SIGN" "$PKGDIR"/usr/local/bin/node
-codesign -s "$SIGN" "$PKGDIR"/32/usr/local/bin/node

--- a/tools/osx-pkg.pmdoc/01local.xml
+++ b/tools/osx-pkg.pmdoc/01local.xml
@@ -1,1 +1,25 @@
-<pkgref spec="1.12" uuid="053587FE-BDF3-4EF5-815D-281427431048"><config><identifier>org.iojs.pkg</identifier><version>1.0</version><description></description><post-install type="none"/><requireAuthorization/><installFrom relative="true" mod="true">../out/dist-osx/usr/local/</installFrom><installTo mod="true" relocatable="true">/usr/local</installTo><flags><followSymbolicLinks/></flags><packageStore type="internal"></packageStore><mod>installTo.isRelativeType</mod><mod>installTo</mod><mod>locationType</mod><mod>relocatable</mod><mod>installFrom.path</mod><mod>installTo.isAbsoluteType</mod><mod>identifier</mod><mod>parent</mod><mod>installTo.path</mod><mod>installFrom.isRelativeType</mod></config></pkgref>
+<pkgref spec="1.12" uuid="053587FE-BDF3-4EF5-815D-281427431048">
+  <config>
+    <identifier>org.iojs.iojs.pkg</identifier>
+    <version>1.0</version>
+    <description></description>
+    <post-install type="none"/>
+    <requireAuthorization/>
+    <installFrom relative="true" mod="true">../out/dist-osx/usr/local/</installFrom>
+    <installTo mod="true" relocatable="true">/usr/local</installTo>
+    <flags>
+      <followSymbolicLinks/>
+    </flags>
+    <packageStore type="internal"></packageStore>
+    <mod>installTo.isRelativeType</mod>
+    <mod>installTo</mod>
+    <mod>locationType</mod>
+    <mod>relocatable</mod>
+    <mod>installFrom.path</mod>
+    <mod>installTo.isAbsoluteType</mod>
+    <mod>identifier</mod>
+    <mod>parent</mod>
+    <mod>installTo.path</mod>
+    <mod>installFrom.isRelativeType</mod>
+  </config>
+</pkgref>

--- a/tools/osx-pkg.pmdoc/02npm.xml
+++ b/tools/osx-pkg.pmdoc/02npm.xml
@@ -1,1 +1,24 @@
-<pkgref spec="1.12" uuid="DF0233A3-6B5D-4FBF-8048-8FC57F42278F"><config><identifier>org.iojs.npm.pkg</identifier><version>1.0</version><description></description><post-install type="none"/><requireAuthorization/><installFrom relative="true">../deps/npm</installFrom><installTo mod="true">/usr/local/lib/node_modules/npm</installTo><flags><followSymbolicLinks/></flags><packageStore type="internal"></packageStore><mod>installTo.path</mod><mod>installFrom.isRelativeType</mod><mod>installTo</mod><mod>scripts.postinstall.isRelativeType</mod><mod>parent</mod><mod>installTo.isAbsoluteType</mod></config><scripts><postinstall relative="true" mod="true">osx-pkg-postinstall.sh</postinstall></scripts></pkgref>
+<pkgref spec="1.12" uuid="DF0233A3-6B5D-4FBF-8048-8FC57F42278F">
+  <config>
+    <identifier>org.iojs.npm.pkg</identifier>
+    <version>1.0</version>
+    <description></description>
+    <post-install type="none"/>
+    <requireAuthorization/>
+    <installFrom relative="true">../deps/npm</installFrom>
+    <installTo mod="true">/usr/local/lib/node_modules/npm</installTo>
+    <flags>
+      <followSymbolicLinks/>
+    </flags>
+    <packageStore type="internal"></packageStore>
+    <mod>installTo.path</mod>
+    <mod>installFrom.isRelativeType</mod>
+    <mod>installTo</mod>
+    <mod>scripts.postinstall.isRelativeType</mod>
+    <mod>parent</mod>
+    <mod>installTo.isAbsoluteType</mod>
+  </config>
+  <scripts>
+    <postinstall relative="true" mod="true">osx-pkg-postinstall.sh</postinstall>
+  </scripts>
+</pkgref>

--- a/tools/osx-pkg.pmdoc/index.xml.tmpl
+++ b/tools/osx-pkg.pmdoc/index.xml.tmpl
@@ -1,9 +1,35 @@
-<pkmkdoc spec="1.12"><properties><title>io.js</title><build>/Users/iojs/Desktop/iojs.pkg</build><organization>org.iojs</organization><userSees ui="both"/><min-target os="3"/><domain system="true"/></properties><distribution><versions min-spec="1.000000"/><scripts></scripts></distribution><contents><choice title="io.js" id="choice3" starts_selected="true" starts_enabled="true" starts_hidden="false"><pkgref id="org.iojs.pkg"/></choice><choice title="npm" id="choice4" starts_selected="true" starts_enabled="true" starts_hidden="false"><pkgref id="org.iojs.npm.pkg"/></choice></contents><resources bg-scale="none" bg-align="topleft"><locale lang="en"><resource relative="true" mod="true" type="background">../doc/osx_installer_logo.png</resource><resource relative="true" mod="true" type="license">../LICENSE</resource><resource mime-type="text/rtf" kind="embedded" type="welcome"><![CDATA[{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf360
+<pkmkdoc spec="1.12">
+  <properties>
+    <title>io.js</title>
+    <build>/Users/iojs/Desktop/iojs.pkg</build>
+    <organization>org.iojs</organization>
+    <userSees ui="both"/>
+    <min-target os="3"/>
+    <domain system="true"/>
+  </properties>
+  <distribution>
+    <versions min-spec="1.000000"/>
+    <scripts></scripts>
+  </distribution>
+  <contents>
+    <choice title="io.js" id="choice1" starts_selected="true" starts_enabled="true" starts_hidden="false">
+      <pkgref id="org.iojs.iojs.pkg"/>
+    </choice>
+    <choice title="npm" id="choice2" starts_selected="true" starts_enabled="true" starts_hidden="false">
+      <pkgref id="org.iojs.npm.pkg"/>
+    </choice>
+  </contents>
+  <resources bg-scale="none" bg-align="topleft">
+    <locale lang="en">
+      <resource relative="true" mod="true" type="background">../doc/osx_installer_logo.png</resource>
+      <resource relative="true" mod="true" type="license">../LICENSE</resource>
+      <resource mime-type="text/rtf" kind="embedded" type="welcome"><![CDATA[{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf360
 {\fonttbl\f0\fnil\fcharset0 LucidaGrande;}
 {\colortbl;\red255\green255\blue255;}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\ql\qnatural\pardirnatural
 
-\f0\fs26 \cf0 This package will install io.js __iojsversion__ and npm __npmversion__ into /usr/local/. The binary /usr/local/bin/iojs will also be symlinked as /usr/local/bin/node.}]]></resource><resource mime-type="text/rtf" kind="embedded" type="conclusion"><![CDATA[{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf360
+\f0\fs26 \cf0 This package will install io.js {iojsversion} and npm {npmversion} into /usr/local/. The binary /usr/local/bin/iojs will also be symlinked as /usr/local/bin/node.}]]></resource>
+      <resource mime-type="text/rtf" kind="embedded" type="conclusion"><![CDATA[{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf360
 {\fonttbl\f0\fnil\fcharset0 LucidaGrande;}
 {\colortbl;\red255\green255\blue255;}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\ql\qnatural\pardirnatural
@@ -18,4 +44,14 @@ npm was installed at\
 \
    /usr/local/bin/npm\
 \
-Make sure that /usr/local/bin is in your $PATH.}]]></resource></locale></resources><flags/><item type="file">01local.xml</item><item type="file">02npm.xml</item><mod>properties.title</mod><mod>properties.userDomain</mod><mod>properties.anywhereDomain</mod><mod>properties.systemDomain</mod></pkmkdoc>
+Make sure that /usr/local/bin is in your $PATH.}]]></resource>
+    </locale>
+  </resources>
+  <flags/>
+  <item type="file">01local.xml</item>
+  <item type="file">02npm.xml</item>
+  <mod>properties.title</mod>
+  <mod>properties.userDomain</mod>
+  <mod>properties.anywhereDomain</mod>
+  <mod>properties.systemDomain</mod>
+</pkmkdoc>

--- a/tools/osx-productsign.sh
+++ b/tools/osx-productsign.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-if ! [ -n "$SIGN" ]; then
+if [ "X$SIGN" == "X" ]; then
   echo "No SIGN environment var.  Skipping codesign." >&2
   exit 0
 fi


### PR DESCRIPTION
I decided to tackle some technical debt in the process of enabling RC builds for 3.0.0, the other option was to just build up more.

This PR extracts almost all of the release logic from Jenkins and puts it back in the Makefile where it belongs. It's not complete _yet_ because I still need to fix vcbuild.bat, but I'll get that done ASAP so we can move forward. I'm putting this up now so the Makefile portion can get a review.

The Makefile is now aware of `nightly`, `next-nightly` and `rc` builds, this is specified with the `NIGHTLY` parameter. The nightly builds also need `COMMIT` and `DATESTRING` parameters to form the full tag. The rc builds need an `RC` parameter which will just be an number for the given RC. The version string of RC builds will look like `v3.0.0-rc1`.

The packaging and uploading logic has been put back in to the Makefile, we were not using a lot of the existing stuff and had instead taken the shortcut of putting it all in Jenkins (when I say "we" I actually mean "I"). Now we're even using the code signing stuff in there. The OSX package definitions have been updated and I even formatted the XML file because I wanted to do some manual editing in there.

I've also fixed a long-standing bug, https://github.com/nodejs/build/issues/45, which comes from the fact that in io.js we opted to go fully with `x86` for 32-bit instead of the `ia32` used by joyent/node. Unfortunately for the Linux tarballs this was done by renaming the file and the internal directory structure still referred to `ia32` so I have now fully banished it from the build process (it's still used by `configure` internally though).

I also got rid of the pkgsrc stuff for now, that can go back in later.

I have set up a new Jenkins job to run this: https://jenkins-iojs.nodesource.com/job/iojs+nightly2/, it has an additional `rc` option in the "buildtype" parameter and a new "rc" parameter.

For tarballs on Linux (including ARM) and OSX it's simply doing this now:

```sh
make -j$JOBS binary-upload DESTCPU=$DESTCPU ARCH=$ARCH NIGHTLY=$buildtype DATESTRING=$datestring COMMIT=$commit RC=$rc
```

For .pkg files on OSX it's doing this:

```sh
CODESIGN_CERT=Developer ID Application: Node Source, LLC
PRODUCTSIGN_CERT=Developer ID Installer: Node Source, LLC
PACKAGEMAKER=~/PackageMaker.app/Contents/MacOS/PackageMaker

make -j$JOBS pkg-upload DESTCPU=$DESTCPU ARCH=$ARCH NIGHTLY=$buildtype DATESTRING=$datestring COMMIT=$commit RC=$rc
```

For the slave that makes the source tarball and the doc/ directory it does this:

```sh
make -j$JOBS tar-upload DESTCPU=$DESTCPU ARCH=$ARCH NIGHTLY=$buildtype DATESTRING=$datestring COMMIT=$commit RC=$rc

make -j$JOBS doc-upload DESTCPU=$DESTCPU ARCH=$ARCH NIGHTLY=$buildtype DATESTRING=$datestring COMMIT=$commit RC=$rc
```

_(The lower-case variables are injected by Jenkins from its build parameters.)_

These make targets do the whole lot from build to upload-to-staging. I've tested and tweaked each of the build types and am confident that this is working as it should, except for Windows which still has a bunch of Jenkins logic and is missing awareness of rc builds.

Standard test run here: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/795/

attn: @nodejs/build 