### PR TITLE
module: remove obsolete global path

### DIFF
--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -445,10 +445,8 @@ Additionally, io.js will search in the following locations:
 
 * 1: `$HOME/.node_modules`
 * 2: `$HOME/.node_libraries`
-* 3: `$PREFIX/lib/node`
 
-Where `$HOME` is the user's home directory, and `$PREFIX` is io.js's
-configured `node_prefix`.
+Where `$HOME` is the user's home directory.
 
 These are mostly for historic reasons.  **You are highly encouraged
 to place your dependencies locally in `node_modules` folders.**  They

--- a/lib/module.js
+++ b/lib/module.js
@@ -478,7 +478,7 @@ Module._initPaths = function() {
     var homeDir = process.env.HOME;
   }
 
-  var paths = [path.resolve(process.execPath, '..', '..', 'lib', 'node')];
+  var paths = [];
 
   if (homeDir) {
     paths.unshift(path.resolve(homeDir, '.node_libraries'));


### PR DESCRIPTION
Resolves #1946

(One test is failing but it's failing for me without this change too and it looks like it has to do with #1945. If I remove that test, everything else passes `make test` with no problem.)

