### PR TITLE
cluster: do not unconditionally set --debug-port

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -278,11 +278,11 @@ function masterInit() {
     cluster.emit('setup', settings);
   }
 
+  var debugPortOffset = 1;
+
   function createWorkerProcess(id, env) {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
-    var debugPort = process.debugPort + id;
-    var hasDebugArg = false;
 
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;
@@ -291,13 +291,11 @@ function masterInit() {
       var match = execArgv[i].match(/^(--debug|--debug-(brk|port))(=\d+)?$/);
 
       if (match) {
+        let debugPort = process.debugPort + debugPortOffset;
+        ++debugPortOffset;
         execArgv[i] = match[1] + '=' + debugPort;
-        hasDebugArg = true;
       }
     }
-
-    if (!hasDebugArg)
-      execArgv = ['--debug-port=' + debugPort].concat(execArgv);
 
     return fork(cluster.settings.exec, cluster.settings.args, {
       env: workerEnv,

--- a/test/parallel/test-cluster-debug-port.js
+++ b/test/parallel/test-cluster-debug-port.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+
+if (cluster.isMaster) {
+  assert.strictEqual(process.execArgv.length, 0, 'run test with no args');
+
+  function checkExitCode(code, signal) {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }
+
+  console.log('forked worker should not have --debug-port');
+  cluster.fork().on('exit', checkExitCode);
+
+  cluster.setupMaster({
+    execArgv: ['--debug-port=' + process.debugPort]
+  });
+
+  console.log('forked worker should have --debug-port, with offset = 1');
+  cluster.fork({
+    portSet: process.debugPort + 1
+  }).on('exit', checkExitCode);
+
+  console.log('forked worker should have --debug-port, with offset = 2');
+  cluster.fork({
+    portSet: process.debugPort + 2
+  }).on('exit', checkExitCode);
+} else {
+  const hasDebugArg = process.execArgv.some(function(arg) {
+    return /debug/.test(arg);
+  });
+
+  assert.strictEqual(hasDebugArg, process.env.portSet !== undefined);
+  assert.strictEqual(process.debugPort, +process.env.portSet || 5858);
+  process.exit();
+}


### PR DESCRIPTION
Currently, each cluster worker is assigned an ever increasing `--debug-port` argument. A long running cluster application that does not use the debugger can run into errors related to the port range. This commit mitigates the problem by only setting the debug port if the master is started with debug arguments, or the user explicitly defines debug arguments for the worker. This commit also adds a new debug port offset counter that is only incremented when a worker is created that utilizes debugging.

Fixes https://github.com/nodejs/io.js/pull/1524, https://github.com/joyent/node/issues/8159