### PR TITLE
tls: fix references to undefined `cb`

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -167,7 +167,7 @@ function oncertcb(info) {
         return self.destroy(err);
 
       if (!self._handle)
-        return cb(new Error('Socket is closed'));
+        return self.destroy(new Error('Socket is closed'));
 
       self._handle.certCbDone();
     });
@@ -192,7 +192,7 @@ function onnewsession(key, session) {
     once = true;
 
     if (!self._handle)
-      return cb(new Error('Socket is closed'));
+      return self.destroy(new Error('Socket is closed'));
 
     self._handle.newSessionDone();
 


### PR DESCRIPTION
5795e835a1021abdf803e1460501487adbac8d7c introduced unintentional
copy-paste bug. `cb` is not actually present in those functions and
should not be called, the socket should be destroy instead.

cc @silverwind 