### PR TITLE
test: only refresh tmpDir for tests that need it

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ test/fixtures
 test/**/node_modules
 test/parallel/test-fs-non-number-arguments-throw.js
 test/disabled
+test/tmp*/

--- a/test/common.js
+++ b/test/common.js
@@ -51,19 +51,17 @@ function rmdirSync(p, originalEr) {
   }
 }
 
-function refreshTmpDir() {
-  if (!process.send) { // Not a child process
-    try {
-      rimrafSync(exports.tmpDir);
-    } catch (e) {
-    }
-
-    try {
-      fs.mkdirSync(exports.tmpDir);
-    } catch (e) {
-    }
+exports.refreshTmpDir = function() {
+  try {
+    rimrafSync(exports.tmpDir);
+  } catch (e) {
   }
-}
+
+  try {
+    fs.mkdirSync(exports.tmpDir);
+  } catch (e) {
+  }
+};
 
 if (process.env.TEST_THREAD_ID) {
   // Distribute ports in parallel tests
@@ -73,8 +71,6 @@ if (process.env.TEST_THREAD_ID) {
   exports.tmpDirName += '.' + process.env.TEST_THREAD_ID;
 }
 exports.tmpDir = path.join(exports.testDir, exports.tmpDirName);
-
-refreshTmpDir();
 
 var opensslCli = null;
 var inFreeBSDJail = null;

--- a/test/fixtures/listen-on-socket-and-exit.js
+++ b/test/fixtures/listen-on-socket-and-exit.js
@@ -3,6 +3,8 @@
 var common = require('../common');
 var net = require('net');
 
+common.refreshTmpDir();
+
 var server = net.createServer().listen(common.PIPE, function() {
   console.log('child listening');
   process.send('listening');

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -15,6 +15,7 @@ if (process.env.FORK) {
   process.exit();
 }
 else {
+  common.refreshTmpDir();
   try {
     fs.unlinkSync(copyPath);
   }

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -10,6 +10,7 @@ var cluster = require('cluster');
 var http = require('http');
 
 if (cluster.isMaster) {
+  common.refreshTmpDir();
   var ok = false;
   var worker = cluster.fork();
   worker.on('message', function(msg) {

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -11,6 +11,7 @@ if (process.platform === 'sunos' || process.platform === 'win32') {
 }
 
 var dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+common.refreshTmpDir();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -11,6 +11,7 @@ if (process.platform === 'sunos' || process.platform === 'win32') {
 }
 
 var dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+common.refreshTmpDir();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 var fn = path.join(common.tmpDir, 'write.txt');
+common.refreshTmpDir();
 var file = fs.createWriteStream(fn, {
       highWaterMark: 10
     });

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -39,7 +39,7 @@ function removeTestFile() {
 }
 
 
-removeTestFile();
+common.refreshTmpDir();
 
 // drain at 0, return false at 10.
 file = fs.createWriteStream(filepath, {

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -39,7 +39,7 @@ function removeTestFile() {
 }
 
 
-removeTestFile();
+common.refreshTmpDir();
 
 
 function run_test_1() {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -21,6 +21,7 @@ var createFileWithPerms = function(file, mode) {
   fs.chmodSync(file, mode);
 };
 
+common.refreshTmpDir();
 createFileWithPerms(readOnlyFile, 0o444);
 createFileWithPerms(readWriteFile, 0o666);
 

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -15,6 +15,8 @@ var data = '南越国是前203年至前111年存在于岭南地区的一个国�
         '历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，' +
         '它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
 
+common.refreshTmpDir();
+
 // test that empty file will be created and have content added
 var filename = join(common.tmpDir, 'append-sync.txt');
 

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -21,6 +21,8 @@ var s = '南越国是前203年至前111年存在于岭南地区的一个国家�
 
 var ncallbacks = 0;
 
+common.refreshTmpDir();
+
 // test that empty file will be created and have content added
 fs.appendFile(filename, s, function(e) {
   if (e) throw e;

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -111,9 +111,7 @@ fs.open(file2, 'a', function(err, fd) {
 if (fs.lchmod) {
   var link = path.join(common.tmpDir, 'symbolic-link');
 
-  try {
-    fs.unlinkSync(link);
-  } catch (er) {}
+  common.refreshTmpDir();
   fs.symlinkSync(file2, link);
 
   fs.lchmod(link, mode_async, function(err) {

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -11,12 +11,7 @@ var fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
 var fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
 var fullPath = path.resolve(fileName);
 
-try {
-  fs.unlinkSync(fullPath);
-}
-catch (e) {
-  // Ignore.
-}
+common.refreshTmpDir();
 
 console.log({
   filenameLength: fileName.length,

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -10,6 +10,8 @@ function unlink(pathname) {
   }
 }
 
+common.refreshTmpDir();
+
 (function() {
   var ncalls = 0;
   var pathname = common.tmpDir + '/test1';

--- a/test/parallel/test-fs-read-stream-fd.js
+++ b/test/parallel/test-fs-read-stream-fd.js
@@ -10,6 +10,7 @@ var input = 'hello world';
 var output = '';
 var fd, stream;
 
+common.refreshTmpDir();
 fs.writeFileSync(file, input);
 fd = fs.openSync(file, 'r');
 

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -15,6 +15,7 @@ var fs = require('fs');
 
 var filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
 var dataExpected = new Array(1000000).join('a');
+common.refreshTmpDir();
 fs.writeFileSync(filename, dataExpected);
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -15,6 +15,7 @@ var fs = require('fs');
 
 var filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
 var dataExpected = new Array(1000000).join('a');
+common.refreshTmpDir();
 fs.writeFileSync(filename, dataExpected);
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -8,6 +8,8 @@ var async_completed = 0, async_expected = 0, unlink = [];
 var isWindows = process.platform === 'win32';
 var skipSymlinks = false;
 
+common.refreshTmpDir();
+
 var root = '/';
 if (isWindows) {
   // something like "C:\\"
@@ -575,9 +577,6 @@ function runTest() {
   var tmpDirs = ['cycles', 'cycles/folder'];
   tmpDirs.forEach(function(t) {
     t = tmp(t);
-    var s;
-    try { s = fs.statSync(t); } catch (ex) {}
-    if (s) return;
     fs.mkdirSync(t, 0o700);
   });
   fs.writeFileSync(tmp('cycles/root.js'), "console.error('roooot!');");

--- a/test/parallel/test-fs-sir-writes-alot.js
+++ b/test/parallel/test-fs-sir-writes-alot.js
@@ -6,11 +6,7 @@ var join = require('path').join;
 
 var filename = join(common.tmpDir, 'out.txt');
 
-try {
-  fs.unlinkSync(filename);
-} catch (e) {
-  // might not exist, that's okay.
-}
+common.refreshTmpDir();
 
 var fd = fs.openSync(filename, 'w');
 

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -3,6 +3,8 @@ var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 
+common.refreshTmpDir();
+
 test1(fs.createReadStream(__filename));
 test2(fs.createReadStream(__filename));
 test3(fs.createReadStream(__filename));

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -13,10 +13,7 @@ var linkPath2 = path.join(common.tmpDir, 'junction2');
 var linkTarget = path.join(common.fixturesDir);
 var linkData = '../fixtures';
 
-// Prepare.
-try { fs.mkdirSync(common.tmpDir); } catch (e) {}
-try { fs.unlinkSync(linkPath1); } catch (e) {}
-try { fs.unlinkSync(linkPath2); } catch (e) {}
+common.refreshTmpDir();
 
 // Test fs.symlink()
 fs.symlink(linkData, linkPath1, 'junction', function(err) {

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -10,10 +10,7 @@ var expected_tests = 4;
 var linkData = path.join(common.fixturesDir, 'cycles/');
 var linkPath = path.join(common.tmpDir, 'cycles_link');
 
-// Delete previously created link
-try {
-  fs.unlinkSync(linkPath);
-} catch (e) {}
+common.refreshTmpDir();
 
 console.log('linkData: ' + linkData);
 console.log('linkPath: ' + linkPath);

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -9,16 +9,13 @@ var expected_tests = 2;
 
 var is_windows = process.platform === 'win32';
 
+common.refreshTmpDir();
+
 var runtest = function(skip_symlinks) {
   if (!skip_symlinks) {
     // test creating and reading symbolic link
     var linkData = path.join(common.fixturesDir, '/cycles/root.js');
     var linkPath = path.join(common.tmpDir, 'symlink1.js');
-
-    // Delete previously created link
-    try {
-      fs.unlinkSync(linkPath);
-    } catch (e) {}
 
     fs.symlink(linkData, linkPath, function(err) {
       if (err) throw err;
@@ -35,11 +32,6 @@ var runtest = function(skip_symlinks) {
   // test creating and reading hard link
   var srcPath = path.join(common.fixturesDir, 'cycles', 'root.js');
   var dstPath = path.join(common.tmpDir, 'link1.js');
-
-  // Delete previously created link
-  try {
-    fs.unlinkSync(dstPath);
-  } catch (e) {}
 
   fs.link(srcPath, dstPath, function(err) {
     if (err) throw err;

--- a/test/parallel/test-fs-truncate-GH-6233.js
+++ b/test/parallel/test-fs-truncate-GH-6233.js
@@ -5,6 +5,8 @@ var fs = require('fs');
 
 var filename = common.tmpDir + '/truncate-file.txt';
 
+common.refreshTmpDir();
+
 // Synchronous test.
 (function() {
   fs.writeFileSync(filename, '0123456789');

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -4,8 +4,7 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 var tmp = common.tmpDir;
-if (!fs.existsSync(tmp))
-  fs.mkdirSync(tmp);
+common.refreshTmpDir();
 var filename = path.resolve(tmp, 'truncate-file.txt');
 
 var success = 0;

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -8,6 +8,8 @@ var filename = path.resolve(tmp, 'truncate-file.txt');
 var data = new Buffer(1024 * 16);
 data.fill('x');
 
+common.refreshTmpDir();
+
 var stat;
 
 // truncateSync

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -10,6 +10,8 @@ var path = require('path'),
     writeCalled = 0;
 
 
+common.refreshTmpDir();
+
 fs.open(filename, 'w', 0o644, function(err, fd) {
   openCalled++;
   if (err) throw err;

--- a/test/parallel/test-fs-write-file-buffer.js
+++ b/test/parallel/test-fs-write-file-buffer.js
@@ -25,6 +25,8 @@ var data = [
 
 data = data.join('\n');
 
+common.refreshTmpDir();
+
 var buf = new Buffer(data, 'base64');
 fs.writeFileSync(join(common.tmpDir, 'test.jpg'), buf);
 

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -26,9 +26,10 @@ if (isWindows) {
   mode = 0o755;
 }
 
+common.refreshTmpDir();
+
 // Test writeFileSync
 var file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
-removeFile(file1);
 
 fs.writeFileSync(file1, '123', {mode: mode});
 
@@ -37,11 +38,8 @@ assert.equal('123', content);
 
 assert.equal(mode, fs.statSync(file1).mode & 0o777);
 
-removeFile(file1);
-
 // Test appendFileSync
 var file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
-removeFile(file2);
 
 fs.appendFileSync(file2, 'abc', {mode: mode});
 
@@ -50,22 +48,8 @@ assert.equal('abc', content);
 
 assert.equal(mode, fs.statSync(file2).mode & mode);
 
-removeFile(file2);
-
 // Verify that all opened files were closed.
 assert.equal(0, openCount);
-
-// Removes a file if it exists.
-function removeFile(file) {
-  try {
-    if (isWindows)
-      fs.chmodSync(file, 0o666);
-    fs.unlinkSync(file);
-  } catch (err) {
-    if (err && err.code !== 'ENOENT')
-      throw err;
-  }
-}
 
 function openSync() {
   openCount++;

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -4,6 +4,8 @@ var assert = require('assert');
 var fs = require('fs');
 var join = require('path').join;
 
+common.refreshTmpDir();
+
 var filename = join(common.tmpDir, 'test.txt');
 
 common.error('writing to ' + filename);

--- a/test/parallel/test-fs-write-stream-change-open.js
+++ b/test/parallel/test-fs-write-stream-change-open.js
@@ -7,6 +7,8 @@ var path = require('path'),
 
 var file = path.join(common.tmpDir, 'write.txt');
 
+common.refreshTmpDir();
+
 var stream = fs.WriteStream(file),
     _fs_close = fs.close,
     _fs_open = fs.open;

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -10,6 +10,8 @@ const secondEncoding = 'binary';
 const examplePath = path.join(common.fixturesDir, 'x.txt');
 const dummyPath = path.join(common.tmpDir, 'x.txt');
 
+common.refreshTmpDir();
+
 const exampleReadStream = fs.createReadStream(examplePath, {
   encoding: firstEncoding
 });

--- a/test/parallel/test-fs-write-stream-end.js
+++ b/test/parallel/test-fs-write-stream-end.js
@@ -4,6 +4,8 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 
+common.refreshTmpDir();
+
 (function() {
   var file = path.join(common.tmpDir, 'write-end-test0.txt');
   var stream = fs.createWriteStream(file);

--- a/test/parallel/test-fs-write-stream-err.js
+++ b/test/parallel/test-fs-write-stream-err.js
@@ -3,6 +3,8 @@ var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 
+common.refreshTmpDir();
+
 var stream = fs.createWriteStream(common.tmpDir + '/out', {
   highWaterMark: 10
 });

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -6,6 +6,8 @@ const path = require('path');
 
 const example = path.join(common.tmpDir, 'dummy');
 
+common.refreshTmpDir();
+
 assert.doesNotThrow(function() {
   fs.createWriteStream(example, undefined);
 });

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -7,6 +7,8 @@ var path = require('path'),
 
 var file = path.join(common.tmpDir, 'write.txt');
 
+common.refreshTmpDir();
+
 (function() {
   var stream = fs.WriteStream(file),
       _fs_close = fs.close;

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -4,6 +4,9 @@ var assert = require('assert');
 var path = require('path');
 var Buffer = require('buffer').Buffer;
 var fs = require('fs');
+
+common.refreshTmpDir();
+
 var fn = path.join(common.tmpDir, 'write-string-coerce.txt');
 var data = true;
 var expected = data + '';

--- a/test/parallel/test-fs-write-sync.js
+++ b/test/parallel/test-fs-write-sync.js
@@ -5,6 +5,7 @@ var path = require('path');
 var fs = require('fs');
 var fn = path.join(common.tmpDir, 'write.txt');
 
+common.refreshTmpDir();
 
 var foo = 'foo';
 var fd = fs.openSync(fn, 'w');

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -10,6 +10,8 @@ var expected = 'ümlaut.';
 var constants = require('constants');
 var found, found2;
 
+common.refreshTmpDir();
+
 fs.open(fn, 'w', 0o644, function(err, fd) {
   if (err) throw err;
   console.log('open done');

--- a/test/parallel/test-http-curl-chunk-problem.js
+++ b/test/parallel/test-http-curl-chunk-problem.js
@@ -30,6 +30,8 @@ function maybeMakeRequest() {
 }
 
 
+common.refreshTmpDir();
+
 var ddcmd = common.ddCommand(filename, 10240);
 console.log('dd command: ', ddcmd);
 

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -7,6 +7,8 @@ var assert = require('assert');
 var http = require('http');
 var fs = require('fs');
 
+common.refreshTmpDir();
+
 var image = fs.readFileSync(common.fixturesDir + '/person.jpg');
 
 console.log('image.length = ' + image.length);

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -5,6 +5,8 @@ var http = require('http');
 var fs = require('fs');
 var path = require('path');
 
+common.refreshTmpDir();
+
 var file = path.join(common.tmpDir, 'http-pipe-fs-test.txt');
 var requests = 0;
 

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -11,8 +11,6 @@ var https = require('https');
 var fs = require('fs');
 var path = require('path');
 
-var resultFile = path.resolve(common.tmpDir, 'result');
-
 var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
 

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -6,6 +6,8 @@ var http = require('http');
 var path = require('path');
 var cp = require('child_process');
 
+common.refreshTmpDir();
+
 var filename = path.join(common.tmpDir || '/tmp', 'big');
 var clientReqComplete = false;
 var count = 0;

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -5,6 +5,8 @@ var join = require('path').join;
 var fs = require('fs');
 var common = require('../common');
 
+common.refreshTmpDir();
+
 var repl = require('repl');
 
 // A stream to push an array into a REPL

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -7,6 +7,8 @@ var assert = require('assert');
 var zlib = require('zlib');
 var path = require('path');
 
+common.refreshTmpDir();
+
 var gunzip = zlib.createGunzip();
 
 var fs = require('fs');

--- a/test/sequential/test-fs-watch-recursive.js
+++ b/test/sequential/test-fs-watch-recursive.js
@@ -15,6 +15,8 @@ if (process.platform === 'darwin') {
   var relativePathOne = path.join('testsubdir', filenameOne);
   var filepathOne = path.join(testsubdir, filenameOne);
 
+  common.refreshTmpDir();
+
   process.on('exit', function() {
     assert.ok(watchSeenOne > 0);
   });

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -32,11 +32,7 @@ process.on('exit', function() {
   assert.ok(watchSeenThree > 0);
 });
 
-// Clean up stale files (if any) from previous run.
-try { fs.unlinkSync(filepathOne); } catch (e) { }
-try { fs.unlinkSync(filepathTwoAbs); } catch (e) { }
-try { fs.unlinkSync(filepathThree); } catch (e) { }
-try { fs.rmdirSync(testsubdir); } catch (e) { }
+common.refreshTmpDir();
 
 fs.writeFileSync(filepathOne, 'hello');
 

--- a/test/sequential/test-mkdir-rmdir.js
+++ b/test/sequential/test-mkdir-rmdir.js
@@ -4,6 +4,8 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 
+common.refreshTmpDir();
+
 var dirname = path.dirname(__filename);
 var d = path.join(common.tmpDir, 'dir');
 

--- a/test/sequential/test-regress-GH-4027.js
+++ b/test/sequential/test-regress-GH-4027.js
@@ -4,6 +4,8 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 
+common.refreshTmpDir();
+
 var filename = path.join(common.tmpDir, 'watched');
 fs.writeFileSync(filename, 'quis custodiet ipsos custodes');
 setTimeout(fs.unlinkSync, 100, filename);

--- a/test/sequential/test-stdout-to-file.js
+++ b/test/sequential/test-stdout-to-file.js
@@ -9,6 +9,8 @@ var scriptString = path.join(common.fixturesDir, 'print-chars.js');
 var scriptBuffer = path.join(common.fixturesDir, 'print-chars-from-buffer.js');
 var tmpFile = path.join(common.tmpDir, 'stdout.txt');
 
+common.refreshTmpDir();
+
 function test(size, useBuffer, cb) {
   var cmd = '"' + process.argv[0] + '"' +
             ' ' +


### PR DESCRIPTION
Expose `common.refreshTmpDir()` and only call it
for tests that use common.tmpDir or common.PIPE.

A positive side effect is the removal of a code
smell where child processes were detected by the
presence of `.send()`. Now each process can decide
for itself if it needs to refresh tmpDir.

/cc @rvagg (who suggested this approach in comments on #1877)