### PR TITLE
build: simplify execution of built binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,16 @@ test-valgrind: all
 	$(PYTHON) tools/test.py --mode=release --valgrind sequential parallel message
 
 test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
-	./$(NODE_EXE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
+	$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
 		--directory="$(shell pwd)/test/gc/node_modules/weak" \
 		--nodedir="$(shell pwd)"
 
 build-addons: $(NODE_EXE)
 	rm -rf test/addons/doc-*/
-	./$(NODE_EXE) tools/doc/addon-verify.js
+	$(NODE) tools/doc/addon-verify.js
 	$(foreach dir, \
 			$(sort $(dir $(wildcard test/addons/*/*.gyp))), \
-			./$(NODE_EXE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
+			$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
 					--directory="$(shell pwd)/$(dir)" \
 					--nodedir="$(shell pwd)" && ) echo "build done"
 
@@ -141,7 +141,7 @@ test-npm: $(NODE_EXE)
 	NODE_EXE=$(NODE_EXE) tools/test-npm.sh
 
 test-npm-publish: $(NODE_EXE)
-	npm_package_config_publishtest=true ./$(NODE_EXE) deps/npm/test/run.js
+	npm_package_config_publishtest=true $(NODE) deps/npm/test/run.js
 
 test-addons: test-build
 	$(PYTHON) tools/test.py --mode=release addons
@@ -173,10 +173,10 @@ out/doc/%: doc/%
 	cp -r $< $@
 
 out/doc/api/%.json: doc/api/%.markdown $(NODE_EXE)
-	out/Release/$(NODE_EXE) tools/doc/generate.js --format=json $< > $@
+	$(NODE) tools/doc/generate.js --format=json $< > $@
 
 out/doc/api/%.html: doc/api/%.markdown $(NODE_EXE)
-	out/Release/$(NODE_EXE) tools/doc/generate.js --format=html --template=doc/template.html $< > $@
+	$(NODE) tools/doc/generate.js --format=html --template=doc/template.html $< > $@
 
 docopen: out/doc/api/all.html
 	-google-chrome out/doc/api/all.html
@@ -370,12 +370,12 @@ bench-http-simple:
 	 benchmark/http_simple_bench.sh
 
 bench-idle:
-	./$(NODE_EXE) benchmark/idle_server.js &
+	$(NODE) benchmark/idle_server.js &
 	sleep 1
-	./$(NODE_EXE) benchmark/idle_clients.js &
+	$(NODE) benchmark/idle_clients.js &
 
 jslint:
-	./$(NODE_EXE) tools/eslint/bin/eslint.js src lib test --rulesdir tools/eslint-rules --reset --quiet
+	$(NODE) tools/eslint/bin/eslint.js src lib test --rulesdir tools/eslint-rules --reset --quiet
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc


### PR DESCRIPTION
Since we aleady have a variable with path to the newly built binary, use that instead of prefixing path. This also allows us to pass a different path through the environment (NODE=).

R=@nodejs/build