### PR TITLE
build: don't run lint from test-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,6 @@ test-all-valgrind: test-build
 
 test-ci:
 	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release message parallel sequential
-	$(MAKE) jslint
-	$(MAKE) cpplint
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release


### PR DESCRIPTION
Since we will run linting before compiling or testing there's no need to run it as part of the ci testing.

Note to person landing this: Don't merge until we have the linter up and running (#1955 and https://github.com/nodejs/build/issues/109).