### PR TITLE
v8: cherry-pick uclibc build patch from upstream

### DIFF
--- a/deps/v8/include/v8config.h
+++ b/deps/v8/include/v8config.h
@@ -124,6 +124,7 @@
 //  V8_LIBC_BIONIC  - Bionic libc
 //  V8_LIBC_BSD     - BSD libc derivate
 //  V8_LIBC_GLIBC   - GNU C library
+//  V8_LIBC_UCLIBC  - uClibc
 //
 // Note that testing for libc must be done using #if not #ifdef. For example,
 // to test for the GNU C library, use:
@@ -136,6 +137,9 @@
 #elif defined(__BIONIC__)
 # define V8_LIBC_BIONIC 1
 # define V8_LIBC_BSD 1
+#elif defined(__UCLIBC__)
+// Must test for UCLIBC before GLIBC, as UCLIBC pretends to be GLIBC.
+# define V8_LIBC_UCLIBC 1
 #elif defined(__GLIBC__) || defined(__GNU_LIBRARY__)
 # define V8_LIBC_GLIBC 1
 #else


### PR DESCRIPTION
Original commit log follows:

    Restore V8_LIBC_UCLIBC as a libc option.

    As uClibc defines __GLIBC__ in an attempt to look like glibc,
    V8_LIBC_GLIBC was true for uClibc as well. Checking for uClibc
    before glibc fixes this and restores the correct behavior.

    Review URL: https://codereview.chromium.org/1066573005

Fixes: https://github.com/nodejs/io.js/issues/1432

R=@jbergstroem or @rvagg?

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/842/