### PR TITLE
build: headers tarball target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,29 @@ doc-upload: tar
 	scp -r out/doc/ $(STAGINGSERVER):staging/$(DISTTYPEDIR)/$(FULLVERSION)/
 	ssh $(STAGINGSERVER) "touch staging/$(DISTTYPEDIR)/$(FULLVERSION)/doc.done"
 
+$(TARBALL)-headers: config.gypi release-only
+	$(PYTHON) ./configure --prefix=/ --dest-cpu=$(DESTCPU) --tag=$(TAG) $(CONFIG_FLAGS)
+	HEADERS_ONLY=1 $(PYTHON) tools/install.py install '$(TARNAME)' '$(PREFIX)'
+	find $(TARNAME)/ -type l | xargs rm # annoying on windows
+	tar -cf $(TARNAME)-headers.tar $(TARNAME)
+	rm -rf $(TARNAME)
+	gzip -c -f -9 $(TARNAME)-headers.tar > $(TARNAME)-headers.tar.gz
+ifeq ($(XZ), 0)
+	xz -c -f -$(XZ_COMPRESSION) $(TARNAME)-headers.tar > $(TARNAME)-headers.tar.xz
+endif
+	rm $(TARNAME)-headers.tar
+
+tar-headers: $(TARBALL)-headers
+
+tar-headers-upload: tar-headers
+	ssh $(STAGINGSERVER) "mkdir -p staging/$(DISTTYPEDIR)/$(FULLVERSION)"
+	scp -p $(TARNAME)-headers.gz $(STAGINGSERVER):staging/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.gz
+	ssh $(STAGINGSERVER) "touch staging/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.gz.done"
+ifeq ($(XZ), 0)
+	scp -p $(TARNAME)-headers.xz $(STAGINGSERVER):staging/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.xz
+	ssh $(STAGINGSERVER) "touch staging/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME)-headers.xz.done"
+endif
+
 $(BINARYTAR): release-only
 	rm -rf $(BINARYNAME)
 	rm -rf out/deps out/Release

--- a/tools/install.py
+++ b/tools/install.py
@@ -156,6 +156,9 @@ def files(action):
 
   if 'true' == variables.get('node_install_npm'): npm_files(action)
 
+  headers(action)
+
+def headers(action):
   action([
     'common.gypi',
     'config.gypi',
@@ -177,7 +180,6 @@ def files(action):
     subdir_files('deps/openssl/openssl/include/openssl', 'include/node/openssl/', action)
     subdir_files('deps/openssl/config/archs', 'include/node/openssl/archs', action)
     action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
-
 
   if 'false' == variables.get('node_shared_zlib'):
     action([
@@ -207,8 +209,14 @@ def run(args):
   install_path = dst_dir + node_prefix + '/'
 
   cmd = args[1] if len(args) > 1 else 'install'
-  if cmd == 'install': return files(install)
-  if cmd == 'uninstall': return files(uninstall)
+
+  if os.environ.get('HEADERS_ONLY'):
+    if cmd == 'install': return headers(install)
+    if cmd == 'uninstall': return headers(uninstall)
+  else:
+    if cmd == 'install': return files(install)
+    if cmd == 'uninstall': return files(uninstall)
+
   raise RuntimeError('Bad command: %s\n' % cmd)
 
 if __name__ == '__main__':


### PR DESCRIPTION
For `make tar-headers` (plus the other options in #1938 for nightlies etc.). Makes a tarball with the headers as they are packaged in binary tarballs - which is different to the source tarball but is better for being used as an includes path for node-gyp et. al.

We will need to get node-gyp to download this file from release directories where it's available. The way I suggest we do that is via #493 which is my next task (YES, YES IT IS!); if node-gyp detects a `process.release.headers_url` (or whatever it ends up being) it knows to download from there and unpack to ~/.node-gyp/. Then we'd need to prepend `include/node` to the list of include directories in addon.gyp (https://github.com/TooTallNate/node-gyp/blob/56b7f9cff21b74421830cf2324545c8420f28e53/addon.gypi#L7-L11) so that it picks up this new directory format but still allows for the old format.

It's worth noting for anyone not aware of this fact but these includes are included in the binary downloads and have been from early 0.10 for all but Windows, so node-gyp shouldn't need to even download anything most of the time. Making node-gyp aware of platform headers is a separate task and should be done but we will always need to make headers available for download in case you're using an executable that hasn't been installed with headers for whatever reason.

```
iojs-v2.3.1/
iojs-v2.3.1/include/
iojs-v2.3.1/include/node/
iojs-v2.3.1/include/node/android-ifaddrs.h
iojs-v2.3.1/include/node/ares.h
iojs-v2.3.1/include/node/ares_version.h
iojs-v2.3.1/include/node/common.gypi
iojs-v2.3.1/include/node/config.gypi
iojs-v2.3.1/include/node/libplatform/
iojs-v2.3.1/include/node/nameser.h
iojs-v2.3.1/include/node/node.h
iojs-v2.3.1/include/node/node_buffer.h
iojs-v2.3.1/include/node/node_internals.h
iojs-v2.3.1/include/node/node_object_wrap.h
iojs-v2.3.1/include/node/node_version.h
iojs-v2.3.1/include/node/openssl/
iojs-v2.3.1/include/node/pthread-fixes.h
iojs-v2.3.1/include/node/smalloc.h
iojs-v2.3.1/include/node/stdint-msvc2008.h
iojs-v2.3.1/include/node/tree.h
iojs-v2.3.1/include/node/uv-aix.h
iojs-v2.3.1/include/node/uv-bsd.h
iojs-v2.3.1/include/node/uv-darwin.h
iojs-v2.3.1/include/node/uv-errno.h
iojs-v2.3.1/include/node/uv-linux.h
iojs-v2.3.1/include/node/uv-sunos.h
iojs-v2.3.1/include/node/uv-threadpool.h
iojs-v2.3.1/include/node/uv-unix.h
iojs-v2.3.1/include/node/uv-version.h
iojs-v2.3.1/include/node/uv-win.h
iojs-v2.3.1/include/node/uv.h
iojs-v2.3.1/include/node/v8-debug.h
iojs-v2.3.1/include/node/v8-platform.h
iojs-v2.3.1/include/node/v8-profiler.h
iojs-v2.3.1/include/node/v8-testing.h
iojs-v2.3.1/include/node/v8-util.h
iojs-v2.3.1/include/node/v8-version.h
iojs-v2.3.1/include/node/v8.h
iojs-v2.3.1/include/node/v8config.h
iojs-v2.3.1/include/node/zconf.h
iojs-v2.3.1/include/node/zlib.h
iojs-v2.3.1/include/node/openssl/aes.h
iojs-v2.3.1/include/node/openssl/archs/
iojs-v2.3.1/include/node/openssl/asn1.h
iojs-v2.3.1/include/node/openssl/asn1_mac.h
iojs-v2.3.1/include/node/openssl/asn1t.h
iojs-v2.3.1/include/node/openssl/bio.h
iojs-v2.3.1/include/node/openssl/blowfish.h
iojs-v2.3.1/include/node/openssl/bn.h
iojs-v2.3.1/include/node/openssl/buffer.h
iojs-v2.3.1/include/node/openssl/camellia.h
iojs-v2.3.1/include/node/openssl/cast.h
iojs-v2.3.1/include/node/openssl/cmac.h
iojs-v2.3.1/include/node/openssl/cms.h
iojs-v2.3.1/include/node/openssl/comp.h
iojs-v2.3.1/include/node/openssl/conf.h
iojs-v2.3.1/include/node/openssl/conf_api.h
iojs-v2.3.1/include/node/openssl/crypto.h
iojs-v2.3.1/include/node/openssl/des.h
iojs-v2.3.1/include/node/openssl/des_old.h
iojs-v2.3.1/include/node/openssl/dh.h
iojs-v2.3.1/include/node/openssl/dsa.h
iojs-v2.3.1/include/node/openssl/dso.h
iojs-v2.3.1/include/node/openssl/dtls1.h
iojs-v2.3.1/include/node/openssl/e_os2.h
iojs-v2.3.1/include/node/openssl/ebcdic.h
iojs-v2.3.1/include/node/openssl/ec.h
iojs-v2.3.1/include/node/openssl/ecdh.h
iojs-v2.3.1/include/node/openssl/ecdsa.h
iojs-v2.3.1/include/node/openssl/engine.h
iojs-v2.3.1/include/node/openssl/err.h
iojs-v2.3.1/include/node/openssl/evp.h
iojs-v2.3.1/include/node/openssl/hmac.h
iojs-v2.3.1/include/node/openssl/idea.h
iojs-v2.3.1/include/node/openssl/krb5_asn.h
iojs-v2.3.1/include/node/openssl/kssl.h
iojs-v2.3.1/include/node/openssl/lhash.h
iojs-v2.3.1/include/node/openssl/md4.h
iojs-v2.3.1/include/node/openssl/md5.h
iojs-v2.3.1/include/node/openssl/mdc2.h
iojs-v2.3.1/include/node/openssl/modes.h
iojs-v2.3.1/include/node/openssl/obj_mac.h
iojs-v2.3.1/include/node/openssl/objects.h
iojs-v2.3.1/include/node/openssl/ocsp.h
iojs-v2.3.1/include/node/openssl/opensslconf.h
iojs-v2.3.1/include/node/openssl/opensslv.h
iojs-v2.3.1/include/node/openssl/ossl_typ.h
iojs-v2.3.1/include/node/openssl/pem.h
iojs-v2.3.1/include/node/openssl/pem2.h
iojs-v2.3.1/include/node/openssl/pkcs12.h
iojs-v2.3.1/include/node/openssl/pkcs7.h
iojs-v2.3.1/include/node/openssl/pqueue.h
iojs-v2.3.1/include/node/openssl/rand.h
iojs-v2.3.1/include/node/openssl/rc2.h
iojs-v2.3.1/include/node/openssl/rc4.h
iojs-v2.3.1/include/node/openssl/ripemd.h
iojs-v2.3.1/include/node/openssl/rsa.h
iojs-v2.3.1/include/node/openssl/safestack.h
iojs-v2.3.1/include/node/openssl/seed.h
iojs-v2.3.1/include/node/openssl/sha.h
iojs-v2.3.1/include/node/openssl/srp.h
iojs-v2.3.1/include/node/openssl/srtp.h
iojs-v2.3.1/include/node/openssl/ssl.h
iojs-v2.3.1/include/node/openssl/ssl2.h
iojs-v2.3.1/include/node/openssl/ssl23.h
iojs-v2.3.1/include/node/openssl/ssl3.h
iojs-v2.3.1/include/node/openssl/stack.h
iojs-v2.3.1/include/node/openssl/symhacks.h
iojs-v2.3.1/include/node/openssl/tls1.h
iojs-v2.3.1/include/node/openssl/ts.h
iojs-v2.3.1/include/node/openssl/txt_db.h
iojs-v2.3.1/include/node/openssl/ui.h
iojs-v2.3.1/include/node/openssl/ui_compat.h
iojs-v2.3.1/include/node/openssl/whrlpool.h
iojs-v2.3.1/include/node/openssl/x509.h
iojs-v2.3.1/include/node/openssl/x509_vfy.h
iojs-v2.3.1/include/node/openssl/x509v3.h
iojs-v2.3.1/include/node/openssl/archs/BSD-x86/
iojs-v2.3.1/include/node/openssl/archs/BSD-x86_64/
iojs-v2.3.1/include/node/openssl/archs/darwin-i386-cc/
iojs-v2.3.1/include/node/openssl/archs/darwin64-x86_64-cc/
iojs-v2.3.1/include/node/openssl/archs/linux-aarch64/
iojs-v2.3.1/include/node/openssl/archs/linux-armv4/
iojs-v2.3.1/include/node/openssl/archs/linux-elf/
iojs-v2.3.1/include/node/openssl/archs/linux-x32/
iojs-v2.3.1/include/node/openssl/archs/linux-x86_64/
iojs-v2.3.1/include/node/openssl/archs/solaris-x86-gcc/
iojs-v2.3.1/include/node/openssl/archs/solaris64-x86_64-gcc/
iojs-v2.3.1/include/node/openssl/archs/VC-WIN32/
iojs-v2.3.1/include/node/openssl/archs/VC-WIN64A/
iojs-v2.3.1/include/node/openssl/archs/VC-WIN64A/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/VC-WIN32/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/solaris64-x86_64-gcc/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/solaris-x86-gcc/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/linux-x86_64/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/linux-x32/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/linux-elf/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/linux-armv4/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/linux-aarch64/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/darwin64-x86_64-cc/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/darwin-i386-cc/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/BSD-x86_64/opensslconf.h
iojs-v2.3.1/include/node/openssl/archs/BSD-x86/opensslconf.h
iojs-v2.3.1/include/node/libplatform/libplatform.h
```

/R=@nodejs/build @TooTallNate 