### PR TITLE
test: tmpdir creation failures should fail tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -52,15 +52,8 @@ function rmdirSync(p, originalEr) {
 }
 
 exports.refreshTmpDir = function() {
-  try {
-    rimrafSync(exports.tmpDir);
-  } catch (e) {
-  }
-
-  try {
-    fs.mkdirSync(exports.tmpDir);
-  } catch (e) {
-  }
+  rimrafSync(exports.tmpDir);
+  fs.mkdirSync(exports.tmpDir);
 };
 
 if (process.env.TEST_THREAD_ID) {


### PR DESCRIPTION
tmpdir creation only happens for tests that need it. So failure to
refresh the temporary directory should result in a failed test.

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/843/

/cc @rvagg who suggested it [here](https://github.com/nodejs/io.js/pull/1877#discussion_r31983389) and @Fishrock123 who suggested it [here](https://github.com/nodejs/io.js/pull/1877#discussion_r32017194)