### PR TITLE
fs: Replace an Error with a deprecation message.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -36,6 +36,8 @@ const isWindows = process.platform === 'win32';
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
 
+const internalUtil = require('internal/util');
+
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +
     'but got ' + typeof options + ' instead');
@@ -1608,6 +1610,8 @@ fs.createReadStream = function(path, options) {
   return new ReadStream(path, options);
 };
 
+var warnedReadStreamOptions = false;
+
 util.inherits(ReadStream, Readable);
 fs.ReadStream = ReadStream;
 
@@ -1619,8 +1623,14 @@ function ReadStream(path, options) {
     options = {};
   else if (typeof options === 'string')
     options = { encoding: options };
-  else if (options === null || typeof options !== 'object')
-    throw new TypeError('options must be a string or an object');
+  else if (options === null || typeof options !== 'object') {
+    warnedReadStreamOptions = internalUtil.printDeprecationMessage(
+      'Passing anything but an object or a string as the second argument to ' +
+      'ReadStream is deprecated.',
+      warnedReadStreamOptions
+    );
+    options = options || {};
+  }
 
   // a little bit bigger buffer and water marks by default
   options = Object.create(options);
@@ -1780,6 +1790,8 @@ fs.createWriteStream = function(path, options) {
   return new WriteStream(path, options);
 };
 
+var warnedWriteStreamOptions = false;
+
 util.inherits(WriteStream, Writable);
 fs.WriteStream = WriteStream;
 function WriteStream(path, options) {
@@ -1790,10 +1802,16 @@ function WriteStream(path, options) {
     options = {};
   else if (typeof options === 'string')
     options = { encoding: options };
-  else if (options === null || typeof options !== 'object')
-    throw new TypeError('options must be a string or an object');
-
-  options = Object.create(options);
+  else if (options === null || typeof options !== 'object') {
+    warnedWriteStreamOptions = internalUtil.printDeprecationMessage(
+      'Passing anything but an object or a string as the second argument to ' +
+      'WriteStream is deprecated.',
+      warnedWriteStreamOptions
+    );
+    options = options || {};
+  } else {
+    options = Object.create(options);
+  }
 
   Writable.call(this, options);
 


### PR DESCRIPTION
This fixes a breaking change in commit 353e26e3c7ed9d160028ea7517d05edbebab5e7d, that was included in a minor version of io.js and broke at least two modules (that were misusing `fs.createWriteStream` method, but still).

_Disclaimer: I am not sure if this is worth fixing, but if it is, this should work._

The two modules I mentioned above were passing a function to fs.createWriteStream, and that was never supported (it was always ignored). In 2.3.0 a more strict options validation was introduced, it started throwing an `Error`, and that two modules (at least) broke.