### PR TITLE
util: fix isBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -3,7 +3,6 @@
 
 const binding = process.binding('buffer');
 const smalloc = process.binding('smalloc');
-const util = require('util');
 const internalUtil = require('internal/util');
 const alloc = smalloc.alloc;
 const truncate = smalloc.truncate;
@@ -457,7 +456,7 @@ Buffer.prototype.fill = function fill(val, start, end) {
 
 
 // XXX remove in v0.13
-Buffer.prototype.get = util.deprecate(function get(offset) {
+Buffer.prototype.get = internalUtil.deprecate(function get(offset) {
   offset = ~~offset;
   if (offset < 0 || offset >= this.length)
     throw new RangeError('index out of range');
@@ -466,7 +465,7 @@ Buffer.prototype.get = util.deprecate(function get(offset) {
 
 
 // XXX remove in v0.13
-Buffer.prototype.set = util.deprecate(function set(offset, v) {
+Buffer.prototype.set = internalUtil.deprecate(function set(offset, v) {
   offset = ~~offset;
   if (offset < 0 || offset >= this.length)
     throw new RangeError('index out of range');

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -16,3 +16,27 @@ exports.printDeprecationMessage = function(msg, warned) {
 
   return true;
 };
+
+// Mark that a method should not be used.
+// Returns a modified function which warns once by default.
+// If --no-deprecation is set, then it is a no-op.
+exports.deprecate = function(fn, msg) {
+  // Allow for deprecating things in the process of starting up.
+  if (global.process === undefined) {
+    return function() {
+      return exports.deprecate(fn, msg).apply(this, arguments);
+    };
+  }
+
+  if (process.noDeprecation === true) {
+    return fn;
+  }
+
+  var warned = false;
+  function deprecated() {
+    warned = exports.printDeprecationMessage(msg, warned);
+    return fn.apply(this, arguments);
+  }
+
+  return deprecated;
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,29 +48,7 @@ exports.format = function(f) {
 };
 
 
-// Mark that a method should not be used.
-// Returns a modified function which warns once by default.
-// If --no-deprecation is set, then it is a no-op.
-exports.deprecate = function(fn, msg) {
-  // Allow for deprecating things in the process of starting up.
-  if (global.process === undefined) {
-    return function() {
-      return exports.deprecate(fn, msg).apply(this, arguments);
-    };
-  }
-
-  if (process.noDeprecation === true) {
-    return fn;
-  }
-
-  var warned = false;
-  function deprecated() {
-    warned = internalUtil.printDeprecationMessage(msg, warned);
-    return fn.apply(this, arguments);
-  }
-
-  return deprecated;
-};
+exports.deprecate = internalUtil.deprecate;
 
 
 var debugs = {};

--- a/lib/util.js
+++ b/lib/util.js
@@ -640,10 +640,7 @@ function isPrimitive(arg) {
 }
 exports.isPrimitive = isPrimitive;
 
-function isBuffer(arg) {
-  return arg instanceof Buffer;
-}
-exports.isBuffer = isBuffer;
+exports.isBuffer = Buffer.isBuffer;
 
 function objectToString(o) {
   return Object.prototype.toString.call(o);

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -71,6 +71,10 @@ assert.equal(true, util.isPrimitive(Infinity));
 assert.equal(true, util.isPrimitive(NaN));
 assert.equal(true, util.isPrimitive(Symbol('symbol')));
 
+// isBuffer
+assert.equal(false, util.isBuffer('foo'));
+assert.equal(true, util.isBuffer(new Buffer('foo')));
+
 // _extend
 assert.deepEqual(util._extend({a:1}),             {a:1});
 assert.deepEqual(util._extend({a:1}, []),         {a:1});


### PR DESCRIPTION
Importing Buffer caused a circular dependency issue. We need to use the
globally exported variable to get around this.

Fixes: https://github.com/nodejs/io.js/issues/1987

This is just quick patch to fix the bug, I hope we can later find a better solution.