### PR TITLE
test: add Buffer slice UTF-8 test

### DIFF
--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -269,6 +269,8 @@ writeTest.write('e', 3, 'ascii');
 writeTest.write('j', 'ascii', 4);
 assert.equal(writeTest.toString(), 'nodejs');
 
+// ASCII slice test
+
 var asciiString = 'hello world';
 var offset = 100;
 
@@ -289,8 +291,25 @@ for (var i = 0; i < asciiString.length; i++) {
   assert.equal(sliceA[i], sliceB[i]);
 }
 
-// TODO utf8 slice tests
+// UTF-8 slice test
 
+var utf8String = '¡hέlló wôrld!';
+var offset = 100;
+
+b.write(utf8String, 0, Buffer.byteLength(utf8String), 'utf8');
+var utf8Slice = b.toString('utf8', 0, Buffer.byteLength(utf8String));
+assert.equal(utf8String, utf8Slice);
+
+var written = b.write(utf8String, offset, 'utf8');
+assert.equal(Buffer.byteLength(utf8String), written);
+utf8Slice = b.toString('utf8', offset, offset + Buffer.byteLength(utf8String));
+assert.equal(utf8String, utf8Slice);
+
+var sliceA = b.slice(offset, offset + Buffer.byteLength(utf8String));
+var sliceB = b.slice(offset, offset + Buffer.byteLength(utf8String));
+for (var i = 0; i < Buffer.byteLength(utf8String); i++) {
+  assert.equal(sliceA[i], sliceB[i]);
+}
 
 var slice = b.slice(100, 150);
 assert.equal(50, slice.length);


### PR DESCRIPTION
Gets rid of another `TODO` comment in the tests.

Thing is, I'm not sure this is really needed. There seem to be things in other places in this test file that  would trigger `utf8Slice()`, at least on casual inspection.

So...@chrisdickinson: I know you ran some code coverage analysis recently. Any chance you could run code coverage on just the one file that's changed here and compare it to the results with the version in master to see if this change results in slightly more coverage? Or point me at the code coverage tool you used and I'll try to get up and running with it to do this myself?