### PR TITLE
lib: allow long paths for require on Windows

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -67,7 +67,7 @@ function readPackage(requestPath) {
   }
 
   var jsonPath = path.resolve(requestPath, 'package.json');
-  var json = internalModuleReadFile(jsonPath);
+  var json = internalModuleReadFile(path._makeLong(jsonPath));
 
   if (json === undefined) {
     return false;
@@ -100,7 +100,7 @@ Module._realpathCache = {};
 
 // check if the file exists and is not a directory
 function tryFile(requestPath) {
-  const rc = internalModuleStat(requestPath);
+  const rc = internalModuleStat(path._makeLong(requestPath));
   return rc === 0 && toRealPath(requestPath);
 }
 
@@ -146,7 +146,7 @@ Module._findPath = function(request, paths) {
     var filename;
 
     if (!trailingSlash) {
-      const rc = internalModuleStat(basePath);
+      const rc = internalModuleStat(path._makeLong(basePath));
       if (rc === 0) {  // File.
         filename = toRealPath(basePath);
       } else if (rc === 1) {  // Directory.

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -1,0 +1,17 @@
+'use strict';
+var common = require('../common');
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+
+// make a path that will be at least 260 chars long.
+var fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
+var fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
+var fullPath = path.resolve(fileName);
+
+common.refreshTmpDir();
+fs.writeFileSync(fullPath, 'module.exports = 42;');
+
+assert.equal(require(fullPath), 42);
+
+fs.unlinkSync(fullPath);


### PR DESCRIPTION
https://github.com/nodejs/io.js/pull/1801 introduced internal fs methods to speed up require.
The methods do not call path._makeLong like their counterpart
from the fs module. This brings back the old behaviour.

Fixes: https://github.com/nodejs/io.js/issues/1990
Fixes: https://github.com/nodejs/io.js/issues/1980