### PR TITLE
fs: Accept a function as an options container.

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1619,7 +1619,8 @@ function ReadStream(path, options) {
     options = {};
   else if (typeof options === 'string')
     options = { encoding: options };
-  else if (options === null || typeof options !== 'object')
+  else if (options === null ||
+           typeof options !== 'object' && typeof options !== 'function')
     throw new TypeError('options must be a string or an object');
 
   // a little bit bigger buffer and water marks by default
@@ -1790,7 +1791,8 @@ function WriteStream(path, options) {
     options = {};
   else if (typeof options === 'string')
     options = { encoding: options };
-  else if (options === null || typeof options !== 'object')
+  else if (options === null ||
+           typeof options !== 'object' && typeof options !== 'function')
     throw new TypeError('options must be a string or an object');
 
   options = Object.create(options);


### PR DESCRIPTION
This is alternate to https://github.com/nodejs/io.js/pull/1982

This should fix a breaking change in commit 353e26e3c7ed9d160028ea7517d05edbebab5e7d, that was included in a minor version of io.js and broke at least two modules (that were misusing `fs.createWriteStream` method, but still).

Those two modules were passing a function to `fs.createWriteStream`, and that was never supported (it was always ignored). In 2.3.0 a more strict options validation was introduced, it started throwing an `Error`, and at least those two modules were broken.

This patch uses a simple way to get around that, treating a `function` as a valid options container.

Apart from `function`s, 353e26e3c7ed9d160028ea7517d05edbebab5e7d changed the behaviour on falsy variables (`null` and `0` started causing an `Error`), and that is not addressed in this PR. I could fix that, replacing the `options === undefined` with a `!options` check (that would involve changing the expectations of several tests). What do you think?

@yosuke-furukawa, @chrisdickinson 

Fixes: https://github.com/nodejs/io.js/issues/1981