### PR TITLE
vm: remove unnecessary HandleScopes

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -362,7 +362,6 @@ class ContextifyContext {
       Local<String> property,
       const PropertyCallbackInfo<Value>& args) {
     Isolate* isolate = args.GetIsolate();
-    HandleScope scope(isolate);
 
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
@@ -387,7 +386,6 @@ class ContextifyContext {
       Local<Value> value,
       const PropertyCallbackInfo<Value>& args) {
     Isolate* isolate = args.GetIsolate();
-    HandleScope scope(isolate);
 
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
@@ -400,7 +398,6 @@ class ContextifyContext {
       Local<String> property,
       const PropertyCallbackInfo<Integer>& args) {
     Isolate* isolate = args.GetIsolate();
-    HandleScope scope(isolate);
 
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
@@ -422,7 +419,6 @@ class ContextifyContext {
       Local<String> property,
       const PropertyCallbackInfo<Boolean>& args) {
     Isolate* isolate = args.GetIsolate();
-    HandleScope scope(isolate);
 
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
@@ -435,8 +431,6 @@ class ContextifyContext {
 
   static void GlobalPropertyEnumeratorCallback(
       const PropertyCallbackInfo<Array>& args) {
-    HandleScope scope(args.GetIsolate());
-
     ContextifyContext* ctx =
         Unwrap<ContextifyContext>(args.Data().As<Object>());
 


### PR DESCRIPTION
The accessors run inside an implicit HandleScope, there is no need to
create a new one.

R=@trevnorris?

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/37/