### PR TITLE
test: check result as early as possible

### DIFF
--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -47,12 +47,10 @@ server.listen(common.PORT, function() {
         var s = fs.createWriteStream(common.tmpDir + '/' + x + '.jpg');
         res.pipe(s);
 
-        // TODO there should be a callback to pipe() that will allow
-        // us to get a callback when the pipe is finished.
-        res.on('end', function() {
+        s.on('finish', function() {
           console.error('done ' + x);
           if (++responses == total) {
-            s.on('close', checkFiles);
+            checkFiles();
           }
         });
       }).on('error', function(e) {


### PR DESCRIPTION
Remove nested event listeners. Listen to pipe's `finish` event as it seems to be the earliest event to fire once results can be checked. Minor positive-ish effects:

* Code is slightly easier to understand. (It wasn't that hard in the first place, though.)

* In my non-scientific highly-questionable benchmarking on my laptop, the test seems to run approximately 10ms faster.

* Allows us to remove a `TODO` comment in the tests