### PR TITLE
buffer: prevent abort on bad proto

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -380,8 +380,6 @@ function slowToString(encoding, start, end) {
 
 Buffer.prototype.toString = function() {
   const length = this.length | 0;
-  if (length === 0)
-    return '';
   if (arguments.length === 0)
     return this.utf8Slice(0, length);
   return slowToString.apply(this, arguments);

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const Buffer = require('buffer').Buffer;
+const Bp = Buffer.prototype;
+
+function FakeBuffer() { }
+FakeBuffer.__proto__ = Buffer;
+FakeBuffer.prototype.__proto__ = Buffer.prototype;
+
+const fb = new FakeBuffer();
+
+assert.throws(function() {
+  new Buffer(fb);
+}, TypeError);
+
+assert.throws(function() {
+  +Buffer.prototype;
+}, TypeError);
+
+assert.throws(function() {
+  Buffer.compare(fb, new Buffer(0));
+}, TypeError);
+
+assert.throws(function() {
+  fb.write('foo');
+}, TypeError);
+
+assert.throws(function() {
+  Buffer.concat([fb, fb]);
+}, TypeError);
+
+assert.throws(function() {
+  fb.toString();
+}, TypeError);
+
+assert.throws(function() {
+  fb.equals(new Buffer(0));
+}, TypeError);
+
+assert.throws(function() {
+  fb.indexOf(5);
+}, TypeError);
+
+assert.throws(function() {
+  fb.readFloatLE(0);
+}, TypeError);
+
+assert.throws(function() {
+  fb.writeFloatLE(0);
+}, TypeError);
+
+assert.throws(function() {
+  fb.fill(0);
+}, TypeError);


### PR DESCRIPTION
If an object's prototype is munged it's possible to bypass the
instanceof check and cause the application to abort. Instead now use
HasInstance() to verify that the object is a Buffer, and throw if not.

This check will not work for JS only methods. So while the application
won't abort, it also won't throw.

Replaces: https://github.com/nodejs/io.js/pull/1486

R=@bnoordhuis 

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/48/