### PR TITLE
module: fix stat with long paths on windows

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -143,7 +143,7 @@ Module._findPath = function(request, paths) {
   // For each path
   for (var i = 0, PL = paths.length; i < PL; i++) {
     // Don't search further if path doesn't exist
-    if (paths[i] && internalModuleStat(paths[i]) < 1) continue;
+    if (paths[i] && internalModuleStat(path._makeLong(paths[i])) < 1) continue;
     var basePath = path.resolve(paths[i], request);
     var filename;
 

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -1,17 +1,23 @@
 'use strict';
-var common = require('../common');
-var fs = require('fs');
-var path = require('path');
-var assert = require('assert');
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
 
 // make a path that is more than 260 chars long.
-var fileNameLen = Math.max(261 - common.tmpDir.length - 1, 1);
-var fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
-var fullPath = path.resolve(fileName);
+const dirNameLen = Math.max(260 - common.tmpDir.length, 1);
+const dirName = path.join(common.tmpDir, 'x'.repeat(dirNameLen));
+const fullDirPath = path.resolve(dirName);
+
+const indexFile = path.join(fullDirPath, 'index.js');
+const otherFile = path.join(fullDirPath, 'other.js');
 
 common.refreshTmpDir();
-fs.writeFileSync(fullPath, 'module.exports = 42;');
 
-assert.equal(require(fullPath), 42);
+fs.mkdirSync(fullDirPath);
+fs.writeFileSync(indexFile, 'require("./other");');
+fs.writeFileSync(otherFile, '');
 
-fs.unlinkSync(fullPath);
+require(indexFile);
+require(otherFile);
+
+common.refreshTmpDir();


### PR DESCRIPTION
Fix from #2011 with is an updated regression test that fails without the patch.

### v2.2.1
```
Error: Cannot find module 'D:\Documents\GitHub\io.js\test\tmp\xxxxxxxxxxxxxxxxxx
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\index.js'
```

### master
```
Error: Cannot find module './other'
```

### master with fix
```

```
No error !