### PR TITLE
test: assert tmp and fixture dirs different

### DIFF
--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -40,6 +40,7 @@ function tmp(p) {
 
 var fixturesAbsDir = common.fixturesDir;
 var tmpAbsDir = common.tmpDir;
+assert(fixturesAbsDir !== tmpAbsDir);
 
 console.error('absolutes\n%s\n%s', fixturesAbsDir, tmpAbsDir);
 
@@ -298,8 +299,6 @@ function test_deep_symlink_mix(callback) {
     return runNextTest();
   }
 
-  // todo: check to see that common.fixturesDir is not rooted in the
-  //       same directory as our test symlink.
   /*
   /tmp/node-test-realpath-f1 -> ../tmp/node-test-realpath-d1/foo
   /tmp/node-test-realpath-d1 -> ../node-test-realpath-d2


### PR DESCRIPTION
I suspect the `todo` comment eliminated here is obsolete and/or overkill, but `assert()` put in place just in case...

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/56/ 