### PR TITLE
build: DTrace is enabled by default on darwin

### DIFF
--- a/configure
+++ b/configure
@@ -230,7 +230,7 @@ parser.add_option('--with-mips-float-abi',
 parser.add_option('--with-dtrace',
     action='store_true',
     dest='with_dtrace',
-    help='build with DTrace (default is true on sunos)')
+    help='build with DTrace (default is true on sunos and darwin)')
 
 parser.add_option('--with-lttng',
     action='store_true',


### PR DESCRIPTION
In configure, the --with-dtrace option only showed that it was true by
default on sunos. It is also true by default on darwin.