### PR TITLE
test: make pipe test Windows-compatible

### DIFF
--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -3,41 +3,19 @@ var common = require('../common');
 var assert = require('assert');
 var path = require('path');
 
-// simulate `cat readfile.js | node readfile.js`
-
-// TODO: Have some way to make this work on windows.
-if (process.platform === 'win32') {
-  console.error('No /dev/stdin on windows.  Skipping test.');
-  process.exit();
-}
-
 var fs = require('fs');
 
-var filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
+var pipe = common.PIPE;
 var dataExpected = new Array(1000000).join('a');
 common.refreshTmpDir();
-fs.writeFileSync(filename, dataExpected);
+fs.writeFileSync(pipe, dataExpected);
 
-if (process.argv[2] === 'child') {
-  fs.readFile('/dev/stdin', function(er, data) {
-    if (er) throw er;
-    process.stdout.write(data);
-  });
-  return;
-}
-
-var exec = require('child_process').exec;
-var f = JSON.stringify(__filename);
-var node = JSON.stringify(process.execPath);
-var cmd = 'cat ' + filename + ' | ' + node + ' ' + f + ' child';
-exec(cmd, { maxBuffer: 1000000 }, function(err, stdout, stderr) {
-  if (err) console.error(err);
-  assert(!err, 'it exits normally');
-  assert(stdout === dataExpected, 'it reads the file and outputs it');
-  assert(stderr === '', 'it does not write to stderr');
-  console.log('ok');
+fs.readFile(pipe, function(er, data) {
+  if (er) throw er;
+  process.stdout.write(data);
+  assert(data.toString() === dataExpected, 'data read is same as data written');
 });
 
 process.on('exit', function() {
-  fs.unlinkSync(filename);
+  fs.unlinkSync(pipe);
 });


### PR DESCRIPTION
The existing test reads `/dev/stdin` instead of using a FIFO pipe created by Node.

* You can't run the existing test on Windows because `/dev/stdin` does not exist on Windows.

* Reading `/dev/stdin` with `fs.readFile()` seems to be a non-idiomatic approach to reading `stdin`with a big dependency on non-universal OS behavior.

* The test in this PR is easier to understand and easier to maintain.

(If this is met with general approval, there are two more tests that would get a similar overhaul in subsequent PRs.)