### PR TITLE
util: moving internal helpers to internal module

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const internalUtil = require('internal/util');
 const debug = util.debuglog('child_process');
 const constants = require('constants');
 
@@ -10,7 +11,7 @@ const Buffer = require('buffer').Buffer;
 const Pipe = process.binding('pipe_wrap').Pipe;
 const child_process = require('internal/child_process');
 
-const errnoException = util._errnoException;
+const errnoException = internalUtil._errnoException;
 const _validateStdio = child_process._validateStdio;
 const setupChannel = child_process.setupChannel;
 const ChildProcess = exports.ChildProcess = child_process.ChildProcess;

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const Buffer = require('buffer').Buffer;
 const util = require('util');
+const internalUtil = require('internal/util');
 const events = require('events');
 const constants = require('constants');
 
@@ -17,8 +18,8 @@ const BIND_STATE_BOUND = 2;
 var cluster = null;
 var dns = null;
 
-const errnoException = util._errnoException;
-const exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = internalUtil._errnoException;
+const exceptionWithHostPort = internalUtil._exceptionWithHostPort;
 
 function lookup(address, family, callback) {
   if (!dns)

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -2,6 +2,7 @@
 
 const net = require('net');
 const util = require('util');
+const internalUtil = require('internal/util');
 
 const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
@@ -27,7 +28,7 @@ function errnoException(err, syscall, hostname) {
     ex.errno = err;
     ex.syscall = syscall;
   } else {
-    ex = util._errnoException(err, syscall);
+    ex = internalUtil._errnoException(err, syscall);
   }
   if (hostname) {
     ex.hostname = hostname;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -5,6 +5,7 @@
 
 const SlowBuffer = require('buffer').SlowBuffer;
 const util = require('util');
+const internalUtil = require('internal/util');
 const pathModule = require('path');
 
 const binding = process.binding('fs');
@@ -34,7 +35,7 @@ const O_WRONLY = constants.O_WRONLY || 0;
 const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
-const errnoException = util._errnoException;
+const errnoException = internalUtil._errnoException;
 
 function throwOptionsError(options) {
   throw new TypeError('Expected options to be either an object or a string, ' +

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -6,6 +6,7 @@ const EventEmitter = require('events').EventEmitter;
 const net = require('net');
 const dgram = require('dgram');
 const util = require('util');
+const internalUtil = require('internal/util');
 const constants = require('constants');
 const assert = require('assert');
 
@@ -18,7 +19,7 @@ const TCP = process.binding('tcp_wrap').TCP;
 const UDP = process.binding('udp_wrap').UDP;
 const SocketList = require('internal/socket_list');
 
-const errnoException = util._errnoException;
+const errnoException = internalUtil._errnoException;
 const SocketListSend = SocketList.SocketListSend;
 const SocketListReceive = SocketList.SocketListReceive;
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const uv = process.binding('uv');
+
 exports.printDeprecationMessage = function(msg, warned) {
   if (process.noDeprecation)
     return true;
@@ -39,4 +41,43 @@ exports.deprecate = function(fn, msg) {
   }
 
   return deprecated;
+};
+
+exports._errnoException = function(err, syscall, original) {
+  const errname = uv.errname(err);
+  var message = syscall + ' ' + errname;
+
+  if (original)
+    message += ' ' + original;
+
+  const e = new Error(message);
+  e.code = errname;
+  e.errno = errname;
+  e.syscall = syscall;
+
+  return e;
+};
+
+
+exports._exceptionWithHostPort = function(err, syscall, address, port, extra) {
+  var details;
+
+  if (port && port > 0) {
+    details = address + ':' + port;
+  } else {
+    details = address;
+  }
+
+  if (extra) {
+    details += ' - Local (' + extra + ')';
+  }
+
+  const ex = exports._errnoException(err, syscall, details);
+
+  ex.address = address;
+  if (port) {
+    ex.port = port;
+  }
+
+  return ex;
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -4,6 +4,7 @@ const events = require('events');
 const stream = require('stream');
 const timers = require('timers');
 const util = require('util');
+const internalUtil = require('internal/util');
 const assert = require('assert');
 const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
@@ -19,8 +20,8 @@ const WriteWrap = process.binding('stream_wrap').WriteWrap;
 
 
 var cluster;
-const errnoException = util._errnoException;
-const exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = internalUtil._errnoException;
+const exceptionWithHostPort = internalUtil._exceptionWithHostPort;
 
 function noop() {}
 

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const util = require('util');
+const internalUtil = require('internal/util');
 const net = require('net');
 const TTY = process.binding('tty_wrap').TTY;
 const isTTY = process.binding('tty_wrap').isTTY;
 const inherits = util.inherits;
-const errnoException = util._errnoException;
+const errnoException = internalUtil._errnoException;
 
 
 exports.isatty = function(fd) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const uv = process.binding('uv');
 const Buffer = require('buffer').Buffer;
 const Debug = require('vm').runInDebugContext('Debug');
 const internalUtil = require('internal/util');
@@ -806,38 +805,10 @@ exports.pump = exports.deprecate(function(readStream, writeStream, callback) {
 }, 'util.pump(): Use readableStream.pipe() instead');
 
 
-exports._errnoException = function(err, syscall, original) {
-  var errname = uv.errname(err);
-  var message = syscall + ' ' + errname;
-  if (original)
-    message += ' ' + original;
-  var e = new Error(message);
-  e.code = errname;
-  e.errno = errname;
-  e.syscall = syscall;
-  return e;
-};
+exports._errnoException = internalUtil.deprecate(
+  internalUtil._errnoException,
+  'util._errnoException is deprecated.');
 
-
-exports._exceptionWithHostPort = function(err,
-                                          syscall,
-                                          address,
-                                          port,
-                                          additional) {
-  var details;
-  if (port && port > 0) {
-    details = address + ':' + port;
-  } else {
-    details = address;
-  }
-
-  if (additional) {
-    details += ' - Local (' + additional + ')';
-  }
-  var ex = exports._errnoException(err, syscall, details);
-  ex.address = address;
-  if (port) {
-    ex.port = port;
-  }
-  return ex;
-};
+exports._exceptionWithHostPort = internalUtil.deprecate(
+  internalUtil._exceptionWithHostPort,
+  'util._exceptionWithHostPort is deprecated.');


### PR DESCRIPTION
1. Moving `_errnoException` and `_exceptionWithHostPort` to
   `internal/util` module as they are internal helper functions. They
   should not be exposed as part of the `util` module.

2. Issuing a deprecation warning when those functions are used.