### PR TITLE
test: regression for `fs` module monkey-patching

### DIFF
--- a/test/parallel/test-fs-monkey-patch-regression.js
+++ b/test/parallel/test-fs-monkey-patch-regression.js
@@ -1,0 +1,13 @@
+// This is the same code from
+// https://github.com/isaacs/node-graceful-fs/blob/master/fs.js just to test
+// if we don't break userland modules which monkey-patches the native `fs`.
+
+'use strict';
+
+var mod = require('module');
+var pre = '(function (exports, require, module, __filename, __dirname) { ';
+var post = '});';
+var src = pre + process.binding('natives').fs + post;
+var vm = require('vm');
+var fn = vm.runInThisContext(src);
+fn(exports, require, module, __filename, __dirname);


### PR DESCRIPTION
The https://github.com/nodejs/io.js/pull/2025 breaks graceful-fs module. To catch the accidental breaking like this, this PR introduces a test to make sure that the native `fs` module is monkey-patchable.