### PR TITLE
fs: fix StatWatcher to handle error codes

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1278,7 +1278,7 @@ function StatWatcher() {
 
   this._handle.onchange = function(current, previous, newStatus) {
     if (oldStatus === -1 &&
-        newStatus === -1 &&
+        newStatus < 0 &&
         current.nlink === previous.nlink) return;
 
     oldStatus = newStatus;

--- a/test/parallel/test-fs-watch-file-nonexistent.js
+++ b/test/parallel/test-fs-watch-file-nonexistent.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var fs = require('fs');
+
+var filename = '/path/to/file/that/does/not/exist';
+
+fs.watchFile(filename, function() {
+  throw new Error('callback should not be called for non-existent files');
+});
+
+setTimeout(function() {
+  fs.unwatchFile(filename);
+}, 10);


### PR DESCRIPTION
Previously, `fs.watchFile()` would call the callback even if the file does
not exist. This is erroneous and is fixed by correctly handling the
error code provided.

Ref: https://github.com/joyent/node/pull/25469
Fixes: https://github.com/nodejs/io.js/issues/1745

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/65/
I just grabbed the commit from joyent/node and doctored it up to fit the new code guidelines for io.js (just the test), squashed and redid the commit log. A note to reviewers: `fs.watchFile` is not covered *at all* by the test suite, do not rely on that for checking backwards compatibility.