### PR TITLE
test: remove obsolete TODO comments for fs.read

### DIFF
--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -2,10 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-// TODO Improved this test. test_ca.pem is too small. A proper test would
-// great a large utf8 (with multibyte chars) file and stream it in,
-// performing sanity checks throughout.
-
 var path = require('path');
 var fs = require('fs');
 var fn = path.join(common.fixturesDir, 'elipses.txt');

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -2,10 +2,6 @@
 var common = require('../common');
 var assert = require('assert');
 
-// TODO Improved this test. test_ca.pem is too small. A proper test would
-// great a large utf8 (with multibyte chars) file and stream it in,
-// performing sanity checks throughout.
-
 var path = require('path');
 var fs = require('fs');
 var fn = path.join(common.fixturesDir, 'elipses.txt');


### PR DESCRIPTION
Not using test_ca.pem in these files anymore.
Using elipses.txt which has multibyte chars.
Not clear what constitutes "large" but that
can be a different ticket if elipses.txt etc.
are insufficiently large.