### PR TITLE
test: check for error on Windows

### DIFF
--- a/test/parallel/test-dgram-bind-shared-ports.js
+++ b/test/parallel/test-dgram-bind-shared-ports.js
@@ -4,15 +4,20 @@ var assert = require('assert');
 var cluster = require('cluster');
 var dgram = require('dgram');
 
-// TODO XXX FIXME when windows supports clustered dgram ports re-enable this
-// test
-if (process.platform == 'win32')
-  process.exit(0);
-
 function noop() {}
 
 if (cluster.isMaster) {
   var worker1 = cluster.fork();
+
+  if (common.isWindows) {
+    var checkErrType = function(er) {
+      assert.equal(er.code, 'ENOTSUP');
+      worker1.kill();
+    };
+
+    worker1.on('error', common.mustCall(checkErrType, 1));
+    return;
+  }
 
   worker1.on('message', function(msg) {
     assert.equal(msg, 'success');


### PR DESCRIPTION
Instead of not running the dgram-bind-shared-ports
on Windows, check that it gets ENOTSUP.

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/70/