### PR TITLE
Uniform ip family values

### DIFF
--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -424,7 +424,7 @@ Local<Object> AddressToJS(Environment* env,
     uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
     port = ntohs(a6->sin6_port);
     info->Set(env->address_string(), OneByteString(env->isolate(), ip));
-    info->Set(env->family_string(), env->ipv6_string());
+    info->Set(env->family_string(), Integer::New(env->isolate(), 6));
     info->Set(env->port_string(), Integer::New(env->isolate(), port));
     break;
 
@@ -433,7 +433,7 @@ Local<Object> AddressToJS(Environment* env,
     uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
     port = ntohs(a4->sin_port);
     info->Set(env->address_string(), OneByteString(env->isolate(), ip));
-    info->Set(env->family_string(), env->ipv4_string());
+    info->Set(env->family_string(), Integer::New(env->isolate(), 4));
     info->Set(env->port_string(), Integer::New(env->isolate(), port));
     break;
 

--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -5,7 +5,7 @@ var dgram = require('dgram');
 
 // IPv4 Test
 var socket_ipv4 = dgram.createSocket('udp4');
-var family_ipv4 = 'IPv4';
+var family_ipv4 = 4;
 
 socket_ipv4.on('listening', function() {
   var address_ipv4 = socket_ipv4.address();
@@ -25,7 +25,7 @@ socket_ipv4.bind(common.PORT, common.localhostIPv4);
 // IPv6 Test
 var localhost_ipv6 = '::1';
 var socket_ipv6 = dgram.createSocket('udp6');
-var family_ipv6 = 'IPv6';
+var family_ipv6 = 6;
 
 socket_ipv6.on('listening', function() {
   var address_ipv6 = socket_ipv6.address();

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -9,8 +9,8 @@ var conns = 0, conns_closed = 0;
 var remoteAddrCandidates = [ common.localhostIPv4 ];
 if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
 
-var remoteFamilyCandidates = ['IPv4'];
-if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
+var remoteFamilyCandidates = [4];
+if (common.hasIPv6) remoteFamilyCandidates.push(6);
 
 var server = net.createServer(function(socket) {
   conns++;

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -86,7 +86,7 @@ switch (platform) {
     var filter = function(e) { return e.address == '127.0.0.1'; };
     var actual = interfaces.lo.filter(filter);
     var expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
-                      mac: '00:00:00:00:00:00', family: 'IPv4',
+                      mac: '00:00:00:00:00:00', family: 4,
                       internal: true }];
     assert.deepEqual(actual, expected);
     break;
@@ -94,7 +94,7 @@ switch (platform) {
     var filter = function(e) { return e.address == '127.0.0.1'; };
     var actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
     var expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
-                      mac: '00:00:00:00:00:00', family: 'IPv4',
+                      mac: '00:00:00:00:00:00', family: 4,
                       internal: true }];
     assert.deepEqual(actual, expected);
     break;

--- a/test/sequential/test-net-server-address.js
+++ b/test/sequential/test-net-server-address.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var net = require('net');
 
 // Test on IPv4 Server
-var family_ipv4 = 'IPv4';
+var family_ipv4 = 4;
 var server_ipv4 = net.createServer();
 
 server_ipv4.on('error', function(e) {
@@ -21,7 +21,7 @@ server_ipv4.listen(common.PORT, common.localhostIPv4, function() {
 
 // Test on IPv6 Server
 var localhost_ipv6 = '::1';
-var family_ipv6 = 'IPv6';
+var family_ipv6 = 6;
 var server_ipv6 = net.createServer();
 
 server_ipv6.on('error', function(e) {

--- a/test/sequential/test-net-server-bind.js
+++ b/test/sequential/test-net-server-bind.js
@@ -74,7 +74,7 @@ process.on('exit', function() {
 
   var expectedConnectionKey1;
 
-  if (address1.family === 'IPv6')
+  if (address1.family === 6)
     expectedConnectionKey1 = '6::::' + address1.port;
   else
     expectedConnectionKey1 = '4:0.0.0.0:' + address1.port;


### PR DESCRIPTION
Fix for enhancement proposed at https://github.com/joyent/node/issues/4873 and later PR at https://github.com/joyent/node/pull/25560, but suggested for io.js `next`

Of course, looking for thoughts if it makes sense for everyone to have numbers instead of strings, for IP family values.