### PR TITLE
REPL fixes

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -994,7 +994,7 @@ function isRecoverableError(e, self) {
       self._inTemplateLiteral = true;
       return true;
     }
-    return /^(Unexpected end of input|Unexpected token :)/.test(message);
+    return /^(Unexpected end of input|Unexpected token)/.test(message);
   }
   return false;
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -611,9 +611,7 @@ REPLServer.prototype.complete = function(line, callback) {
       if (!expr) {
         // If context is instance of vm.ScriptContext
         // Get global vars synchronously
-        if (this.useGlobal ||
-            this.context.constructor &&
-            this.context.constructor.name === 'Context') {
+        if (this.useGlobal || vm.isContext(this.context)) {
           var contextProto = this.context;
           while (contextProto = Object.getPrototypeOf(contextProto)) {
             completionGroups.push(Object.getOwnPropertyNames(contextProto));

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -206,3 +206,13 @@ testMe.complete('require(\'n', function(error, data) {
   assert.strictEqual(error, null);
   assert.deepEqual(data, [['net'], 'n']);
 });
+
+// Make sure tab completion works on context properties
+putIn.run(['.clear']);
+
+putIn.run([
+  'var custom = "test";'
+]);
+testMe.complete('cus', function(error, data) {
+  assert.deepEqual(data, [['custom'], 'cus']);
+});

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -1,0 +1,33 @@
+'use strict';
+/*
+ * This is a regression test for https://github.com/joyent/node/issues/8874.
+ */
+var common = require('../common');
+var assert = require('assert');
+
+var spawn = require('child_process').spawn;
+// use -i to force node into interactive mode, despite stdout not being a TTY
+var args = [ '-i' ];
+var child = spawn(process.execPath, args);
+
+var input = 'var foo = "bar\\\nbaz"';
+// Match '...' as well since it marks a multi-line statement
+var expectOut = /^> ... undefined\n/;
+
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', function(c) {
+  throw new Error('child.stderr be silent');
+});
+
+child.stdout.setEncoding('utf8');
+var out = '';
+child.stdout.on('data', function(c) {
+  out += c;
+});
+
+child.stdout.on('end', function() {
+  assert(expectOut.test(out));
+  console.log('ok');
+});
+
+child.stdin.end(input);


### PR DESCRIPTION
This PR contains three commits:

- A port of https://github.com/joyent/node/issues/8874, which has already landed on joyent/node.
- A port of https://github.com/joyent/node/pull/25382, which has not yet landed.
- A new commit, which fixes `test-repl-tab-complete.js`, which was silently not working as expected. The test was relying on assertions that were never executed.