### PR TITLE
net: wrap connect in nextTick

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -925,7 +925,9 @@ function lookupAndConnect(self, options) {
   // TODO(evanlucas) should we hot path this for localhost?
   var addressType = exports.isIP(host);
   if (addressType) {
-    connect(self, host, port, addressType, localAddress, localPort);
+    process.nextTick(function() {
+      connect(self, host, port, addressType, localAddress, localPort);
+    });
     return;
   }
 


### PR DESCRIPTION
Fixes an edge case regression introduced in
1bef71747678c19c7214048de5b9e3848889248d.

With the lookup being skipped, an error could be emitted before and
error listener has been added.

An example of this was presented by changing the server’s IP address
and then immediately making a request to the old address.

Related: https://github.com/nodejs/io.js/pull/1823