### PR TITLE
test: do not use valid public hosts for timeout testing

### DIFF
--- a/test/internet/test-net-connect-timeout.js
+++ b/test/internet/test-net-connect-timeout.js
@@ -2,8 +2,6 @@
 // This example attempts to time out before the connection is established
 // https://groups.google.com/forum/#!topic/nodejs/UE0ZbfLt6t8
 // https://groups.google.com/forum/#!topic/nodejs-dev/jR7-5UDqXkw
-//
-// TODO: how to do this without relying on the responses of specific sites?
 
 var common = require('../common');
 var net = require('net');
@@ -11,61 +9,34 @@ var assert = require('assert');
 
 var start = new Date();
 
-var gotTimeout0 = false;
-var gotTimeout1 = false;
+var gotTimeout = false;
 
-var gotConnect0 = false;
-var gotConnect1 = false;
+var gotConnect = false;
 
 var T = 100;
 
 
-// With DNS
+// 240.*.*.*.* is "reserved for future use"
+var socket = net.createConnection(9999, '240.0.0.0');
 
-var socket0 = net.createConnection(9999, 'google.com');
+socket.setTimeout(T);
 
-socket0.setTimeout(T);
-
-socket0.on('timeout', function() {
+socket.on('timeout', function() {
   console.error('timeout');
-  gotTimeout0 = true;
+  gotTimeout = true;
   var now = new Date();
   assert.ok(now - start < T + 500);
-  socket0.destroy();
+  socket.destroy();
 });
 
-socket0.on('connect', function() {
+socket.on('connect', function() {
   console.error('connect');
-  gotConnect0 = true;
-  socket0.destroy();
-});
-
-
-// Without DNS
-
-var socket1 = net.createConnection(9999, '24.24.24.24');
-
-socket1.setTimeout(T);
-
-socket1.on('timeout', function() {
-  console.error('timeout');
-  gotTimeout1 = true;
-  var now = new Date();
-  assert.ok(now - start < T + 500);
-  socket1.destroy();
-});
-
-socket1.on('connect', function() {
-  console.error('connect');
-  gotConnect1 = true;
-  socket1.destroy();
+  gotConnect = true;
+  socket.destroy();
 });
 
 
 process.on('exit', function() {
-  assert.ok(gotTimeout0);
-  assert.ok(!gotConnect0);
-
-  assert.ok(gotTimeout1);
-  assert.ok(!gotConnect1);
+  assert.ok(gotTimeout);
+  assert.ok(!gotConnect);
 });


### PR DESCRIPTION
A couple of assumptions I've made:

* Purpose of the `test/internet` directory: Is it just tests that rely on an internet connection but really shouldn't ideally? Or is that an incorrect assumption? (Is it documented anywhere?) Now that this one doesn't rely on a working internet connection, should it be moved to `test/parallel` instead?

* DNS lookup vs. no DNS lookup seems irrelevant in the context of testing socket timeout so I removed the DNS lookup one. (I couldn't figure out a reasonable way to do it that didn't involve internet connectivity. It needs to do a DNS lookup, after all.) Am I missing something or does that seem about right?

Additional information that may be useful:

* `240.0.0.0` might, theoretically, be used at some future time. But that is unlikely. And even so, it's still a better choice for the foreseeable future than a valid Time-Warner IP, which is what it seems the previous one was.

* There is a "discard" prefix address in IPv6 that would be useful here, but I couldn't get it to work. I'm reluctant to file a bug report because the problem is likely just my IPv6 ignorance.

