### PR TITLE
crypto: fix VerifyCallback in case of verify error

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2310,7 +2310,7 @@ inline CheckResult CheckWhitelistedServerCert(X509_STORE_CTX* ctx) {
 inline int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx) {
   // Failure on verification of the cert is handled in
   // Connection::VerifyError.
-  if (preverify_ok == 0)
+  if (preverify_ok == 0 || X509_STORE_CTX_get_error(ctx) != X509_V_OK)
     return 1;
 
   // Server does not need to check the whitelist.


### PR DESCRIPTION
3beb880716654dbb2bbb9e333758825172951775 has a bug in VerifyCallback when preverify is 1 and the cert chain has an verify error. If the error is UNABLE_TO_GET_ISSUER_CERT_LOCALLY, it leads an assertion error in finding rootCA.
The whitelist check should be made only when the cert chain has no verify error with X509_V_OK.

Fixes: https://github.com/nodejs/io.js/issues/2061

CI of https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/87/  are green except one failure of test-debug-port-from-cmdline.js on win2012r2. It's not related with this fix.

 `make test-internet `are fine and the result of a test shown by the issue reporter of #2061 is below.
```sh
$ ./iojs -e "require('tls').connect(443, '143.116.116.84');"
events.js:141
      throw er; // Unhandled 'error' event
            ^
Error: certificate has expired
    at Error (native)
    at TLSSocket.<anonymous> (_tls_wrap.js:965:38)
    at emitNone (events.js:67:13)
    at TLSSocket.emit (events.js:166:7)
    at TLSSocket._finishInit (_tls_wrap.js:546:8)
````
The error code is different because UNABLE_TO_GET_ISSUER_CERT_LOCALLY is overwritten by CERT_HAS_EXPIRED according to the order of verify checks.

R= @bnoordhuis 