### PR TITLE
Make it possible to build iojs with ninja

### DIFF
--- a/tools/gyp/pylib/gyp/generator/ninja.py
+++ b/tools/gyp/pylib/gyp/generator/ninja.py
@@ -1169,7 +1169,7 @@ class NinjaWriter(object):
         ldflags.append(r'-Wl,-rpath=\$$ORIGIN/%s' % rpath)
         ldflags.append('-Wl,-rpath-link=%s' % rpath)
     self.WriteVariableList(ninja_file, 'ldflags',
-                           gyp.common.uniquer(map(self.ExpandSpecial, ldflags)))
+                           map(self.ExpandSpecial, ldflags))
 
     library_dirs = config.get('library_dirs', [])
     if self.flavor == 'win':


### PR DESCRIPTION
This change fixes link-time error when building iojs with ninja instead of make. The following commands now work fine:

$ ./tools/gyp_node.gyp -f ninja
$ ninja -C out/Release iojs -j100

The patch is going to be merged into gyp (https://codereview.chromium.org/1209553002/). The more details about why this change is necessary can be found in the mentioned codereview.
