### PR TITLE
node-gyp: temporary fixes to support nightlies & rc builds, download header tarball only

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -5,6 +5,7 @@
     'product_prefix': '',
 
     'include_dirs': [
+      '<(node_root_dir)/include/node',
       '<(node_root_dir)/src',
       '<(node_root_dir)/deps/uv/include',
       '<(node_root_dir)/deps/v8/include'

--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -39,8 +39,8 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
-
+  var defaultUrl = getDefaultIojsUrl(process.version)
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || defaultUrl
 
   // Determine which node dev files version we are installing
   var versionStr = argv[0] || gyp.opts.target || process.version
@@ -454,4 +454,27 @@ function install (gyp, argv, callback) {
     gyp.commands.install(argv, cb)
   }
 
+}
+
+
+// pick out 'nightly', 'next-nightly' or 'rc' from the version string if it's there
+// adjust URL accordingly
+function getDefaultIojsUrl(version) {
+  var versionMatch = version.match(/^v\d+\.\d+\.\d+-(?:(?:(nightly|next-nightly)\d{8}[0-9a-f]{10})|(?:(rc)\d+))$/)
+  var distType = versionMatch ? versionMatch[1] || versionMatch[2] : 'release'
+  var defaultUrl = `https://iojs.org/download/${distType}`
+  return defaultUrl
+}
+
+
+if (require.main === module) {
+  var assert = require('assert')
+  console.log('test v2.3.4 -> https://iojs.org/download/release')
+  assert(getDefaultIojsUrl('v2.3.4', 'https://iojs.org/download/release'))
+  console.log('test v2.3.4-nightly12345678aaaaaaaaaa -> https://iojs.org/download/nightly')
+  assert(getDefaultIojsUrl('v2.3.4-nightly12345678aaaaaaaaaa', 'https://iojs.org/download/nightly'))
+  console.log('test v2.3.4-next-nightly12345678aaaaaaaaaa -> https://iojs.org/download/release/next-nightly')
+  assert(getDefaultIojsUrl('v2.3.4-next-nightly12345678aaaaaaaaaa', 'https://iojs.org/download/next-nightly'))
+  console.log('test v2.3.4-rc100 -> https://iojs.org/download/rc')
+  assert(getDefaultIojsUrl('v2.3.4-rc100', 'https://iojs.org/download/rc'))
 }

--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
 
       // now download the node tarball
       var tarPath = gyp.opts['tarball']
-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
+      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '-headers.tar.gz'
         , badDownload = false
         , extractCount = 0
         , gunzip = zlib.createGunzip()


### PR DESCRIPTION
I'd like to get these two commits on to `next` as a ***temporary*** measure to:

**make node-gyp aware of `nightly`, `next-nightly` and `rc` binaries and download the files from the right locations for these.**

Primarily I'd like this so that nightlies and rc builds become actually useful to people so we can get testers. Also we can make a better case for getting a new NAN released if the RC builds for 3.0 will actually use it without any hackery.

Ultimately I need to get the [`process.release`](https://github.com/nodejs/io.js/pull/493) work finished and the additional node-gyp changes which would nullify the need for this change completely but getting that through the node-gyp -> npm -> io.js process is going to take a while. When that's all done we can stop floating all of these patches.

**make node-gyp only download the new headers tarball that we are producing, it's under 200k and has everything needed for most cases.**

These header tarballs are in the same format as the headers that ship with the binary tarballs and installers (except windows) and the ideal has been for node-gyp to be aware of platform headers and use them where it makes sense to avoid downloading all together. So far nobody has done that work and even when it's done we'll still need the ability to download headers (for multiple reasons).

The catch here is that the headers tarball format does not match the source tarball format. There is a change in addon.gypi to accommodate this change in a backward-compatible way (adds `include/node` to the includes path, the existing ones become redundant when using the headers tarball). This is OK for most uses, _BUT_ where addons are using header files that don't belong to Node, V8 or libuv then we get into a sticky situation. The only usage of that type that I'm aware of in the ecosystem is addons using the bundled openssl. [bignum](https://github.com/justmoon/node-bignum/blob/master/binding.gyp#L45) is probably the most popular addon that uses this technique. We'd just need get authors to add backward-compatible fixes to these to make them work (I have publish rights to bignum so that's easy). IMO, we may as well get this over and done with in 3.0 because we're probably going to have to do it some time.

/cc @nodejs/build @othiym23 @TooTallNate 