### PR TITLE
url: fix typo in comment

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -162,7 +162,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     //
     // ex:
     // http://a@b@c/ => user:a@b host:c
-    // http://a@b?@c => user:a host:c path:/?@c
+    // http://a@b?@c => user:a host:b path:/?@c
 
     // v0.12 TODO(isaacs): This is not quite how Chrome does things.
     // Review our test case against browsers more comprehensively.


### PR DESCRIPTION
Checked against results of `url.parse()` to make sure this was right.

<strike>(Not sure about the subsequent comment that indicates this isn't the way Chrome does it. It is, as far as I can tell. Perhaps it's referring to some specific nuance that escapes me. I'll dig through the logs a bit more to see if I can get more information. But if you, kind reader, have an idea, hey, clue me, kthxbai.)</strike> (Found the info: https://github.com/nodejs/io.js/commit/5dc51d4e215b658a0fefe9d5eebc22f80747cd0b)