### PR TITLE
repl: remove obsolete TODO

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -855,7 +855,6 @@ function addStandardGlobals(completionGroups, filter) {
 }
 
 function defineDefaultCommands(repl) {
-  // TODO remove me after 0.3.x
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
     action: function() {


### PR DESCRIPTION
It's long past v0.3.0 and .break isn't going anywhere anytime soon.

(Aside: You may think all I do is sit around evaluating "TODO" comments. You would not be wrong.)