### PR TITLE
src: update comment for NODE_MODULE_VERSION

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -40,6 +40,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 45  /* io.js v2.0.0 */
+#define NODE_MODULE_VERSION 45  /* io.js v3.0.0 */
 
 #endif  /* SRC_NODE_VERSION_H_ */


### PR DESCRIPTION
I updated `NODE_MODULE_VERSION` to `45` but failed to update the comment, thanks @mzgol for picking this up. I pushed it through without review because it was needed for an RC2 of 3.0 but the lack of review was the downfall here. Sorry!