### PR TITLE
benchmark: Add remaining path benchmarks & optimize

### DIFF
--- a/benchmark/path/basename.js
+++ b/benchmark/path/basename.js
@@ -12,14 +12,15 @@ function main(conf) {
   var p = path[conf.type];
 
   // Force optimization before starting the benchmark
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  p.basename('/foo/bar/baz/asdf/quux.html');
   v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.resolve)');
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  eval('%OptimizeFunctionOnNextCall(p.basename)');
+  p.basename('/foo/bar/baz/asdf/quux.html');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+    p.basename('/foo/bar/baz/asdf/quux.html');
+    p.basename('/foo/bar/baz/asdf/quux.html', '.html');
   }
   bench.end(n);
 }

--- a/benchmark/path/dirname.js
+++ b/benchmark/path/dirname.js
@@ -12,14 +12,14 @@ function main(conf) {
   var p = path[conf.type];
 
   // Force optimization before starting the benchmark
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  p.dirname('/foo/bar/baz/asdf/quux');
   v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.resolve)');
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  eval('%OptimizeFunctionOnNextCall(p.dirname)');
+  p.dirname('/foo/bar/baz/asdf/quux');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+    p.dirname('/foo/bar/baz/asdf/quux');
   }
   bench.end(n);
 }

--- a/benchmark/path/extname.js
+++ b/benchmark/path/extname.js
@@ -12,14 +12,15 @@ function main(conf) {
   var p = path[conf.type];
 
   // Force optimization before starting the benchmark
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  p.extname('index.html');
   v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.resolve)');
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  eval('%OptimizeFunctionOnNextCall(p.extname)');
+  p.extname('index.html');
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+    p.extname('index.html');
+    p.extname('index');
   }
   bench.end(n);
 }

--- a/benchmark/path/format.js
+++ b/benchmark/path/format.js
@@ -1,5 +1,6 @@
 var common = require('../common.js');
 var path = require('path');
+var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: ['win32', 'posix'],
@@ -22,6 +23,12 @@ function main(conf) {
     ext : '.html',
     name : 'index'
   };
+
+  // Force optimization before starting the benchmark
+  p.format(test);
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(p.format)');
+  p.format(test);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/isAbsolute.js
+++ b/benchmark/path/isAbsolute.js
@@ -1,5 +1,6 @@
 var common = require('../common.js');
 var path = require('path');
+var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: ['win32', 'posix'],
@@ -12,6 +13,12 @@ function main(conf) {
   var tests = conf.type === 'win32'
     ? ['//server', 'C:\\baz\\..', 'bar\\baz', '.']
     : ['/foo/bar', '/baz/..', 'bar/baz', '.'];
+
+  // Force optimization before starting the benchmark
+  p.isAbsolute(tests[0]);
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(p.isAbsolute)');
+  p.isAbsolute(tests[0]);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/join.js
+++ b/benchmark/path/join.js
@@ -1,5 +1,6 @@
 var common = require('../common.js');
 var path = require('path');
+var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: ['win32', 'posix'],
@@ -9,6 +10,12 @@ var bench = common.createBenchmark(main, {
 function main(conf) {
   var n = +conf.n;
   var p = path[conf.type];
+
+  // Force optimization before starting the benchmark
+  p.join('/foo', 'bar', '', 'baz/asdf', 'quux', '..');
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(p.join)');
+  p.join('/foo', 'bar', '', 'baz/asdf', 'quux', '..');
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/normalize.js
+++ b/benchmark/path/normalize.js
@@ -1,5 +1,6 @@
 var common = require('../common.js');
 var path = require('path');
+var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: ['win32', 'posix'],
@@ -9,6 +10,12 @@ var bench = common.createBenchmark(main, {
 function main(conf) {
   var n = +conf.n;
   var p = path[conf.type];
+
+  // Force optimization before starting the benchmark
+  p.normalize('/foo/bar//baz/asdf/quux/..');
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(p.normalize)');
+  p.normalize('/foo/bar//baz/asdf/quux/..');
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/parse.js
+++ b/benchmark/path/parse.js
@@ -10,16 +10,19 @@ var bench = common.createBenchmark(main, {
 function main(conf) {
   var n = +conf.n;
   var p = path[conf.type];
+  var test = conf.type === 'win32'
+    ? 'C:\\path\\dir\\index.html'
+    : '/home/user/dir/index.html';
 
   // Force optimization before starting the benchmark
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  p.parse(test);
   v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.resolve)');
-  p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+  eval('%OptimizeFunctionOnNextCall(p.parse)');
+  p.parse(test);
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    p.resolve('foo/bar', '/tmp/file/', '..', 'a/../subfile');
+    p.parse(test);
   }
   bench.end(n);
 }

--- a/benchmark/path/relative.js
+++ b/benchmark/path/relative.js
@@ -1,5 +1,6 @@
 var common = require('../common.js');
 var path = require('path');
+var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: ['win32', 'posix'],
@@ -9,6 +10,12 @@ var bench = common.createBenchmark(main, {
 function main(conf) {
   var n = +conf.n;
   var runTest = conf.type === 'win32' ? runWin32Test : runPosixTest;
+
+  // Force optimization before starting the benchmark
+  runTest();
+  v8.setFlagsFromString('--allow_natives_syntax');
+  eval('%OptimizeFunctionOnNextCall(path[conf.type].relative)');
+  runTest();
 
   bench.start();
   for (var i = 0; i < n; i++) {


### PR DESCRIPTION
As a follow-up to 0d15161, this commit adds benchmarks for the rest of the path functions and also forces V8 to optimize the functions before starting the benchmark test (as suggested in a comment by @evanlucas).