### PR TITLE
readline: fix freeze if `keypress` event throws

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -910,7 +910,15 @@ function emitKeypressEvents(stream) {
       var r = stream[KEYPRESS_DECODER].write(b);
       if (r) {
         for (var i = 0; i < r.length; i++) {
-          stream[ESCAPE_DECODER].next(r[i]);
+          try {
+            stream[ESCAPE_DECODER].next(r[i]);
+          } catch (err) {
+            // if the generator throws (it could happen in the `keypress`
+            // event), we need to restart it.
+            stream[ESCAPE_DECODER] = emitKeys(stream);
+            stream[ESCAPE_DECODER].next();
+            throw err;
+          }
         }
       }
     } else {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -192,6 +192,24 @@ function isWarned(emitter) {
   assert.equal(callCount, 1);
   rli.close();
 
+  // Regression test for repl freeze, #1968:
+  // check that nothing fails if 'keypress' event throws.
+  fi = new FakeInput();
+  rli = new readline.Interface({ input: fi, output: fi, terminal: true });
+  var keys = [];
+  fi.on('keypress', function(key) {
+    keys.push(key);
+    if (key === 'X') {
+      throw new Error('bad thing happened');
+    }
+  });
+  try {
+    fi.emit('data', 'fooX');
+  } catch(e) { }
+  fi.emit('data', 'bar');
+  assert.equal(keys.join(''), 'fooXbar');
+  rli.close();
+
   // calling readline without `new`
   fi = new FakeInput();
   rli = readline.Interface({ input: fi, output: fi, terminal: terminal });


### PR DESCRIPTION
The issue is described here: https://github.com/nodejs/io.js/pull/1968

I consider `keypress` event in readline a public api, and if such a handler throws, readline should continue to work normally.

Basically, I see are two good ways to deal with it:

 1. restart the generator when it errors out
 2. throw an error in the next tick

Since everything in readline is synchronous now, adding `nextTick` would break things. So I went with option 1.

This PR fixes a particular bug. But avoiding throwing in repl might still be a good idea. So PR https://github.com/nodejs/io.js/pull/1968 might still make sense, but as a refactor, not a bugfix (I'll let someone else to review it though).

// cc: @monsanto 