### PR TITLE
test: formatting skip messages for TAP parsing

### DIFF
--- a/test/internet/test-http-https-default-ports.js
+++ b/test/internet/test-http-https-default-ports.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/internet/test-tls-connnect-cnnic.js
+++ b/test/internet/test-tls-connnect-cnnic.js
@@ -11,7 +11,7 @@
 var common = require('../common');
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var tls = require('tls');

--- a/test/internet/test-tls-connnect-melissadata.js
+++ b/test/internet/test-tls-connnect-melissadata.js
@@ -5,7 +5,7 @@
 var common = require('../common');
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var tls = require('tls');

--- a/test/internet/test-tls-reuse-host-from-socket.js
+++ b/test/internet/test-tls-reuse-host-from-socket.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -6,7 +6,7 @@ var net = require('net');
 
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: not reliable on Windows.');
-  process.exit(0);
+  return;
 }
 
 if (process.getuid() === 0) {

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -5,7 +5,7 @@ var cluster = require('cluster');
 var net = require('net');
 
 if (process.platform === 'win32') {
-  console.log('Skipping test, not reliable on Windows.');
+  console.log('1..0 # Skipped: not reliable on Windows.');
   process.exit(0);
 }
 

--- a/test/parallel/test-cluster-disconnect-unshared-udp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-udp.js
@@ -1,6 +1,6 @@
 'use strict';
 if (process.platform === 'win32') {
-  console.log('skipping test on windows, where clustered dgram is ENOTSUP');
+  console.log('1..0 # Skipped: on windows, because clustered dgram is ENOTSUP');
   process.exit(0);
 }
 

--- a/test/parallel/test-cluster-disconnect-unshared-udp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-udp.js
@@ -1,7 +1,7 @@
 'use strict';
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: on windows, because clustered dgram is ENOTSUP');
-  process.exit(0);
+  return;
 }
 
 var cluster = require('cluster');

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -5,12 +5,12 @@ var cluster = require('cluster');
 var net = require('net');
 
 if (process.platform === 'win32') {
-  console.log('Skipping test, not reliable on Windows.');
+  console.log('1..0 # Skipped: not reliable on Windows');
   process.exit(0);
 }
 
 if (process.getuid() === 0) {
-  console.log('Do not run this test as root.');
+  console.log('1..0 # Skipped: as this test should not be run as `root`');
   process.exit(0);
 }
 

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -6,12 +6,12 @@ var net = require('net');
 
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: not reliable on Windows');
-  process.exit(0);
+  return;
 }
 
 if (process.getuid() === 0) {
   console.log('1..0 # Skipped: as this test should not be run as `root`');
-  process.exit(0);
+  return;
 }
 
 if (cluster.isMaster) {

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -56,7 +56,7 @@ for (var i in TEST_CASES) {
   var test = TEST_CASES[i];
 
   if (ciphers.indexOf(test.algo) == -1) {
-    console.log('skipping unsupported ' + test.algo + ' test');
+    console.log('1..0 # Skipped: unsupported ' + test.algo + ' test');
     continue;
   }
 

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -9,7 +9,7 @@ var constants = require('constants');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 var tls = require('tls');

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-dh-odd-key.js
+++ b/test/parallel/test-crypto-dh-odd-key.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -5,7 +5,7 @@ var constants = require('constants');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-domain.js
+++ b/test/parallel/test-crypto-domain.js
@@ -5,7 +5,7 @@ var domain = require('domain');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-domains.js
+++ b/test/parallel/test-crypto-domains.js
@@ -8,7 +8,7 @@ var errors = 0;
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-ecb.js
+++ b/test/parallel/test-crypto-ecb.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-from-binary.js
+++ b/test/parallel/test-crypto-from-binary.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-hash-stream-pipe.js
+++ b/test/parallel/test-crypto-hash-stream-pipe.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -6,7 +6,7 @@ var path = require('path');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -6,7 +6,7 @@ var constants = require('constants');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -6,7 +6,7 @@ var util = require('util');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 var tls = require('tls');

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -5,7 +5,7 @@ var util = require('util');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-dgram-bind-default-address.js
+++ b/test/parallel/test-dgram-bind-default-address.js
@@ -16,7 +16,7 @@ dgram.createSocket('udp4').bind(common.PORT + 0, common.mustCall(function() {
 }));
 
 if (!common.hasIPv6) {
-  console.error('Skipping udp6 part of test, no IPv6 support');
+  console.log('1..0 # Skipped: udp6 part of test, because no IPv6 support');
   return;
 }
 

--- a/test/parallel/test-dgram-bind-default-address.js
+++ b/test/parallel/test-dgram-bind-default-address.js
@@ -6,7 +6,7 @@ var dgram = require('dgram');
 // skip test in FreeBSD jails since 0.0.0.0 will resolve to default interface
 if (common.inFreeBSDJail) {
   console.log('1..0 # Skipped: In a FreeBSD jail');
-  process.exit();
+  return;
 }
 
 dgram.createSocket('udp4').bind(common.PORT + 0, common.mustCall(function() {

--- a/test/parallel/test-dgram-empty-packet.js
+++ b/test/parallel/test-dgram-empty-packet.js
@@ -9,7 +9,7 @@ var client;
 var timer;
 
 if (process.platform === 'darwin') {
-  console.error('Test is disabled due to 17894467 Apple bug');
+  console.log('1..0 # Skipped: because of 17894467 Apple bug');
   return;
 }
 

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -8,7 +8,7 @@ var callbacks = 0;
 var client, timer, buf;
 
 if (process.platform === 'darwin') {
-  console.error('Test is disabled due to 17894467 Apple bug');
+  console.log('1..0 # Skipped: because of 17894467 Apple bug');
   return;
 }
 

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -7,7 +7,7 @@ var path = require('path');
 // `fs.readFile('/')` does not fail on FreeBSD, because you can open and read
 // the directory there.
 if (process.platform === 'freebsd') {
-  console.error('Skipping test, platform not supported.');
+  console.log('1..0 # Skipped: platform not supported.');
   process.exit();
 }
 

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -8,7 +8,7 @@ var path = require('path');
 // the directory there.
 if (process.platform === 'freebsd') {
   console.log('1..0 # Skipped: platform not supported.');
-  process.exit();
+  return;
 }
 
 var callbacks = 0;

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: No /dev/stdin on windows.');
-  process.exit();
+  return;
 }
 
 var fs = require('fs');

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -6,7 +6,7 @@ var path = require('path');
 // simulate `cat readfile.js | node readfile.js`
 
 if (process.platform === 'win32') {
-  console.error('No /dev/stdin on windows.  Skipping test.');
+  console.log('1..0 # Skipped: No /dev/stdin on windows.');
   process.exit();
 }
 

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: No /dev/stdin on windows.');
-  process.exit();
+  return;
 }
 
 var fs = require('fs');

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 // simulate `cat readfile.js | node readfile.js`
 
 if (process.platform === 'win32') {
-  console.error('No /dev/stdin on windows.  Skipping test.');
+  console.log('1..0 # Skipped: No /dev/stdin on windows.');
   process.exit();
 }
 

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: No /dev/stdin on windows.');
-  process.exit();
+  return;
 }
 
 var fs = require('fs');

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -6,7 +6,7 @@ var path = require('path');
 // simulate `cat readfile.js | node readfile.js`
 
 if (process.platform === 'win32') {
-  console.error('No /dev/stdin on windows.  Skipping test.');
+  console.log('1..0 # Skipped: No /dev/stdin on windows.');
   process.exit();
 }
 

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -80,7 +80,7 @@ function test_simple_error_callback(cb) {
 function test_simple_relative_symlink(callback) {
   console.log('test_simple_relative_symlink');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
   var entry = common.tmpDir + '/symlink',
@@ -143,7 +143,7 @@ function test_simple_absolute_symlink(callback) {
 function test_deep_relative_file_symlink(callback) {
   console.log('test_deep_relative_file_symlink');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
 
@@ -175,7 +175,7 @@ function test_deep_relative_file_symlink(callback) {
 function test_deep_relative_dir_symlink(callback) {
   console.log('test_deep_relative_dir_symlink');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
   var expected = path.join(common.fixturesDir, 'cycles', 'folder');
@@ -207,7 +207,7 @@ function test_deep_relative_dir_symlink(callback) {
 function test_cyclic_link_protection(callback) {
   console.log('test_cyclic_link_protection');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
   var entry = common.tmpDir + '/cycles/realpath-3a';
@@ -230,7 +230,7 @@ function test_cyclic_link_protection(callback) {
 function test_cyclic_link_overprotection(callback) {
   console.log('test_cyclic_link_overprotection');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
   var cycles = common.tmpDir + '/cycles';
@@ -251,7 +251,7 @@ function test_cyclic_link_overprotection(callback) {
 function test_relative_input_cwd(callback) {
   console.log('test_relative_input_cwd');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
 
@@ -295,7 +295,7 @@ function test_deep_symlink_mix(callback) {
   if (isWindows) {
     // This one is a mix of files and directories, and it's quite tricky
     // to get the file/dir links sorted out correctly.
-    console.log('skipping symlink test (no way to work on windows)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
 
@@ -391,7 +391,7 @@ assert.equal(upone, uponeActual,
 function test_up_multiple(cb) {
   console.error('test_up_multiple');
   if (skipSymlinks) {
-    console.log('skipping symlink test (no privs)');
+    console.log('1..0 # Skipped: symlink test (no privs)');
     return runNextTest();
   }
   function cleanup() {

--- a/test/parallel/test-http-curl-chunk-problem.js
+++ b/test/parallel/test-http-curl-chunk-problem.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 // http://groups.google.com/group/nodejs/browse_thread/thread/f66cd3c960406919

--- a/test/parallel/test-http-curl-chunk-problem.js
+++ b/test/parallel/test-http-curl-chunk-problem.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 var assert = require('assert');
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-http-full-response.js
+++ b/test/parallel/test-http-full-response.js
@@ -27,7 +27,7 @@ function runAb(opts, callback) {
   exec(command, function(err, stdout, stderr) {
     if (err) {
       if (/ab|apr/mi.test(stderr)) {
-        console.log('problem spawning ab - skipping test.\n' + stderr);
+        console.log('1..0 # Skipped: problem spawning `ab`.\n' + stderr);
         process.reallyExit(0);
       }
       process.exit();

--- a/test/parallel/test-http-localaddress.js
+++ b/test/parallel/test-http-localaddress.js
@@ -5,7 +5,7 @@ var http = require('http'),
 
 if (!common.hasMultiLocalhost()) {
   console.log('1..0 # Skipped: platform-specific test.');
-  process.exit();
+  return;
 }
 
 var server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-localaddress.js
+++ b/test/parallel/test-http-localaddress.js
@@ -4,7 +4,7 @@ var http = require('http'),
     assert = require('assert');
 
 if (!common.hasMultiLocalhost()) {
-  console.log('Skipping platform-specific test.');
+  console.log('1..0 # Skipped: platform-specific test.');
   process.exit();
 }
 

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-agent-servername.js
+++ b/test/parallel/test-https-agent-servername.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var https = require('https');

--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -6,7 +6,7 @@ var http = require('http');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-client-checkServerIdentity.js
+++ b/test/parallel/test-https-client-checkServerIdentity.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-client-reject.js
+++ b/test/parallel/test-https-client-reject.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-connecting-to-http.js
+++ b/test/parallel/test-https-connecting-to-http.js
@@ -7,7 +7,7 @@ var http = require('http');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -12,7 +12,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 var tls = require('tls');

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -3,7 +3,7 @@ var common = require('../common');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 var assert = require('assert');
@@ -14,7 +14,7 @@ var spawn = require('child_process').spawn;
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-https-host-headers.js
+++ b/test/parallel/test-https-host-headers.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -5,13 +5,13 @@ var common = require('../common'),
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 
 if (!common.hasMultiLocalhost()) {
   console.log('1..0 # Skipped: platform-specific test.');
-  process.exit();
+  return;
 }
 
 var options = {

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -10,7 +10,7 @@ if (!common.hasCrypto) {
 var https = require('https');
 
 if (!common.hasMultiLocalhost()) {
-  console.log('Skipping platform-specific test.');
+  console.log('1..0 # Skipped: platform-specific test.');
   process.exit();
 }
 

--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-req-split.js
+++ b/test/parallel/test-https-req-split.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -24,7 +24,7 @@ if (!haveIntl) {
       '"Intl" object is NOT present but v8_enable_i18n_support is ' +
       enablei18n;
   assert.equal(enablei18n, false, erMsg);
-  console.log('Skipping Intl tests because Intl object not present.');
+  console.log('1..0 # Skipped: Intl tests because Intl object not present.');
 
 } else {
   var erMsg =
@@ -46,8 +46,8 @@ if (!haveIntl) {
 
   // If list is specified and doesn't contain 'en' then return.
   if (process.config.variables.icu_locales && !haveLocale('en')) {
-    console.log('Skipping detailed Intl tests because English is not listed ' +
-                'as supported.');
+    console.log('1..0 # Skipped: detailed Intl tests because English is not ' +
+                'listed as supported.');
     // Smoke test. Does it format anything, or fail?
     console.log('Date(0) formatted to: ' + dtf.format(date0));
     return;

--- a/test/parallel/test-listen-fd-cluster.js
+++ b/test/parallel/test-listen-fd-cluster.js
@@ -10,7 +10,7 @@ var cluster = require('cluster');
 console.error('Cluster listen fd test', process.argv.slice(2));
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
+  console.log('1..0 # Skipped: This test is disabled on windows.');
   return;
 }
 

--- a/test/parallel/test-listen-fd-detached-inherit.js
+++ b/test/parallel/test-listen-fd-detached-inherit.js
@@ -7,7 +7,7 @@ var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
+  console.log('1..0 # Skipped: This test is disabled on windows.');
   return;
 }
 

--- a/test/parallel/test-listen-fd-detached.js
+++ b/test/parallel/test-listen-fd-detached.js
@@ -7,7 +7,7 @@ var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
+  console.log('1..0 # Skipped: This test is disabled on windows.');
   return;
 }
 

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -7,7 +7,7 @@ var PORT = common.PORT;
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.error('This test is disabled on windows.');
+  console.log('1..0 # Skipped: This test is disabled on windows.');
   return;
 }
 

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -14,7 +14,7 @@ var dlerror_msg = error_desc[process.platform];
 
 if (!dlerror_msg) {
   console.log('1..0 # Skipped: platform not supported.');
-  process.exit();
+  return;
 }
 
 try {

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -13,7 +13,7 @@ var error_desc = {
 var dlerror_msg = error_desc[process.platform];
 
 if (!dlerror_msg) {
-  console.error('Skipping test, platform not supported.');
+  console.log('1..0 # Skipped: platform not supported.');
   process.exit();
 }
 

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -5,7 +5,7 @@ var net = require('net');
 var dns = require('dns');
 
 if (!common.hasIPv6) {
-  console.error('Skipping test, no IPv6 support');
+  console.log('1..0 # Skipped: no IPv6 support');
   return;
 }
 

--- a/test/parallel/test-process-getgroups.js
+++ b/test/parallel/test-process-getgroups.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 
 if (process.platform === 'darwin') {
-  console.log('Skipping. Output of `id -G` is unreliable on Darwin.');
+  console.log('1..0 # Skipped: Output of `id -G` is unreliable on Darwin.');
   return;
 }
 

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var spawn = require('child_process').spawn;
 
 if (process.platform === 'win32') {
-  console.log('Skipping test, platform not supported.');
+  console.log('1..0 # Skipped: platform not supported.');
   return;
 }
 

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -5,7 +5,7 @@ var stream = require('stream');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -4,12 +4,12 @@ var assert = require('assert');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var tls = require('tls');

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -4,12 +4,12 @@ var assert = require('assert');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -3,7 +3,7 @@ var common = require('../common');
 var assert = require('assert');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-async-cb-after-socket-end.js
+++ b/test/parallel/test-tls-async-cb-after-socket-end.js
@@ -9,7 +9,7 @@ var constants = require('constants');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var tls = require('tls');

--- a/test/parallel/test-tls-cert-regression.js
+++ b/test/parallel/test-tls-cert-regression.js
@@ -4,7 +4,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-check-server-identity.js
+++ b/test/parallel/test-tls-check-server-identity.js
@@ -5,7 +5,7 @@ var util = require('util');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-abort2.js
+++ b/test/parallel/test-tls-client-abort2.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-default-ciphers.js
+++ b/test/parallel/test-tls-client-default-ciphers.js
@@ -4,7 +4,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-reject.js
+++ b/test/parallel/test-tls-client-reject.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -5,7 +5,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -4,7 +4,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var tls = require('tls');

--- a/test/parallel/test-tls-connect-given-socket.js
+++ b/test/parallel/test-tls-connect-given-socket.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -3,7 +3,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 var fs = require('fs');

--- a/test/parallel/test-tls-delayed-attach.js
+++ b/test/parallel/test-tls-delayed-attach.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-destroy-whilst-write.js
+++ b/test/parallel/test-tls-destroy-whilst-write.js
@@ -4,7 +4,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 var stream = require('stream');

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-econnreset.js
+++ b/test/parallel/test-tls-econnreset.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-friendly-error-message.js
+++ b/test/parallel/test-tls-friendly-error-message.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -5,7 +5,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-handshake-nohang.js
+++ b/test/parallel/test-tls-handshake-nohang.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-hello-parser-failure.js
+++ b/test/parallel/test-tls-hello-parser-failure.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-interleave.js
+++ b/test/parallel/test-tls-interleave.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -3,7 +3,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 var fs = require('fs');

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 var fs = require('fs');

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -3,7 +3,7 @@ var common = require('../common');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-no-sslv23.js
+++ b/test/parallel/test-tls-no-sslv23.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 
@@ -13,7 +13,7 @@ var spawn = require('child_process').spawn;
 
 if (common.opensslCli === false) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 var cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem');

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -12,7 +12,7 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 
 if (common.opensslCli === false) {
-  console.error('Skipping because openssl command cannot be executed');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -1,7 +1,7 @@
 'use strict';
 if (!process.features.tls_npn) {
-  console.error('Skipping because node compiled without OpenSSL or ' +
-                'with old OpenSSL version.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
+              'with old OpenSSL version.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -11,7 +11,7 @@ var common = require('../common'),
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -2,12 +2,12 @@
 var common = require('../common');
 
 if (!process.features.tls_ocsp) {
-  console.error('Skipping because node compiled without OpenSSL or ' +
-                'with old OpenSSL version.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
+              'with old OpenSSL version.');
   process.exit(0);
 }
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -8,12 +8,12 @@ if (!process.features.tls_ocsp) {
 }
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-on-empty-socket.js
+++ b/test/parallel/test-tls-on-empty-socket.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-pause.js
+++ b/test/parallel/test-tls-pause.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -3,7 +3,7 @@ var common = require('../common');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 // This is a rather complex test which sets up various TLS servers with node
@@ -101,7 +101,7 @@ var testCases =
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -3,12 +3,12 @@ var common = require('../common');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 doTest({ tickets: false }, function() {

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -3,12 +3,12 @@ var common = require('../common');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var assert = require('assert');

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -1,7 +1,7 @@
 'use strict';
 if (!process.features.tls_sni) {
-  console.error('Skipping because node compiled without OpenSSL or ' +
-                'with old OpenSSL version.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
+              'with old OpenSSL version.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -11,7 +11,7 @@ var common = require('../common'),
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -1,7 +1,7 @@
 'use strict';
 if (!process.features.tls_sni) {
-  console.error('Skipping because node compiled without OpenSSL or ' +
-                'with old OpenSSL version.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
+              'with old OpenSSL version.');
   process.exit(0);
 }
 

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -11,7 +11,7 @@ var common = require('../common'),
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-timeout-server-2.js
+++ b/test/parallel/test-tls-timeout-server-2.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/parallel/test-tty-wrap.js
+++ b/test/parallel/test-tty-wrap.js
@@ -7,7 +7,7 @@ var isTTY = process.binding('tty_wrap').isTTY;
 
 if (isTTY(1) == false) {
   console.log('1..0 # Skipped: fd 1 is not a tty.');
-  process.exit(0);
+  return;
 }
 
 var handle = new TTY(1);

--- a/test/parallel/test-tty-wrap.js
+++ b/test/parallel/test-tty-wrap.js
@@ -6,7 +6,7 @@ var TTY = process.binding('tty_wrap').TTY;
 var isTTY = process.binding('tty_wrap').isTTY;
 
 if (isTTY(1) == false) {
-  console.error('fd 1 is not a tty. skipping test.');
+  console.log('1..0 # Skipped: fd 1 is not a tty.');
   process.exit(0);
 }
 

--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/pummel/test-abort-fatal-error.js
+++ b/test/pummel/test-abort-fatal-error.js
@@ -4,7 +4,7 @@ var common = require('../common');
 
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: no RLIMIT_NOFILE on Windows');
-  process.exit(0);
+  return;
 }
 
 var exec = require('child_process').exec;

--- a/test/pummel/test-abort-fatal-error.js
+++ b/test/pummel/test-abort-fatal-error.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var common = require('../common');
 
 if (process.platform === 'win32') {
-  console.log('skipping test on windows');
+  console.log('1..0 # Skipped: no RLIMIT_NOFILE on Windows');
   process.exit(0);
 }
 

--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var crypto = require('crypto');
 

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -5,7 +5,7 @@ var os = require('os');
 var util = require('util');
 
 if (os.type() != 'SunOS') {
-  console.error('Skipping because DTrace not available.');
+  console.log('1..0 # Skipped: no DTRACE support');
   process.exit(0);
 }
 

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -6,7 +6,7 @@ var util = require('util');
 
 if (os.type() != 'SunOS') {
   console.log('1..0 # Skipped: no DTRACE support');
-  process.exit(0);
+  return;
 }
 
 /*

--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -13,7 +13,7 @@ var https = require('https');
 var fs = require('fs');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn;
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 var https = require('https');
@@ -14,7 +14,7 @@ var fs = require('fs');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 // renegotiation limits to test

--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -1,7 +1,7 @@
 'use strict';
 if (process.platform === 'win32') {
   console.log('1..0 # Skipped: no `wrk` on windows');
-  process.exit(0);
+  return;
 }
 
 // This test requires the program 'wrk'

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -1,6 +1,6 @@
 'use strict';
 if (process.platform === 'win32') {
-  console.log('skipping this test because there is no wrk on windows');
+  console.log('1..0 # Skipped: no `wrk` on windows');
   process.exit(0);
 }
 

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -11,7 +11,7 @@ var spawn = require('child_process').spawn;
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -12,7 +12,7 @@ var tls = require('tls');
 var fs = require('fs');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn;
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 
@@ -13,7 +13,7 @@ var fs = require('fs');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 // renegotiation limits to test

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -5,12 +5,12 @@ var common = require('../common');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 var join = require('path').join;

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -4,7 +4,7 @@
 var common = require('../common');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -3,12 +3,12 @@ var common = require('../common');
 
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  process.exit(0);
+  return;
 }
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 
 doTest();

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 
 if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 

--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 var fs = require('fs');

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn;
 var fs = require('fs');
 
 if (process.platform === 'win32') {
-  console.log('Skipping test, no RLIMIT_NOFILE on Windows.');
+  console.log('1..0 # Skipped: no RLIMIT_NOFILE on Windows');
   return;
 }
 

--- a/test/sequential/test-net-server-address.js
+++ b/test/sequential/test-net-server-address.js
@@ -37,7 +37,7 @@ server_ipv6.listen(common.PORT, localhost_ipv6, function() {
 });
 
 if (!common.hasIPv6) {
-  console.error('Skipping ipv6 part of test, no IPv6 support');
+  console.log('1..0 # Skipped: ipv6 part of test, no IPv6 support');
   return;
 }
 

--- a/test/sequential/test-regress-GH-1531.js
+++ b/test/sequential/test-regress-GH-1531.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var https = require('https');
 

--- a/test/sequential/test-setproctitle.js
+++ b/test/sequential/test-setproctitle.js
@@ -4,7 +4,7 @@
 // FIXME add sunos support
 if ('linux freebsd darwin'.indexOf(process.platform) === -1) {
   console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
-  process.exit();
+  return;
 }
 
 var common = require('../common');

--- a/test/sequential/test-setproctitle.js
+++ b/test/sequential/test-setproctitle.js
@@ -3,7 +3,7 @@
 
 // FIXME add sunos support
 if ('linux freebsd darwin'.indexOf(process.platform) === -1) {
-  console.error('Skipping test, platform not supported.');
+  console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
   process.exit();
 }
 

--- a/test/sequential/test-tls-honorcipherorder.js
+++ b/test/sequential/test-tls-honorcipherorder.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 if (!common.hasCrypto) {
   console.log('1..0 # Skipped: missing crypto');
-  process.exit();
+  return;
 }
 var tls = require('tls');
 


### PR DESCRIPTION
This patch makes the skip messages consistent so that the TAP plugin
in CI can parse the messages properly. The format will be

    1..0 # Skipped: [Actual reason why the test is skipped]

cc @bnoordhuis 