### PR TITLE
smoke test to install and test popular npm modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci:
-	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release message parallel sequential
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release message parallel sequential smoke
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release
@@ -143,6 +143,9 @@ test-npm: $(NODE_EXE)
 
 test-npm-publish: $(NODE_EXE)
 	npm_package_config_publishtest=true $(NODE) deps/npm/test/run.js
+
+test-smoke: $(NODE_EXE)
+	$(PYTHON) tools/test.py smoke
 
 test-addons: test-build
 	$(PYTHON) tools/test.py --mode=release addons

--- a/test/smoke/smoke.js
+++ b/test/smoke/smoke.js
@@ -1,0 +1,71 @@
+// Clone repo and run tests for popular npm packages
+
+'use strict';
+var os = require('os');
+var fs = require('fs');
+var path = require('path');
+var spawnSync = require('child_process').spawnSync;
+var common = require('../common');
+
+const iojs = path.resolve(__dirname, '../../iojs');
+const npm = path.resolve(__dirname, '../../deps/npm/cli.js');
+
+// .eslintrc in iojs will be used if we do our work in iojs/test/tmpdir.
+// So.....override with something in os.tmpdir().
+common.tmpDir = path.resolve(os.tmpdir(), 'node-smoke-test');
+
+common.refreshTmpDir();
+process.chdir(common.tmpDir);
+fs.mkdirSync('.bin');
+process.chdir('.bin');
+fs.symlinkSync(iojs, 'node');
+fs.symlinkSync(iojs, 'iojs');
+fs.symlinkSync(npm, 'npm');
+const pathPrepend = path.resolve(common.tmpDir, '.bin');
+
+process.envPATH = pathPrepend + path.delimiter + process.env.PATH;
+
+const checkResult = function(result) {
+  if (result.status !== 0) {
+    if (result.stdout) {
+      console.log(result.stdout.toString());
+    }
+    if (result.stderr) {
+      console.error(result.stderr.toString());
+    }
+    const error = result.error || new Error('spawned command failed');
+    throw error;
+  }
+};
+
+exports.npmTest = function(module) {
+  console.error('Running smoke test for module "' + module + '"...');
+  const modulePath = path.resolve(common.tmpDir, module);
+  fs.mkdirSync(modulePath);
+  process.chdir(modulePath);
+
+  console.error('...installing...');
+  var result = spawnSync('npm', ['install', module, '--cache-min=Infinity']);
+  checkResult(result);
+
+  const packageJsonPath = path.resolve(modulePath, 'node_modules', module,
+    'package.json');
+  const metadata = require(packageJsonPath);
+  const packageUrl = metadata.repository.url.replace(/^git\+/, '');
+
+  console.error('...cloning repo...');
+  result = spawnSync('git', ['clone', packageUrl, '--depth=1']);
+  checkResult(result);
+
+  process.chdir(path.basename(packageUrl).replace(/\.git$/, ''));
+
+  console.error('...installing devDependencies...');
+  result = spawnSync('npm', ['install', '--cache-min=Infinity']);
+  checkResult(result);
+
+  console.error('...running tests...');
+  result = spawnSync('npm', ['test']);
+  checkResult(result);
+
+  console.error('Tests succeeded for module "' + module + '".\n');
+};

--- a/test/smoke/test-npm-coffee-script.js
+++ b/test/smoke/test-npm-coffee-script.js
@@ -1,0 +1,4 @@
+'use strict';
+var smoke = require('./smoke');
+
+smoke.npmTest('coffee-script');

--- a/test/smoke/test-npm-commander.js
+++ b/test/smoke/test-npm-commander.js
@@ -1,0 +1,4 @@
+'use strict';
+var smoke = require('./smoke');
+
+smoke.npmTest('commander');

--- a/test/smoke/test-npm-gulp-util.js
+++ b/test/smoke/test-npm-gulp-util.js
@@ -1,0 +1,4 @@
+'use strict';
+var smoke = require('./smoke');
+
+smoke.npmTest('gulp-util');

--- a/test/smoke/test-npm-minimist.js
+++ b/test/smoke/test-npm-minimist.js
@@ -1,0 +1,4 @@
+'use strict';
+var smoke = require('./smoke');
+
+smoke.npmTest('minimist');

--- a/test/smoke/test-npm-q.js
+++ b/test/smoke/test-npm-q.js
@@ -1,0 +1,4 @@
+'use strict';
+var smoke = require('./smoke');
+
+smoke.npmTest('q');

--- a/test/smoke/test-npm-underscore.js
+++ b/test/smoke/test-npm-underscore.js
@@ -1,0 +1,4 @@
+'use strict';
+var smoke = require('./smoke');
+
+smoke.npmTest('underscore');

--- a/test/smoke/testcfg.py
+++ b/test/smoke/testcfg.py
@@ -1,0 +1,6 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import testpy
+
+def GetConfiguration(context, root):
+  return testpy.SimpleTestConfiguration(context, root, 'smoke')

--- a/tools/test.py
+++ b/tools/test.py
@@ -1344,6 +1344,7 @@ BUILT_IN_TESTS = [
   'addons',
   'gc',
   'debugger',
+  'smoke',
 ]
 
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -52,12 +52,13 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% sequential parallel message -J&set jslint=1&goto arg-ok
-if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap message sequential parallel&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap message sequential parallel smoke&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&goto arg-ok
 if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
+if /i "%1"=="test-smoke"    set test_args=%test_args% smoke&goto arg-ok
 if /i "%1"=="test-all"      set test_args=%test_args% sequential parallel message gc internet pummel&set buildnodeweak=1&set jslint=1&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="msi"           set msi=1&set licensertf=1&goto arg-ok
@@ -224,7 +225,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all]
+echo vcbuild.bat [debug/release] [msi] [test-all/test-uv/test-internet/test-pummel/test-simple/test-message/test-smoke] [clean] [noprojgen] [small-icu/full-icu/intl-none] [nobuild] [nosign] [x86/x64] [download-all]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build


### PR DESCRIPTION
Run `npm test` on popular packages as a smoke test.

This is similar to https://github.com/rvagg/iojs-smoke-tests but there are some advantages (and disadvantages) to the approach here. It may be the case that both are worth having.

This is not ready for merging--last mile includes getting Windows to work, making it possible to run smoke tests in parallel, code cleanup, etc.--but before tackling Windows, I'd prefer to get some feedback on whether this is worth completing or not.

The main advantages with this approach over the existing docker-base smoke tests:

* Can run on any platform (although I haven't gotten Windows to work yet).  Since the existing smoke tests rely on docker, they can only be executed on a subset of Linux distros. (Yes, you can install docker on a Mac with boot2docker, but that just fires up an ubuntu VM to actually run things.)

* Can be integrated into CI. Like this: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/111/ So, in theory, we can run the smoke tests on every commit if we wish.