### PR TITLE
repl: Prevent REPL crash when tab-completed with Proxy objects

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -641,7 +641,14 @@ REPLServer.prototype.complete = function(line, callback) {
 
           if (obj != null) {
             if (typeof obj === 'object' || typeof obj === 'function') {
-              memberGroups.push(Object.getOwnPropertyNames(obj));
+              try {
+                memberGroups.push(Object.getOwnPropertyNames(obj));
+              } catch (ex) {
+                // Probably a Proxy object without `getOwnPropertyNames` trap.
+                // We simply ignore it here, as we don't want to break the
+                // autocompletion. Fixes the bug
+                // https://github.com/nodejs/io.js/issues/2119
+              }
             }
             // works for non-objects
             try {

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -1,4 +1,7 @@
 'use strict';
+
+// Flags: --harmony-proxies
+
 var common = require('../common');
 var assert = require('assert');
 var util = require('util');
@@ -231,4 +234,17 @@ putIn.run([
 ]);
 testMe.complete('cus', common.mustCall(function(error, data) {
   assert.deepEqual(data, [['custom'], 'cus']);
+}));
+
+// Make sure tab completion doesn't crash REPL with half-baked proxy objects.
+// See: https://github.com/nodejs/io.js/issues/2119
+putIn.run(['.clear']);
+
+putIn.run([
+  'var proxy = Proxy.create({});'
+]);
+
+testMe.complete('proxy.', common.mustCall(function(error, data) {
+  assert.strictEqual(error, null);
+  assert.deepEqual(data, [[], 'proxy.']);
 }));


### PR DESCRIPTION
If the proxy objects don't have a valid `hasOwnPropertyNames` trap,
REPL crashes with a `TypeError`, as per the bug report
https://github.com/nodejs/io.js/issues/2119

    > var proxy = Proxy.create({ fix: function() { return {}; } });
    undefined
    > proxy.<tab>
    TypeError: Proxy handler #<Object> has no 'getOwnPropertyNames' trap
        at Function.getOwnPropertyNames (native)
        at repl.js:644:40
        at REPLServer.defaultEval (repl.js:169:5)
        at bound (domain.js:254:14)
        at REPLServer.runBound [as eval] (domain.js:267:12)
        at REPLServer.complete (repl.js:639:14)
        at REPLServer.complete [as completer] (repl.js:207:10)
        at REPLServer.Interface._tabComplete (readline.js:377:8)
        at REPLServer.Interface._ttyWrite (readline.js:845:14)
        at ReadStream.onkeypress (readline.js:105:10)

This patch traps the error thrown and issues Error message.