### PR TITLE
test: add test for dgram.setTTL

### DIFF
--- a/test/parallel/test-dgram-setTTL.js
+++ b/test/parallel/test-dgram-setTTL.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const socket = dgram.createSocket('udp4');
+
+socket.bind(common.PORT);
+socket.on('listening', function() {
+  var result = socket.setTTL(16);
+  assert.strictEqual(result, 16);
+
+  assert.throws(function() {
+    socket.setTTL('foo');
+  }, /Argument must be a number/);
+
+  socket.close();
+});


### PR DESCRIPTION
Verify that passing a non-number will throw and that the argument is
returned on success.

There currently is not a test to verify this functionality.