### PR TITLE
tools: install gdbinit from v8 to $PREFIX/share

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -149,6 +149,8 @@ def files(action):
   # behave similarly for systemtap
   action(['src/node.stp'], 'share/systemtap/tapset/')
 
+  action(['deps/v8/tools/gdbinit'], 'share/doc/node/')
+
   if 'freebsd' in sys.platform or 'openbsd' in sys.platform:
     action(['doc/iojs.1'], 'man/man1/')
   else:

--- a/tools/rpm/iojs.spec
+++ b/tools/rpm/iojs.spec
@@ -93,6 +93,7 @@ done
 /usr/bin/*
 /usr/include/*
 /usr/lib/node_modules/
+/usr/share/doc/node/gdbinit
 /usr/share/man/man1/iojs.1.gz
 /usr/share/systemtap/tapset/node.stp
 %{_datadir}/%{name}/
@@ -100,6 +101,9 @@ done
 
 
 %changelog
+* Tue Jul 7 2015 Ali Ijaz Sheikh <ofrobots@google.com>
+- Added gdbinit.
+
 * Mon Apr 13 2015 Dan Varga <danvarga@gmail.com>
 - Fix paths for changelog and manpage
 


### PR DESCRIPTION
gdbinit provided by V8 can be very useful for low-level debugging of crashes in node and in binary addons. Most useful commands at 'jst' for JS stack traces and 'job' for printing a heap object.

This patch installs the file at $PREFIX/share/tools/gdbinit making it available on installed Node.js binaries too.

Here's a sample session that uses these gdb macros: https://gist.github.com/ofrobots/0bdcab89771221ace68d
