### PR TITLE
doc: Changing TC references to TSC

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -4,7 +4,7 @@
 
 * [Issues and Pull Requests](#issues-and-pull-requests)
 * [Accepting Modifications](#accepting-modifications)
- - [Involving the TC](#involving-the-tc)
+ - [Involving the TSC](#involving-the-tsc)
 * [Landing Pull Requests](#landing-pull-requests)
  - [Technical HOWTO](#technical-howto)
  - [I Just Made a Mistake](#i-just-made-a-mistake)
@@ -25,7 +25,7 @@ pull requests to the io.js project.
 Collaborators should feel free to take full responsibility for
 managing issues and pull requests they feel qualified to handle, as
 long as this is done while being mindful of these guidelines, the
-opinions of other Collaborators and guidance of the TC.
+opinions of other Collaborators and guidance of the TSC.
 
 Collaborators may **close** any issue or pull request they believe is
 not relevant for the future of the io.js project. Where this is
@@ -39,7 +39,7 @@ necessary.
 
 All modifications to the io.js code and documentation should be
 performed via GitHub pull requests, including modifications by
-Collaborators and TC members.
+Collaborators and TSC members.
 
 All pull requests must be reviewed and accepted by a Collaborator with
 sufficient expertise who is able to take full responsibility for the
@@ -63,7 +63,7 @@ Where there is no disagreement amongst Collaborators, a pull request
 may be landed given appropriate review. Where there is discussion
 amongst Collaborators, consensus should be sought if possible. The
 lack of consensus may indicate the need to elevate discussion to the
-TC for resolution (see below).
+TSC for resolution (see below).
 
 All bugfixes require a test case which demonstrates the defect. The
 test should *fail* before the change, and *pass* after the change.
@@ -72,10 +72,10 @@ All pull requests that modify executable code should be subjected to
 continuous integration tests on the
 [project CI server](https://jenkins-iojs.nodesource.com/).
 
-### Involving the TC
+### Involving the TSC
 
-Collaborators may opt to elevate pull requests or issues to the TC for
-discussion by assigning the ***tc-agenda*** tag. This should be done
+Collaborators may opt to elevate pull requests or issues to the TSC for
+discussion by assigning the ***tsc-agenda*** tag. This should be done
 where a pull request:
 
 - has a significant impact on the codebase,
@@ -83,7 +83,7 @@ where a pull request:
 - has failed to reach consensus amongst the Collaborators who are
   actively participating in the discussion.
 
-The TC should serve as the final arbiter where required.
+The TSC should serve as the final arbiter where required.
 
 ## Landing Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ CoC](http://www.rust-lang.org/conduct.html).
 * Private harassment is also unacceptable. No matter who you are, if
   you feel you have been or are being harassed or made uncomfortable
   by a community member, please contact one of the channel ops or any
-  of the TC members immediately with a capture (log, photo, email) of
+  of the TSC members immediately with a capture (log, photo, email) of
   the harassment if possible.  Whether you're a regular contributor or
   a newcomer, we care about making this community a safe place for you
   and we've got your back.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,11 +1,12 @@
 # io.js Project Governance
 
-## Technical Committee
+## Technical Steering Committee
 
-The io.js project is jointly governed by a Technical Committee (TC)
-which is responsible for high-level guidance of the project.
+The io.js project is jointly governed by a Technical Steering Committee
+(TSC) which is responsible for high-level guidance of the project. TSC
+was formerly known as Technical Committee (TC).
 
-The TC has final authority over this project including:
+The TSC has final authority over this project including:
 
 * Technical direction
 * Project governance and process (including this policy)
@@ -14,28 +15,28 @@ The TC has final authority over this project including:
 * Conduct guidelines
 * Maintaining the list of additional Collaborators
 
-Initial membership invitations to the TC were given to individuals who
+Initial membership invitations to the TSC were given to individuals who
 had been active contributors to io.js, and who have significant
 experience with the management of the io.js project. Membership is
 expected to evolve over time according to the needs of the project.
 
-For the current list of TC members, see the project
+For the current list of TSC members, see the project
 [README.md](./README.md#current-project-team-members).
 
 ## Collaborators
 
 The [iojs/io.js](https://github.com/nodejs/io.js) GitHub repository is
-maintained by the TC and additional Collaborators who are added by the
-TC on an ongoing basis.
+maintained by the TSC and additional Collaborators who are added by the
+TSC on an ongoing basis.
 
 Individuals making significant and valuable contributions are made
 Collaborators and given commit-access to the project. These
-individuals are identified by the TC and their addition as
-Collaborators is discussed during the weekly TC meeting.
+individuals are identified by the TSC and their addition as
+Collaborators is discussed during the weekly TSC meeting.
 
 _Note:_ If you make a significant contribution and are not considered
-for commit-access, log an issue or contact a TC member directly and it
-will be brought up in the next TC meeting.
+for commit-access, log an issue or contact a TSC member directly and it
+will be brought up in the next TSC meeting.
 
 Modifications of the contents of the iojs/io.js repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a
@@ -51,8 +52,8 @@ on the consensus model used for governance.
 
 Collaborators may opt to elevate significant or controversial
 modifications, or modifications that have not found consensus to the
-TC for discussion by assigning the ***tc-agenda*** tag to a pull
-request or issue. The TC should serve as the final arbiter where
+TSC for discussion by assigning the ***tsc-agenda*** tag to a pull
+request or issue. The TSC should serve as the final arbiter where
 required.
 
 For the current list of Collaborators, see the project
@@ -61,39 +62,39 @@ For the current list of Collaborators, see the project
 A guide for Collaborators is maintained in
 [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md).
 
-## TC Membership
+## TSC Membership
 
-TC seats are not time-limited.  There is no fixed size of the TC.
+TSC seats are not time-limited.  There is no fixed size of the TSC.
 However, the expected target is between 6 and 12, to ensure adequate
 coverage of important areas of expertise, balanced with the ability to
 make decisions efficiently.
 
-There is no specific set of requirements or qualifications for TC
+There is no specific set of requirements or qualifications for TSC
 membership beyond these rules.
 
-The TC may add additional members to the TC by a standard TC motion.
+The TSC may add additional members to the TSC by a standard TSC motion.
 
-A TC member may be removed from the TC by voluntary resignation, or by
-a standard TC motion.
+A TSC member may be removed from the TSC by voluntary resignation, or by
+a standard TSC motion.
 
-Changes to TC membership should be posted in the agenda, and may be
-suggested as any other agenda item (see "TC Meetings" below).
+Changes to TSC membership should be posted in the agenda, and may be
+suggested as any other agenda item (see "TSC Meetings" below).
 
-No more than 1/3 of the TC members may be affiliated with the same
-employer.  If removal or resignation of a TC member, or a change of
-employment by a TC member, creates a situation where more than 1/3 of
-the TC membership shares an employer, then the situation must be
-immediately remedied by the resignation or removal of one or more TC
+No more than 1/3 of the TSC members may be affiliated with the same
+employer.  If removal or resignation of a TSC member, or a change of
+employment by a TSC member, creates a situation where more than 1/3 of
+the TSC membership shares an employer, then the situation must be
+immediately remedied by the resignation or removal of one or more TSC
 members affiliated with the over-represented employer(s).
 
-## TC Meetings
+## TSC Meetings
 
-The TC meets weekly on a Google Hangout On Air. The meeting is run by
-a designated moderator approved by the TC. Each meeting should be
+The TSC meets weekly on a Google Hangout On Air. The meeting is run by
+a designated moderator approved by the TSC. Each meeting should be
 published to YouTube.
 
-Items are added to the TC agenda which are considered contentious or
-are modifications of governance, contribution policy, TC membership,
+Items are added to the TSC agenda which are considered contentious or
+are modifications of governance, contribution policy, TSC membership,
 or release process.
 
 The intention of the agenda is not to approve or review all patches.
@@ -102,15 +103,15 @@ group of Collaborators.
 
 Any community member or contributor can ask that something be added to
 the next meeting's agenda by logging a GitHub Issue. Any Collaborator,
-TC member or the moderator can add the item to the agenda by adding
-the ***tc-agenda*** tag to the issue.
+TSC member or the moderator can add the item to the agenda by adding
+the ***tsc-agenda*** tag to the issue.
 
-Prior to each TC meeting, the moderator will share the Agenda with
-members of the TC. TC members can add any items they like to the
-agenda at the beginning of each meeting. The moderator and the TC
+Prior to each TSC meeting, the moderator will share the Agenda with
+members of the TSC. TSC members can add any items they like to the
+agenda at the beginning of each meeting. The moderator and the TSC
 cannot veto or remove items.
 
-The TC may invite persons or representatives from certain projects to
+The TSC may invite persons or representatives from certain projects to
 participate in a non-voting capacity. These invitees currently are:
 
 * A representative from [build](https://github.com/node-forward/build)
@@ -121,7 +122,7 @@ agenda item and sending it as a pull request after the meeting.
 
 ## Consensus Seeking Process
 
-The TC follows a
+The TSC follows a
 [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
 decision making model.
 
@@ -129,7 +130,7 @@ When an agenda item has appeared to reach a consensus, the moderator
 will ask "Does anyone object?" as a final call for dissent from the
 consensus.
 
-If an agenda item cannot reach a consensus, a TC member can call for
+If an agenda item cannot reach a consensus, a TSC member can call for
 either a closing vote or a vote to table the issue to the next
-meeting. The call for a vote must be approved by a majority of the TC
+meeting. The call for a vote must be approved by a majority of the TSC
 or else the discussion will continue. Simple majority wins.

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -1,11 +1,11 @@
 # io.js Working Groups
 
 io.js Working Groups are autonomous projects created by the
-[Technical Committee (TC)](https://github.com/nodejs/io.js/blob/master/GOVERNANCE.md#technical-committee).
+[Technical Steering Committee (TSC)](https://github.com/nodejs/io.js/blob/master/GOVERNANCE.md#technical-steering-committee).
 
-Working Groups can be formed at any time but must be ratified by the TC.
+Working Groups can be formed at any time but must be ratified by the TSC.
 Once formed the work defined in the Working Group charter is the
-responsibility of the WG rather than the TC.
+responsibility of the WG rather than the TSC.
 
 It is important that Working Groups are not formed pre-maturely. Working
 Groups are not formed to *begin* a set of tasks but instead are formed
@@ -14,7 +14,7 @@ think it would benefit from being done as an autonomous project.
 
 If the work defined in a Working Group charter is completed the Working
 Group should be dissolved and the responsibility for governance absorbed
-back in to the TC.
+back in to the TSC.
 
 ## Current Working Groups
 
@@ -160,7 +160,7 @@ content.
 The roadmap working group is responsible for user community outreach
 and the translation of their concerns into a plan of action for io.js.
 
-The final [ROADMAP](./ROADMAP.md) document is still owned by the TC and requires
+The final [ROADMAP](./ROADMAP.md) document is still owned by the TSC and requires
 the same approval for changes as any other project asset.
 
 Their responsibilities are:
@@ -195,9 +195,9 @@ Their responsibilities are:
 * Maintaining the [addon-examples](https://github.com/nodejs/node-addon-examples)
   GitHub repository, including code, issues and documentation.
 * Maintaining the C++ Addon API within the io.js project, in subordination to
-  the io.js TC.
+  the io.js TSC.
 * Maintaining the Addon documentation within the io.js project, in
-  subordination to the io.js TC.
+  subordination to the io.js TSC.
 * Maintaining the _nan_ package in npm, releasing new versions as appropriate.
 * Messaging about the future of the io.js and NAN interface to give the
   community advance notice of changes.
@@ -208,15 +208,15 @@ The current members can be found in their
 ## Starting a WG
 
 A Working Group is established by first defining a charter  that can be
-ratified by the TC. A charter is a *statement of purpose*, a
+ratified by the TSC. A charter is a *statement of purpose*, a
 *list of responsibilities* and a *list of initial membership*.
 
 A working group needs 3 initial members. These should be individuals
 already undertaking the work described in the charter.
 
 The list of responsibilities should be specific. Once established, these
-responsibilities are no longer governed by the TC and therefore should
-not be broad or subjective. The only recourse the TC has over the working
+responsibilities are no longer governed by the TSC and therefore should
+not be broad or subjective. The only recourse the TSC has over the working
 group is to revoke the entire charter and take on the work previously
 done by the working group themselves.
 
@@ -232,7 +232,7 @@ README.
 
 ## Bootstrap Governance
 
-Once the TC ratifies a charter the WG inherits the following
+Once the TSC ratifies a charter the WG inherits the following
 documentation for governance, contribution, conduct and an MIT
 LICENSE. The WG is free to change these documents through their own
 governance process, hence the term "bootstrap."
@@ -415,7 +415,7 @@ CoC](https://github.com/rust-lang/rust/wiki/Note-development-policy#conduct).
 * Private harassment is also unacceptable. No matter who you are, if
   you feel you have been or are being harassed or made uncomfortable
   by a community member, please contact one of the channel ops or any
-  of the TC members immediately with a capture (log, photo, email) of
+  of the TSC members immediately with a capture (log, photo, email) of
   the harassment if possible.  Whether you're a regular contributor or
   a newcomer, we care about making this community a safe place for you
   and we've got your back.


### PR DESCRIPTION
Since we choose to call the governing body as Technical Steering
Committee, this patch replaces the old name Technical Committee.
The GOVERNANCE.md has reference to the old name.

Changes to README.md are done by @Fishrock123 at https://github.com/nodejs/io.js/pull/2085