### PR TITLE
build: avoid calling configure twice from vcbuild

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -86,19 +86,12 @@ if "%i18n_arg%"=="intl-none" set i18n_arg=--with-intl=none
 
 call :getnodeversion || exit /b 1
 
-@rem Set environment for msbuild
 :project-gen
 @rem Skip project generation if requested.
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-SETLOCAL
-  if defined VS100COMNTOOLS call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
-  python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
-  if errorlevel 1 goto create-msvs-files-failed
-  if not exist node.sln goto create-msvs-files-failed
-  echo Project files generated.
-ENDLOCAL
+if defined VS100COMNTOOLS call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
 
 @rem Look for Visual Studio 2015
 if not defined VS140COMNTOOLS goto vc-set-2013
@@ -128,12 +121,6 @@ echo Failed to find Visual Studio installation.
 goto exit
 
 :msbuild-found
-
-:project-gen
-@rem Skip project generation if requested.
-if defined noprojgen goto msbuild
-
-@rem Generate the VS project.
 python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed


### PR DESCRIPTION
This was introduced in a merge from nodejs (dcbb9e1d).

/R= @nodejs/build