### PR TITLE
test: add missing crypto checks

### DIFF
--- a/test/internet/test-tls-connnect-cnnic.js
+++ b/test/internet/test-tls-connnect-cnnic.js
@@ -7,6 +7,13 @@
 //     0x44, 0xB5, 0x00, 0x76, 0x48, 0x11, 0x41, 0xED },
 // },
 // in src/CNNICHashWhitelist.inc
+
+var common = require('../common');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+
 var tls = require('tls');
 var socket = tls.connect(443, 'www1.cnnic.cn', function() {
   socket.resume();

--- a/test/internet/test-tls-connnect-melissadata.js
+++ b/test/internet/test-tls-connnect-melissadata.js
@@ -1,6 +1,13 @@
 'use strict';
 // Test for authorized access to the server which has a cross root
 // certification between Starfield Class 2 and ValiCert Class 2
+
+var common = require('../common');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+
 var tls = require('tls');
 var socket = tls.connect(443, 'address.melissadata.net', function() {
   socket.resume();


### PR DESCRIPTION
Add a check for crypto before using it, similar to how other tests work.

Guess my previous commit ("Refactor _all_ tests that depends on crypto", 671fbd5a9de03c5ede968ef6c6b365965a546a55) wasn't accurate :panda_face: 

/R=@shigeki? (you reviewed last time)