### PR TITLE
tools: expose skip output to test runner

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -255,6 +255,9 @@ class TapProgressIndicator(SimpleProgressIndicator):
         logger.info('#' + l)
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
+    elif output.HasSkipped():
+      logger.info('ok %i - %s # skip %s' % (self._done, command,
+        output.output.stdout.replace('1..0 # Skipped:', '').strip()))
     else:
       logger.info('ok %i - %s' % (self._done, command))
 
@@ -470,6 +473,10 @@ class TestOutput(object):
     else:
       outcome = PASS
     return not outcome in self.test.outcomes
+
+  def HasSkipped(self):
+    s = '1..0 # Skipped:'
+    return self.store_unexpected_output and self.output.stdout.startswith(s)
 
   def HasPreciousOutput(self):
     return self.UnexpectedOutput() and self.store_unexpected_output

--- a/tools/test.py
+++ b/tools/test.py
@@ -49,6 +49,7 @@ from datetime import datetime
 from Queue import Queue, Empty
 
 logger = logging.getLogger('testrunner')
+is_skipped = re.compile(r"# SKIP\S+ (.+)", re.IGNORECASE)
 
 VERBOSE = False
 
@@ -256,8 +257,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
     elif output.HasSkipped():
-      skip = re.findall('# SKIP\S+ (.+)', output.output.stdout,
-        re.IGNORECASE)      
+      skip = is_skipped.findall(output.output.stdout)      
       logger.info('ok %i - %s # skip %s' % (self._done, command, skip[0]))
     else:
       logger.info('ok %i - %s' % (self._done, command))
@@ -476,8 +476,7 @@ class TestOutput(object):
     return not outcome in self.test.outcomes
 
   def HasSkipped(self):
-    skip = re.search('# SKIP\S+ (.+)', self.output.stdout,
-      re.IGNORECASE)
+    skip = is_skipped.search(self.output.stdout)
     return self.store_unexpected_output and skip
 
   def HasPreciousOutput(self):

--- a/tools/test.py
+++ b/tools/test.py
@@ -27,6 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
 import imp
 import logging
 import optparse
@@ -255,7 +256,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
     elif output.HasSkipped():
-      skip = re.findall('# SKIP\S+ (.+)', output.output.stdout.strip(),
+      skip = re.findall('# SKIP\S+ (.+)', output.output.stdout,
         re.IGNORECASE)      
       logger.info('ok %i - %s # skip %s' % (self._done, command, skip[0]))
     else:
@@ -475,7 +476,7 @@ class TestOutput(object):
     return not outcome in self.test.outcomes
 
   def HasSkipped(self):
-    skip = re.search('# SKIP\S+ (.+)', self.output.stdout.strip(),
+    skip = re.search('# SKIP\S+ (.+)', self.output.stdout,
       re.IGNORECASE)
     return self.store_unexpected_output and skip
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -27,7 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 import imp
 import logging
 import optparse
@@ -256,8 +255,9 @@ class TapProgressIndicator(SimpleProgressIndicator):
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
     elif output.HasSkipped():
-      logger.info('ok %i - %s # skip %s' % (self._done, command,
-        output.output.stdout.replace('1..0 # Skipped:', '').strip()))
+      skip = re.findall('# SKIP\S+ (.+)', output.output.stdout.strip(),
+        re.IGNORECASE)      
+      logger.info('ok %i - %s # skip %s' % (self._done, command, skip[0]))
     else:
       logger.info('ok %i - %s' % (self._done, command))
 
@@ -475,8 +475,9 @@ class TestOutput(object):
     return not outcome in self.test.outcomes
 
   def HasSkipped(self):
-    s = '1..0 # Skipped:'
-    return self.store_unexpected_output and self.output.stdout.startswith(s)
+    skip = re.search('# SKIP\S+ (.+)', self.output.stdout.strip(),
+      re.IGNORECASE)
+    return self.store_unexpected_output and skip
 
   def HasPreciousOutput(self):
     return self.UnexpectedOutput() and self.store_unexpected_output

--- a/tools/test.py
+++ b/tools/test.py
@@ -256,11 +256,13 @@ class TapProgressIndicator(SimpleProgressIndicator):
         logger.info('#' + l)
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
-    elif output.HasSkipped():
-      skip = skip_regex.search(output.output.stdout).group(1)     
-      logger.info('ok %i - %s # skip %s' % (self._done, command, skip))
     else:
-      logger.info('ok %i - %s' % (self._done, command))
+      skip = skip_regex.search(output.output.stdout)
+      if skip:
+        logger.info('ok %i - %s # skip %s' %
+          (self._done, command, skip.group(1)))
+      else:
+        logger.info('ok %i - %s' % (self._done, command))
 
     duration = output.test.duration
 
@@ -474,10 +476,6 @@ class TestOutput(object):
     else:
       outcome = PASS
     return not outcome in self.test.outcomes
-
-  def HasSkipped(self):
-    skip = skip_regex.search(self.output.stdout)
-    return self.store_unexpected_output and skip
 
   def HasPreciousOutput(self):
     return self.UnexpectedOutput() and self.store_unexpected_output

--- a/tools/test.py
+++ b/tools/test.py
@@ -49,7 +49,7 @@ from datetime import datetime
 from Queue import Queue, Empty
 
 logger = logging.getLogger('testrunner')
-is_skipped = re.compile(r"# SKIP\S+ (.+)", re.IGNORECASE)
+skip_regex = re.compile(r'# SKIP\S*\s+(.*)', re.IGNORECASE)
 
 VERBOSE = False
 
@@ -257,7 +257,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
     elif output.HasSkipped():
-      skip = is_skipped.findall(output.output.stdout)      
+      skip = skip_regex.findall(output.output.stdout)      
       logger.info('ok %i - %s # skip %s' % (self._done, command, skip[0]))
     else:
       logger.info('ok %i - %s' % (self._done, command))
@@ -476,7 +476,7 @@ class TestOutput(object):
     return not outcome in self.test.outcomes
 
   def HasSkipped(self):
-    skip = is_skipped.search(self.output.stdout)
+    skip = skip_regex.search(self.output.stdout)
     return self.store_unexpected_output and skip
 
   def HasPreciousOutput(self):

--- a/tools/test.py
+++ b/tools/test.py
@@ -257,8 +257,8 @@ class TapProgressIndicator(SimpleProgressIndicator):
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
     elif output.HasSkipped():
-      skip = skip_regex.findall(output.output.stdout)      
-      logger.info('ok %i - %s # skip %s' % (self._done, command, skip[0]))
+      skip = skip_regex.search(output.output.stdout).group(1)     
+      logger.info('ok %i - %s # skip %s' % (self._done, command, skip))
     else:
       logger.info('ok %i - %s' % (self._done, command))
 


### PR DESCRIPTION
In the TAP protocol, skips are flagged as ok. Expose more information so we can understand if the test was skipped or not. Refs #2109.

(see http://testanything.org/tap-specification.html -> directives -> skipping tests)

/R=@nodejs/build, @bnoordhuis (keeps my python on track)