### PR TITLE
build: run-ci makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,11 @@ docopen: out/doc/api/all.html
 docclean:
 	-rm -rf out/doc
 
+run-ci:
+	$(PYTHON) ./configure $(CONFIG_FLAGS)
+	$(MAKE)
+	$(MAKE) test-ci
+
 RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)
 VERSION=v$(RAWVER)
 
@@ -464,4 +469,4 @@ lint: jslint cpplint
 	dynamiclib test test-all test-addons build-addons website-upload pkg \
 	blog blogclean tar binary release-only bench-http-simple bench-idle \
 	bench-all bench bench-misc bench-array bench-buffer bench-net \
-	bench-http bench-fs bench-tls cctest
+	bench-http bench-fs bench-tls cctest run-ci


### PR DESCRIPTION
Adding a single rule to be called from Jenkins.

Jenkins jobs typically call:
python ./configure
make -j $(getconf _NPROCESSORS_ONLN)
make test-ci

After this change, we can have Jenkins call:
make run-ci -j $(getconf _NPROCESSORS_ONLN)

This allows us to customize how we call configure
for different repos or branches (e.g. joyent\node).