### PR TITLE
repl: preventing recursive eval of RegEx predefined properties

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -115,6 +115,12 @@ function REPLServer(prompt,
   // just for backwards compat, see github.com/joyent/node/pull/7127
   self.rli = this;
 
+  const savedRegExMatches = ['', '', '', '', '', '', '', '', '', ''];
+  const sep = '\u0000\u0000\u0000';
+  const regExMatcher = new RegExp(`^${sep}(.*)${sep}(.*)${sep}(.*)${sep}(.*)` +
+                                  `${sep}(.*)${sep}(.*)${sep}(.*)${sep}(.*)` +
+                                  `${sep}(.*)$`);
+
   eval_ = eval_ || defaultEval;
 
   function defaultEval(code, context, file, cb) {
@@ -148,6 +154,10 @@ function REPLServer(prompt,
       break;
     }
 
+    // This will set the values from `savedRegExMatches` to corresponding
+    // predefined RegExp properties `RegExp.$1`, `RegExp.$2` ... `RegExp.$9`
+    regExMatcher.test(savedRegExMatches.join(sep));
+
     if (!err) {
       try {
         if (self.useGlobal) {
@@ -164,6 +174,12 @@ function REPLServer(prompt,
           return;
         }
       }
+    }
+
+    // After executing the current expression, store the values of RegExp
+    // predefined properties back in `savedRegExMatches`
+    for (let idx = 1; idx < savedRegExMatches.length; idx += 1) {
+      savedRegExMatches[idx] = RegExp[`$${idx}`];
     }
 
     cb(err, result);

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -232,6 +232,16 @@ function error_test() {
     { client: client_unix, send: '\'the\\\n\\\nfourtheye\'\n',
       expect: prompt_multiline + prompt_multiline +
               '\'thefourtheye\'\n' + prompt_unix },
+    // Regression test for https://github.com/nodejs/io.js/issues/597
+    { client: client_unix,
+      send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
+      expect: `true\n${prompt_unix}` },
+    // the following test's result depends on the RegEx's match from the above
+    { client: client_unix,
+      send: 'RegExp.$1\nRegExp.$2\nRegExp.$3\nRegExp.$4\nRegExp.$5\n' +
+            'RegExp.$6\nRegExp.$7\nRegExp.$8\nRegExp.$9\n',
+      expect: ['\'1\'\n', '\'2\'\n', '\'3\'\n', '\'4\'\n', '\'5\'\n', '\'6\'\n',
+               '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
   ]);
 }
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/io.js/issues/597

In REPL, if we evaluate the `RegExp` object's predefined properties,
and if they happen to have the same expression, for example,

    > RegExp.$1
    'RegExp.$1'

then doing `eval(RegExp.$1)` would evaluate `RegExp.$1` recursively and
eventually throw `RangeError: Maximum call stack size exceeded`.

This patch stores the old values of `RegExp`'s predefined properties and
restores them just before the current expression entered by user is
evaluated.