### PR TITLE
doc: note about custom inspect functions

### DIFF
--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -241,11 +241,9 @@ The following key combinations in the REPL have these special effects:
 ### Customizing Object displays in the REPL
 
 The REPL module internally uses
-[`util.inspect`](https://iojs.org/api/util.html#util_util_inspect_object_options),
- when printing values. But, `util.inspect` delegates the call
+[util.inspect()][], when printing values. But, `util.inspect` delegates the call
  to the object's `inspect` function, if it has one. You can read more about
- this delegation
- [here](https://iojs.org/api/util.html#util_custom_inspect_function_on_objects).
+ this delegation [here][].
 
 If you have defined an `inspect` function on an object, like this:
 
@@ -260,3 +258,6 @@ and try to print `obj` in REPL, it will invoke the custom `inspect` function:
 
     > obj
     { bar: 'baz' }
+
+[util.inspect()]: util.html#util_util_inspect_object_options
+[here]: util.html#util_custom_inspect_function_on_objects

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -240,18 +240,18 @@ The following key combinations in the REPL have these special effects:
 
 ### Overriding representation of Objects in REPL
 
-REPL module internally uses
+The REPL module internally uses
 [`util.inspect`](https://iojs.org/api/util.html#util_util_inspect_object_options),
  by default, to print the actual values. But, `util.inspect` delegates the call
  to the object's `inspect` function, if it has one. You can read more about
- this delegation,
+ this delegation
  [here](https://iojs.org/api/util.html#util_custom_inspect_function_on_objects).
 
 So, if you have defined an `inspect` function on an object, like this
 
     > var obj = { foo: 'this will not show up in the inspect() output' };
     undefined
-    > obj.inspect = function(depth) {
+    > obj.inspect = function() {
     ...   return { bar: 'baz' };
     ... };
     [Function]

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -247,7 +247,7 @@ The REPL module internally uses
  this delegation
  [here](https://iojs.org/api/util.html#util_custom_inspect_function_on_objects).
 
-So, if you have defined an `inspect` function on an object, like this
+If you have defined an `inspect` function on an object, like this:
 
     > var obj = { foo: 'this will not show up in the inspect() output' };
     undefined
@@ -256,7 +256,7 @@ So, if you have defined an `inspect` function on an object, like this
     ... };
     [Function]
 
-and try to print `obj` in REPL, it will invoke the custom `inspect` function
+and try to print `obj` in REPL, it will invoke the custom `inspect` function:
 
     > obj
     { bar: 'baz' }

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -241,11 +241,11 @@ The following key combinations in the REPL have these special effects:
 ### Customizing Object displays in the REPL
 
 The REPL module internally uses
-[util.inspect()][], when printing values. But, `util.inspect` delegates the call
- to the object's `inspect` function, if it has one. You can read more about
- this delegation [here][].
+[util.inspect()][], when printing values. However, `util.inspect` delegates the
+ call to the object's `inspect()` function, if it has one. You can read more
+ about this delegation [here][].
 
-If you have defined an `inspect` function on an object, like this:
+For example, if you have defined an `inspect()` function on an object, like this:
 
     > var obj = { foo: 'this will not show up in the inspect() output' };
     undefined
@@ -254,7 +254,7 @@ If you have defined an `inspect` function on an object, like this:
     ... };
     [Function]
 
-and try to print `obj` in REPL, it will invoke the custom `inspect` function:
+and try to print `obj` in REPL, it will invoke the custom `inspect()` function:
 
     > obj
     { bar: 'baz' }

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -238,11 +238,11 @@ The following key combinations in the REPL have these special effects:
   - `<tab>` - Show both global and local(scope) variables
 
 
-### Overriding representation of Objects in REPL
+### Customizing Object displays in the REPL
 
 The REPL module internally uses
 [`util.inspect`](https://iojs.org/api/util.html#util_util_inspect_object_options),
- by default, to print the actual values. But, `util.inspect` delegates the call
+ when printing values. But, `util.inspect` delegates the call
  to the object's `inspect` function, if it has one. You can read more about
  this delegation
  [here](https://iojs.org/api/util.html#util_custom_inspect_function_on_objects).

--- a/doc/api/repl.markdown
+++ b/doc/api/repl.markdown
@@ -237,3 +237,26 @@ The following key combinations in the REPL have these special effects:
   - `<ctrl>D` - Similar to the `.exit` keyword.
   - `<tab>` - Show both global and local(scope) variables
 
+
+### Overriding representation of Objects in REPL
+
+REPL module internally uses
+[`util.inspect`](https://iojs.org/api/util.html#util_util_inspect_object_options),
+ by default, to print the actual values. But, `util.inspect` delegates the call
+ to the object's `inspect` function, if it has one. You can read more about
+ this delegation,
+ [here](https://iojs.org/api/util.html#util_custom_inspect_function_on_objects).
+
+So, if you have defined an `inspect` function on an object, like this
+
+    > var obj = { foo: 'this will not show up in the inspect() output' };
+    undefined
+    > obj.inspect = function(depth) {
+    ...   return { bar: 'baz' };
+    ... };
+    [Function]
+
+and try to print `obj` in REPL, it will invoke the custom `inspect` function
+
+    > obj
+    { bar: 'baz' }


### PR DESCRIPTION
See: https://github.com/nodejs/io.js/issues/1798

When an Object is printed in REPL, the actual representation can be
overriden by defining `inspect` method on the objects. This patch
includes a note about the same in the REPL documentation