### PR TITLE
src: introduce process.release object

### DIFF
--- a/configure
+++ b/configure
@@ -191,6 +191,13 @@ parser.add_option('--tag',
     dest='tag',
     help='custom build tag')
 
+parser.add_option('--release-urlbase',
+    action='store',
+    dest='release_urlbase',
+    help='Provide a custom URL prefix for the `process.release` properties '
+         '`sourceUrl` and `headersUrl`. When compiling a release build, this '
+         'will default to https://iojs.org/download/release/')
+
 parser.add_option('--v8-options',
     action='store',
     dest='v8_options',
@@ -674,6 +681,8 @@ def configure_node(o):
     o['variables']['node_tag'] = '-' + options.tag
   else:
     o['variables']['node_tag'] = ''
+
+  o['variables']['node_release_urlbase'] = options.release_urlbase or ''
 
   if options.v8_options:
     o['variables']['node_v8_options'] = options.v8_options.replace('"', '\\"')

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -672,6 +672,36 @@ An example of the possible output looks like:
          target_arch: 'x64',
          v8_use_snapshot: 'true' } }
 
+## process.release
+
+An Object containing metadata related to the current release, including URLs
+for the source tarball and headers-only tarball.
+
+`process.release` contains the following properties:
+
+* `name`: a string with a value that will always be `"io.js"` for io.js.
+* `sourceUrl`: a complete URL pointing to a _.tar.gz_ file containing the
+  source of the current release.
+* `headersUrl`: a complete URL pointing to a _.tar.gz_ file containing only
+  the header files for the current release. This file is significantly smaller
+  than the full source file and can be used for compiling add-ons against
+  io.js.
+* `libUrl`: a complete URL pointing to an _iojs.lib_ file matching the
+  architecture and version of the current release. This file is used for
+  compiling add-ons against io.js. _This property is only present on Windows
+  builds of io.js and will be missing on all other platforms._
+
+e.g.
+
+    { name: 'io.js',
+      sourceUrl: 'https://iojs.org/download/release/v2.3.5/iojs-v2.3.5.tar.gz',
+      headersUrl: 'https://iojs.org/download/release/v2.3.5/iojs-v2.3.5-headers.tar.gz',
+      libUrl: 'https://iojs.org/download/release/v2.3.5/win-x64/iojs.lib' }
+
+In custom builds from non-release versions of the source tree, only the
+`name` property may be present. The additional properties should not be
+relied upon to exist.
+
 ## process.kill(pid[, signal])
 
 Send a signal to a process. `pid` is the process id and `signal` is the

--- a/node.gyp
+++ b/node.gyp
@@ -199,6 +199,11 @@
             'src/node_main.cc',
           ],
         }],
+        [ 'node_release_urlbase!=""', {
+          'defines': [
+            'NODE_RELEASE_URLBASE="<(node_release_urlbase)"',
+          ]
+        }],
         [ 'v8_enable_i18n_support==1', {
           'defines': [ 'NODE_HAVE_I18N_SUPPORT=1' ],
           'dependencies': [

--- a/src/node.cc
+++ b/src/node.cc
@@ -2756,6 +2756,39 @@ void SetupProcessObject(Environment* env,
                     "platform",
                     OneByteString(env->isolate(), NODE_PLATFORM));
 
+  // process.release
+  Local<Object> release = Object::New(env->isolate());
+  READONLY_PROPERTY(process, "release", release);
+  READONLY_PROPERTY(release, "name", OneByteString(env->isolate(), "io.js"));
+
+// if this is a release build and no explicit base has been set
+// substitute the standard release download URL
+#ifndef NODE_RELEASE_URLBASE
+# if NODE_VERSION_IS_RELEASE
+#  define NODE_RELEASE_URLBASE "https://iojs.org/download/release/"
+# endif
+#endif
+
+#if defined(NODE_RELEASE_URLBASE)
+#  define _RELEASE_URLPFX NODE_RELEASE_URLBASE "v" NODE_VERSION_STRING "/"
+#  define _RELEASE_URLFPFX _RELEASE_URLPFX "iojs-v" NODE_VERSION_STRING
+
+  READONLY_PROPERTY(release,
+                    "sourceUrl",
+                    OneByteString(env->isolate(),
+                    _RELEASE_URLFPFX ".tar.gz"));
+  READONLY_PROPERTY(release,
+                    "headersUrl",
+                    OneByteString(env->isolate(),
+                    _RELEASE_URLFPFX "-headers.tar.gz"));
+#  ifdef _WIN32
+  READONLY_PROPERTY(release,
+                    "libUrl",
+                    OneByteString(env->isolate(),
+                    _RELEASE_URLPFX "win-" NODE_ARCH "/iojs.lib"));
+#  endif
+#endif
+
   // process.argv
   Local<Array> arguments = Array::New(env->isolate(), argc);
   for (int i = 0; i < argc; ++i) {

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -35,6 +35,7 @@ set noperfctr_arg=
 set noperfctr_msi_arg=
 set i18n_arg=
 set download_arg=
+set release_urls_arg=
 
 :next-arg
 if "%1"=="" goto args-done
@@ -79,6 +80,7 @@ if "%config%"=="Debug" set debug_arg=--debug
 if defined nosnapshot set snapshot_arg=--without-snapshot
 if defined noetw set noetw_arg=--without-etw& set noetw_msi_arg=/p:NoETW=1
 if defined noperfctr set noperfctr_arg=--without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
+if defined RELEASE_URLBASE set release_urlbase_arg=--release-urlbase=%RELEASE_URLBASE%
 
 if "%i18n_arg%"=="full-icu" set i18n_arg=--with-intl=full-icu
 if "%i18n_arg%"=="small-icu" set i18n_arg=--with-intl=small-icu


### PR DESCRIPTION
Replaces #493 and looking for new feedback.

**Requirements**: provide URLs to node-gyp for downloading headers and other required files for building native addons. Decoupling it from a hardwired `http://nodejs.org/dist/` gives us the ability to provide locations for nightlies, next-nightlies, rcs and any other kind of test builds we want to provide with a working node-gyp. This is also the path to stop patching node-gyp for io.js and into the future gives us the option to continue releasing as `iojs` (or whatever name we happened to want!) if that's what we decide.

This new PR simplifies from the original approach, requiring only `--release-urlbase` be passed to `configure`. It's optional but required for release builds (e.g. `make binary RELEASE_URLBASE=https://iojs.org/download/nightly/`). We would supply a string such as `https://iojs.org/download/nightly/`. This gets converted to `process.release.sourceUrl`, `process.release.headersUrl` and `process.release.libUrl` if windows.

A few minor whitespace fixes in Makefile too.

```
$ ./iojs -pe process.release
{ sourceUrl: 'https://iojs.org/download/nightly/v2.3.5-nightly2015071047e2c5c828/iojs-v2.3.5-nightly2015071047e2c5c828.tar.gz',
  headersUrl: 'https://iojs.org/download/nightly/v2.3.5-nightly2015071047e2c5c828/iojs-v2.3.5-nightly2015071047e2c5c828-headers.tar.gz' }
```

_(on Windows you get a `libUrl` property that would point to something like `'https://iojs.org/download/nightly/v2.3.5-nightly2015071047e2c5c828/win-x64/iojs.lib'`)_