### PR TITLE
node: remove bad fn call and check

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1091,8 +1091,6 @@ Handle<Value> MakeCallback(Environment* env,
         return Undefined(env->isolate());
     }
   }
-  env->tick_callback_function()->Call(process, 0, nullptr);
-  CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
   if (try_catch.HasCaught()) {
     return Undefined(env->isolate());


### PR DESCRIPTION
These two lines exist because of a screw up on my part while combining
MakeCallback() and MakeDomainCallback().

The reason it never broke core tests is because any paths it would have
broken were rerouted to AsyncWrap::MakeCallback(). The only case that
node::MakeCallback() handles anymore is setImmediate().

Fix: a1da024 "node, async-wrap: remove MakeDomainCallback"

R=@bnoordhuis?

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/145/