### PR TITLE
path: assert path.join() arguments equally

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -477,9 +477,7 @@ posix.join = function() {
   var path = '';
   for (var i = 0; i < arguments.length; i++) {
     var segment = arguments[i];
-    if (typeof segment !== 'string') {
-      throw new TypeError('Arguments to path.join must be strings');
-    }
+    assertPath(segment);
     if (segment) {
       if (!path) {
         path += segment;


### PR DESCRIPTION
Re-use `assertPath()` when asserting path argument types in `join()` as throughout the rest of the `path` module.

This also ensures the same error message generated for posix as for win32.