### PR TITLE
child_process: fix arguments comments

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -62,7 +62,7 @@ exports._forkChild = function(fd) {
 };
 
 
-function normalizeExecArgs(command /*, options, callback */) {
+function normalizeExecArgs(command /*, options, callback*/) {
   var file, args, options, callback;
 
   if (typeof arguments[1] === 'function') {
@@ -98,7 +98,7 @@ function normalizeExecArgs(command /*, options, callback */) {
 }
 
 
-exports.exec = function(command /*, options, callback */) {
+exports.exec = function(command /*, options, callback*/) {
   var opts = normalizeExecArgs.apply(null, arguments);
   return exports.execFile(opts.file,
                           opts.args,
@@ -107,7 +107,7 @@ exports.exec = function(command /*, options, callback */) {
 };
 
 
-exports.execFile = function(file /* args, options, callback */) {
+exports.execFile = function(file /*, args, options, callback*/) {
   var args, callback;
   var options = {
     encoding: 'utf8',
@@ -443,7 +443,7 @@ function checkExecSyncError(ret) {
 }
 
 
-function execFileSync(/*command, options*/) {
+function execFileSync(/*command, args, options*/) {
   var opts = normalizeSpawnArguments.apply(null, arguments);
   var inheritStderr = !opts.options.stdio;
 
@@ -462,7 +462,7 @@ function execFileSync(/*command, options*/) {
 exports.execFileSync = execFileSync;
 
 
-function execSync(/*comand, options*/) {
+function execSync(/*command, options*/) {
   var opts = normalizeExecArgs.apply(null, arguments);
   var inheritStderr = opts.options ? !opts.options.stdio : true;
 


### PR DESCRIPTION
Sorry for the noise. While reading through child_process.js, I noticed the commented arguments to `execFileSync` were wrong. I also found some style inconsistencies and a typo while looking through the other argument comments.