### PR TITLE
test: properly clean up temp directory

### DIFF
--- a/test/sequential/test-chdir.js
+++ b/test/sequential/test-chdir.js
@@ -11,15 +11,28 @@ assert.equal(true, process.cwd() === __dirname);
 
 var dir = path.resolve(common.fixturesDir,
     'weird \uc3a4\uc3ab\uc3af characters \u00e1\u00e2\u00e3');
-fs.mkdirSync(dir);
+
+try {
+  fs.mkdirSync(dir);
+} catch (e) {
+  if (e.code !== 'EEXIST') {
+    cleanup();
+    throw e;
+  }
+}
+
 process.chdir(dir);
 assert(process.cwd() == dir);
 
 process.chdir('..');
 assert(process.cwd() == path.resolve(common.fixturesDir));
-fs.rmdirSync(dir);
+cleanup();
 
 assert.throws(function() { process.chdir({}); }, TypeError, 'Bad argument.');
 assert.throws(function() { process.chdir(); }, TypeError, 'Bad argument.');
 assert.throws(function() { process.chdir('x', 'y'); },
               TypeError, 'Bad argument.');
+
+function cleanup() {
+  fs.rmdirSync(dir);
+}


### PR DESCRIPTION
This test didn't clean up its temp directory when the `mkdirSync` call fails, which broke future runs of this test with `EEXIST` errors. This change ensures the temp directory is always cleaned up.

The reason I encountered this is because it seems to be a persistent failure on OS X 10.11, at least on my machine.