### PR TITLE
doc: properly inheriting from EventEmitter

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -168,16 +168,14 @@ triggered, the listener has been removed from the array of listeners for the
 Inheriting from `EventEmitter` is no different from inheriting from any other
 constructor function. For example:
 
-```js
-'use strict';
-const util = require('util');
-const EventEmitter = require('events').EventEmitter;
+    'use strict';
+    const util = require('util');
+    const EventEmitter = require('events').EventEmitter;
 
-function MyEventEmitter() {
-  // Initialize necessary properties from `EventEmitter` in this instance
-  EventEmitter.call(this);
-}
+    function MyEventEmitter() {
+      // Initialize necessary properties from `EventEmitter` in this instance
+      EventEmitter.call(this);
+    }
 
-// Inherit functions from `EventEmitter`'s prototype
-util.inherits(MyEventEmitter, EventEmitter);
-```
+    // Inherit functions from `EventEmitter`'s prototype
+    util.inherits(MyEventEmitter, EventEmitter);

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -162,3 +162,22 @@ added.
 This event is emitted *after* a listener is removed.  When this event is
 triggered, the listener has been removed from the array of listeners for the
 `event`.
+
+### Inheriting from 'EventEmitter'
+
+Inheriting from `EventEmitter` is no different from inheriting from any other
+constructor function. For example:
+
+```js
+'use strict';
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
+
+function MyEventEmitter() {
+  // Initialize necessary properties from `EventEmitter` in this instance
+  EventEmitter.call(this);
+}
+
+// Inherit functions from `EventEmitter`'s prototype
+util.inherits(MyEventEmitter, EventEmitter);
+```


### PR DESCRIPTION
There are so many buggy code out there, just because not
inheriting properly from `EventEmitter`. This patch gives a official
recommendation.