### PR TITLE
Deprecate mixed async crypto

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -647,7 +647,13 @@ exports.setEngine = function setEngine(id, flags) {
   return binding.setEngine(id, flags);
 };
 
-exports.randomBytes = exports.pseudoRandomBytes = randomBytes;
+exports.randomBytes = exports.pseudoRandomBytes = function(size, callback) {
+  if (typeof callback === 'function') {
+    const warning = 'using randomBytes asynchronously with a callback is deprecated.';
+    internalUtil.printDeprecationMessage(warning);
+  }
+  return randomBytes(size, callback);
+};
 
 exports.rng = exports.prng = randomBytes;
 


### PR DESCRIPTION
deprecates async usage of `.randomBytes()`