### PR TITLE
node-gyp: detect RC build with x.y.z-rc.n format

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -460,7 +460,7 @@ function install (gyp, argv, callback) {
 // pick out 'nightly', 'next-nightly' or 'rc' from the version string if it's there
 // adjust URL accordingly
 function getDefaultIojsUrl(version) {
-  var versionMatch = version.match(/^v\d+\.\d+\.\d+-(?:(?:(nightly|next-nightly)\d{8}[0-9a-f]{10})|(?:(rc)\d+))$/)
+  var versionMatch = version.match(/^v\d+\.\d+\.\d+-(?:(?:(nightly|next-nightly)\.?\d{8}[0-9a-f]{10})|(?:(rc)\.\d+))$/)
   var distType = versionMatch ? versionMatch[1] || versionMatch[2] : 'release'
   var defaultUrl = `https://iojs.org/download/${distType}`
   return defaultUrl
@@ -470,11 +470,15 @@ function getDefaultIojsUrl(version) {
 if (require.main === module) {
   var assert = require('assert')
   console.log('test v2.3.4 -> https://iojs.org/download/release')
-  assert(getDefaultIojsUrl('v2.3.4', 'https://iojs.org/download/release'))
+  assert.equal(getDefaultIojsUrl('v2.3.4'), 'https://iojs.org/download/release')
   console.log('test v2.3.4-nightly12345678aaaaaaaaaa -> https://iojs.org/download/nightly')
-  assert(getDefaultIojsUrl('v2.3.4-nightly12345678aaaaaaaaaa', 'https://iojs.org/download/nightly'))
+  assert.equal(getDefaultIojsUrl('v2.3.4-nightly12345678aaaaaaaaaa'), 'https://iojs.org/download/nightly')
+  console.log('test v2.3.4-nightly.12345678aaaaaaaaaa -> https://iojs.org/download/nightly')
+  assert.equal(getDefaultIojsUrl('v2.3.4-nightly.12345678aaaaaaaaaa'), 'https://iojs.org/download/nightly')
   console.log('test v2.3.4-next-nightly12345678aaaaaaaaaa -> https://iojs.org/download/release/next-nightly')
-  assert(getDefaultIojsUrl('v2.3.4-next-nightly12345678aaaaaaaaaa', 'https://iojs.org/download/next-nightly'))
-  console.log('test v2.3.4-rc100 -> https://iojs.org/download/rc')
-  assert(getDefaultIojsUrl('v2.3.4-rc100', 'https://iojs.org/download/rc'))
+  assert.equal(getDefaultIojsUrl('v2.3.4-next-nightly12345678aaaaaaaaaa'), 'https://iojs.org/download/next-nightly')
+  console.log('test v2.3.4-next-nightly.12345678aaaaaaaaaa -> https://iojs.org/download/release/next-nightly')
+  assert.equal(getDefaultIojsUrl('v2.3.4-next-nightly.12345678aaaaaaaaaa'), 'https://iojs.org/download/next-nightly')
+  console.log('test v2.3.4-rc.100 -> https://iojs.org/download/rc')
+  assert.equal(getDefaultIojsUrl('v2.3.4-rc.100'), 'https://iojs.org/download/rc')
 }


### PR DESCRIPTION
Targetting next, builds on bda3a2dd9d5a4dc3718835b00403b6d1a3d4a7bb but we've changed the version string for RC builds so the regex needs to work.

I'm thinking that we should probably squash all of the node-gyp patches into one or two since they are getting out of hand. Perhaps we should pull in the latest npm and do it with that. Thoughts?