### PR TITLE
Standard-compliant getters

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -353,8 +353,12 @@ CryptoStream.prototype.setKeepAlive = function(enable, initialDelay) {
   if (this.socket) this.socket.setKeepAlive(enable, initialDelay);
 };
 
-CryptoStream.prototype.__defineGetter__('bytesWritten', function() {
-  return this.socket ? this.socket.bytesWritten : 0;
+Object.defineProperty(CryptoStream.prototype, 'bytesWritten', {
+  get: function() {
+    return this.socket ? this.socket.bytesWritten : 0;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 CryptoStream.prototype.getPeerCertificate = function(detailed) {
@@ -530,26 +534,46 @@ CleartextStream.prototype.address = function() {
 };
 
 
-CleartextStream.prototype.__defineGetter__('remoteAddress', function() {
-  return this.socket && this.socket.remoteAddress;
+Object.defineProperty(CleartextStream.prototype, 'remoteAddress', {
+  get: function() {
+    return this.socket && this.socket.remoteAddress;
+  },
+  enumerable: true,
+  configurable: true
 });
 
-CleartextStream.prototype.__defineGetter__('remoteFamily', function() {
-  return this.socket && this.socket.remoteFamily;
+Object.defineProperty(CleartextStream.prototype, 'remoteFamily', {
+  get: function() {
+    return this.socket && this.socket.remoteFamily;
+  },
+  enumerable: true,
+  configurable: true
 });
 
-CleartextStream.prototype.__defineGetter__('remotePort', function() {
-  return this.socket && this.socket.remotePort;
+Object.defineProperty(CleartextStream.prototype, 'remotePort', {
+  get: function() {
+    return this.socket && this.socket.remotePort;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 
-CleartextStream.prototype.__defineGetter__('localAddress', function() {
-  return this.socket && this.socket.localAddress;
+Object.defineProperty(CleartextStream.prototype, 'localAddress', {
+  get: function() {
+    return this.socket && this.socket.localAddress;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 
-CleartextStream.prototype.__defineGetter__('localPort', function() {
-  return this.socket && this.socket.localPort;
+Object.defineProperty(CleartextStream.prototype, 'localPort', {
+  get: function() {
+    return this.socket && this.socket.localPort;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -683,13 +683,20 @@ function filterDuplicates(names) {
 }
 
 // Legacy API
-exports.__defineGetter__('createCredentials',
-  internalUtil.deprecate(function() {
-    return require('tls').createSecureContext;
-  }, 'crypto.createCredentials is deprecated. ' +
-     'Use tls.createSecureContext instead.'));
+Object.defineProperty(exports, 'createCredentials', {
+  get: internalUtil.deprecate(function() {
+      return require('tls').createSecureContext;
+    }, 'crypto.createCredentials is deprecated. ' +
+       'Use tls.createSecureContext instead.'),
+  enumerable: true,
+  configurable: true
+});
 
-exports.__defineGetter__('Credentials', internalUtil.deprecate(function() {
-  return require('tls').SecureContext;
-}, 'crypto.Credentials is deprecated. ' +
-   'Use tls.createSecureContext instead.'));
+Object.defineProperty(exports, 'Credentials', {
+  get: internalUtil.deprecate(function() {
+      return require('tls').SecureContext;
+    }, 'crypto.Credentials is deprecated. ' +
+       'Use tls.createSecureContext instead.'),
+  enumerable: true,
+  configurable: true
+});

--- a/lib/net.js
+++ b/lib/net.js
@@ -573,16 +573,28 @@ Socket.prototype._getpeername = function() {
 };
 
 
-Socket.prototype.__defineGetter__('remoteAddress', function() {
-  return this._getpeername().address;
+Object.defineProperty(Socket.prototype, 'remoteAddress', {
+  get: function() {
+    return this._getpeername().address;
+  },
+  enumerable: true,
+  configurable: true
 });
 
-Socket.prototype.__defineGetter__('remoteFamily', function() {
-  return this._getpeername().family;
+Object.defineProperty(Socket.prototype, 'remoteFamily', {
+  get: function() {
+    return this._getpeername().family;
+  },
+  enumerable: true,
+  configurable: true
 });
 
-Socket.prototype.__defineGetter__('remotePort', function() {
-  return this._getpeername().port;
+Object.defineProperty(Socket.prototype, 'remotePort', {
+  get: function() {
+    return this._getpeername().port;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 
@@ -600,13 +612,21 @@ Socket.prototype._getsockname = function() {
 };
 
 
-Socket.prototype.__defineGetter__('localAddress', function() {
-  return this._getsockname().address;
+Object.defineProperty(Socket.prototype, 'localAddress', {
+  get: function() {
+    return this._getsockname().address;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 
-Socket.prototype.__defineGetter__('localPort', function() {
-  return this._getsockname().port;
+Object.defineProperty(Socket.prototype, 'localPort', {
+  get: function() {
+    return this._getsockname().port;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 
@@ -719,27 +739,31 @@ function createWriteReq(req, handle, data, encoding) {
 }
 
 
-Socket.prototype.__defineGetter__('bytesWritten', function() {
-  var bytes = this._bytesDispatched,
-      state = this._writableState,
-      data = this._pendingData,
-      encoding = this._pendingEncoding;
+Object.defineProperty(Socket.prototype, 'bytesWritten', {
+  get: function() {
+    var bytes = this._bytesDispatched,
+        state = this._writableState,
+        data = this._pendingData,
+        encoding = this._pendingEncoding;
 
-  state.getBuffer().forEach(function(el) {
-    if (el.chunk instanceof Buffer)
-      bytes += el.chunk.length;
-    else
-      bytes += Buffer.byteLength(el.chunk, el.encoding);
-  });
+    state.getBuffer().forEach(function(el) {
+      if (el.chunk instanceof Buffer)
+        bytes += el.chunk.length;
+      else
+        bytes += Buffer.byteLength(el.chunk, el.encoding);
+    });
 
-  if (data) {
-    if (data instanceof Buffer)
-      bytes += data.length;
-    else
-      bytes += Buffer.byteLength(data, encoding);
-  }
+    if (data) {
+      if (data instanceof Buffer)
+        bytes += data.length;
+      else
+        bytes += Buffer.byteLength(data, encoding);
+    }
 
-  return bytes;
+    return bytes;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -156,11 +156,15 @@ function Interface(input, output, completer, terminal) {
 
 inherits(Interface, EventEmitter);
 
-Interface.prototype.__defineGetter__('columns', function() {
-  var columns = Infinity;
-  if (this.output && this.output.columns)
-    columns = this.output.columns;
-  return columns;
+Object.defineProperty(Interface.prototype, 'columns', {
+  get: function() {
+    var columns = Infinity;
+    if (this.output && this.output.columns)
+      columns = this.output.columns;
+    return columns;
+  },
+  enumerable: true,
+  configurable: true
 });
 
 Interface.prototype.setPrompt = function(prompt) {


### PR DESCRIPTION
The non-standard `__defineGetter__` calls are scattered through the code.
These can be safely replaced with standard `Object.defineProperty`.