### PR TITLE
lib: issuing deprecation warning for freelist

### DIFF
--- a/lib/freelist.js
+++ b/lib/freelist.js
@@ -1,3 +1,6 @@
 'use strict';
 
+const util = require('internal/util');
+
 module.exports = require('internal/freelist');
+util.printDeprecationMessage('freelist module is deprecated.');

--- a/test/parallel/test-freelist.js
+++ b/test/parallel/test-freelist.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Flags: --expose-internals
+
+const assert = require('assert');
+const freelist = require('freelist');
+const internalFreelist = require('internal/freelist');
+
+assert.equal(typeof freelist, 'object');
+assert.equal(typeof freelist.FreeList, 'function');
+assert.strictEqual(freelist, internalFreelist);
+
+const flist1 = new freelist.FreeList('flist1', 3, String);
+
+// Allocating when empty, should not change the list size
+var result = flist1.alloc('test');
+assert.strictEqual(typeof result, 'string');
+assert.strictEqual(result, 'test');
+assert.strictEqual(flist1.list.length, 0);
+
+// Exhaust the free list
+assert(flist1.free('test1'));
+assert(flist1.free('test2'));
+assert(flist1.free('test3'));
+
+// Now it should not return 'true', as max length is exceeded
+assert.strictEqual(flist1.free('test4'), false);
+assert.strictEqual(flist1.free('test5'), false);
+
+// At this point 'alloc' should just return the stored values
+assert.strictEqual(flist1.alloc(), 'test1');
+assert.strictEqual(flist1.alloc(), 'test2');
+assert.strictEqual(flist1.alloc(), 'test3');


### PR DESCRIPTION
As per the dicussion in https://github.com/nodejs/io.js/issues/569,
this patch issues a deprecation warning when freelist modeule is
required.