### PR TITLE
util: removing redundant checks in is* functions

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -607,8 +607,7 @@ function isUndefined(arg) {
 exports.isUndefined = isUndefined;
 
 function isRegExp(re) {
-  return re !== null && typeof re === 'object' &&
-         objectToString(re) === '[object RegExp]';
+  return objectToString(re) === '[object RegExp]';
 }
 exports.isRegExp = isRegExp;
 
@@ -618,14 +617,12 @@ function isObject(arg) {
 exports.isObject = isObject;
 
 function isDate(d) {
-  return d !== null && typeof d === 'object' &&
-         objectToString(d) === '[object Date]';
+  return objectToString(d) === '[object Date]';
 }
 exports.isDate = isDate;
 
 function isError(e) {
-  return e !== null && typeof e === 'object' &&
-      (objectToString(e) === '[object Error]' || e instanceof Error);
+  return objectToString(e) === '[object Error]' || e instanceof Error;
 }
 exports.isError = isError;
 


### PR DESCRIPTION
When Object.prototype.toString is used to determine the type, we don't
have to explicitly check for other types. This patch removes the
redundant checks like that.