### PR TITLE
repl: removing the buggy trimWhitespace function

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -272,7 +272,7 @@ function REPLServer(prompt,
     if (self._inTemplateLiteral) {
       self._inTemplateLiteral = false;
     } else {
-      cmd = trimWhitespace(cmd);
+      cmd = cmd.trim();
     }
 
     // Check to see if a REPL keyword was used. If it returns true,
@@ -943,18 +943,6 @@ function defineDefaultCommands(repl) {
     }
   });
 }
-
-
-function trimWhitespace(cmd) {
-  const trimmer = /^\s*(.+)\s*$/m;
-  var matches = trimmer.exec(cmd);
-
-  if (matches && matches.length === 2) {
-    return matches[1];
-  }
-  return '';
-}
-
 
 function regexpEscape(s) {
   return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');

--- a/test/fixtures/repl-load.js
+++ b/test/fixtures/repl-load.js
@@ -1,0 +1,1 @@
+module.exports = 'repl';

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -189,7 +189,13 @@ function error_test() {
     { client: client_unix, send: 'url.format("http://google.com")',
       expect: 'http://google.com/' },
     { client: client_unix, send: 'var path = 42; path',
-      expect: '42' }
+      expect: '42' },
+    // making sure that the fixed trim logic works fine
+    { client: client_unix, send: '    \t  .break \t \t  ',
+      expect: prompt_unix },
+    { client: client_unix, send: '.load ' +
+              require('path').join(common.fixturesDir, 'repl-load.js     \t   '),
+      expect: prompt_unix + '\'repl\'\n' + prompt_unix },
   ]);
 }
 


### PR DESCRIPTION
As it is, the trimWhitespace function will not remove the white sapce
characters at the end of the string, as the greedy capturing group .+
captures everything till end of the string, leaving \s* with nothing.
This patch removes the function and uses a proper RegEx which will
match all the whitespace characters at the beginning and ending of the
string and replaces the matched whitespace characters with empty string.

This is a floating fix till https://github.com/nodejs/io.js/pull/2163 lands

cc @chrisdickinson 