### PR TITLE
test: fix test-debug-port-from-cmdline

### DIFF
--- a/test/parallel/test-debug-port-from-cmdline.js
+++ b/test/parallel/test-debug-port-from-cmdline.js
@@ -4,11 +4,11 @@ var assert = require('assert');
 var spawn = require('child_process').spawn;
 
 var debugPort = common.PORT;
-var args = ['--debug-port=' + debugPort];
+var args = ['--interactive', '--debug-port=' + debugPort];
 var childOptions = { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] };
 var child = spawn(process.execPath, args, childOptions);
 
-child.stdin.end("process.send({ msg: 'childready' });");
+child.stdin.write("process.send({ msg: 'childready' });\n");
 
 child.stderr.on('data', function(data) {
   var lines = data.toString().replace(/\r/g, '').trim().split('\n');
@@ -23,6 +23,7 @@ child.on('message', function onChildMsg(message) {
 
 process.on('exit', function() {
   child.kill();
+  assertOutputLines();
 });
 
 var outputLines = [];
@@ -31,7 +32,6 @@ function processStderrLine(line) {
   outputLines.push(line);
 
   if (/Debugger listening/.test(line)) {
-    assertOutputLines();
     process.exit();
   }
 }


### PR DESCRIPTION
`test-debug-port-from-cmdline.js` has been failing occasionally with unclear errors in Windows and silently (false positive) in Linux.

Errors found in Windows:
```
Error: Not enough storage is available to process this command.
Error: Access is denied.
Error: The system cannot find the file specified.
```

Note that in case of success it should always display two lines of output:
```
> Starting debugger agent.
> Debugger listening on port 12346
```

This test was failing because the spawned process was terminated before anything could be done, by calling `child.stdin.end`. With this change, the child's stdin is no longer closed. When the stdin is not a tty, io.js waits for the whole input before starting, so the child must be run with `--interactive` to process the command sent by the parent. The child is killed explicitly by the parent before it exits.

This test was failing silently because the asserts were not called if nothing was received from the child. This fix moves assertOutputLines to always run on exit.

Fixes nodejs/io.js#2094
Fixes nodejs/io.js#2177