### PR TITLE
src: make base64 decoding 10-15% faster

### DIFF
--- a/benchmark/buffers/buffer-base64-decode.js
+++ b/benchmark/buffers/buffer-base64-decode.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var common = require('../common.js');
+
+var bench = common.createBenchmark(main, {});
+
+function main(conf) {
+  for (var s = 'abcd'; s.length < 32 << 20; s += s);
+  s.match(/./);  // Flatten string.
+  assert.equal(s.length % 4, 0);
+  var b = Buffer(s.length / 4 * 3);
+  b.write(s, 0, s.length, 'base64');
+  bench.start();
+  for (var i = 0; i < 32; i += 1) b.base64Write(s, 0, s.length);
+  bench.end(32);
+}

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -802,7 +802,9 @@ assert.equal(buf[4], 0);
 
 // Check for fractional length args, junk length args, etc.
 // https://github.com/joyent/node/issues/1758
-Buffer(3.3).toString(); // throws bad argument error in commit 43cb4ec
+
+// Call .fill() first, stops valgrind warning about uninitialized memory reads.
+Buffer(3.3).fill().toString(); // throws bad argument error in commit 43cb4ec
 assert.equal(Buffer(-1).length, 0);
 assert.equal(Buffer(NaN).length, 0);
 assert.equal(Buffer(3.3).length, 3);


### PR DESCRIPTION
Make the inner loop execute fewer compare-and-branch executions per
processed byte, resulting in a 10-15% speedup.

This coincidentally fixes an out-of-bounds read:

    while (unbase64(*src) < 0 && src < srcEnd)

Should have read:

    while (src < srcEnd && unbase64(*src) < 0)

But this commit removes the offending code altogether.

Fixes: #2166

R=@trevnorris?

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/155/