### PR TITLE
buffer: fix missing null/undefined check

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -105,6 +105,10 @@ function fromObject(obj) {
     return b;
   }
 
+  if (obj == null) {
+    throw new TypeError('must start with number, buffer, array or string');
+  }
+
   if (obj instanceof ArrayBuffer) {
     return binding.createFromArrayBuffer(obj);
   }

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1179,3 +1179,7 @@ Buffer.poolSize = ps;
 assert.throws(function() {
   Buffer(10).copy();
 });
+
+assert.throws(function() {
+  new Buffer();
+}, /must start with number, buffer, array or string/);


### PR DESCRIPTION
The new implementation of Buffer missed the check for null/undefined as
the first argument to new Buffer(). Reintroduce the check and add test.

Fix: e8734c0 "buffer: implement Uint8Array backed Buffer"
Fix: https://github.com/nodejs/io.js/issues/2194

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/159/