### PR TITLE
docs: link to more up-to-date v8 docs

### DIFF
--- a/doc/api/addons.markdown
+++ b/doc/api/addons.markdown
@@ -8,7 +8,7 @@ knowledge of several libraries:
    creating objects, calling functions, etc.  Documented mostly in the
    `v8.h` header file (`deps/v8/include/v8.h` in the io.js source
    tree), which is also available
-   [online](http://izs.me/v8-docs/main.html).
+   [online](https://v8docs.nodesource.com/).
 
  - [libuv](https://github.com/libuv/libuv), C event loop library.
    Anytime one needs to wait for a file descriptor to become readable,


### PR DESCRIPTION
Updated replacement for https://github.com/nodejs/io.js/pull/2155

Using nodesource docs is at least a step forward. We'll let https://github.com/nodejs/docs/issues/3 sort out final details later.