### PR TITLE
src: replace usage of v8::Handle with v8::Local

### DIFF
--- a/benchmark/misc/function_call/binding.cc
+++ b/benchmark/misc/function_call/binding.cc
@@ -9,7 +9,7 @@ void Hello(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(c++);
 }
 
-extern "C" void init (Handle<Object> target) {
+extern "C" void init (Local<Object> target) {
   HandleScope scope(Isolate::GetCurrent());
   NODE_SET_METHOD(target, "hello", Hello);
 }

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -14,7 +14,7 @@
 namespace node {
 
 inline AsyncWrap::AsyncWrap(Environment* env,
-                            v8::Handle<v8::Object> object,
+                            v8::Local<v8::Object> object,
                             ProviderType provider,
                             AsyncWrap* parent)
     : BaseObject(env, object), bits_(static_cast<uint32_t>(provider) << 1) {
@@ -58,20 +58,20 @@ inline AsyncWrap::ProviderType AsyncWrap::provider_type() const {
 }
 
 
-inline v8::Handle<v8::Value> AsyncWrap::MakeCallback(
-    const v8::Handle<v8::String> symbol,
+inline v8::Local<v8::Value> AsyncWrap::MakeCallback(
+    const v8::Local<v8::String> symbol,
     int argc,
-    v8::Handle<v8::Value>* argv) {
+    v8::Local<v8::Value>* argv) {
   v8::Local<v8::Value> cb_v = object()->Get(symbol);
   CHECK(cb_v->IsFunction());
   return MakeCallback(cb_v.As<v8::Function>(), argc, argv);
 }
 
 
-inline v8::Handle<v8::Value> AsyncWrap::MakeCallback(
+inline v8::Local<v8::Value> AsyncWrap::MakeCallback(
     uint32_t index,
     int argc,
-    v8::Handle<v8::Value>* argv) {
+    v8::Local<v8::Value>* argv) {
   v8::Local<v8::Value> cb_v = object()->Get(index);
   CHECK(cb_v->IsFunction());
   return MakeCallback(cb_v.As<v8::Function>(), argc, argv);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -12,7 +12,6 @@ using v8::Array;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HandleScope;
 using v8::HeapProfiler;
 using v8::Integer;
@@ -83,7 +82,7 @@ intptr_t RetainedAsyncInfo::GetSizeInBytes() {
 }
 
 
-RetainedObjectInfo* WrapperInfo(uint16_t class_id, Handle<Value> wrapper) {
+RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
   // No class_id should be the provider type of NONE.
   CHECK_NE(NODE_ASYNC_ID_OFFSET, class_id);
   CHECK(wrapper->IsObject());
@@ -129,9 +128,9 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-static void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+static void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
@@ -160,9 +159,9 @@ void LoadAsyncWrapperInfo(Environment* env) {
 }
 
 
-Handle<Value> AsyncWrap::MakeCallback(const Handle<Function> cb,
+Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
                                       int argc,
-                                      Handle<Value>* argv) {
+                                      Local<Value>* argv) {
   CHECK(env()->context() == env()->isolate()->GetCurrentContext());
 
   Local<Object> context = object();

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -47,7 +47,7 @@ class AsyncWrap : public BaseObject {
   };
 
   inline AsyncWrap(Environment* env,
-                   v8::Handle<v8::Object> object,
+                   v8::Local<v8::Object> object,
                    ProviderType provider,
                    AsyncWrap* parent = nullptr);
 
@@ -56,15 +56,15 @@ class AsyncWrap : public BaseObject {
   inline ProviderType provider_type() const;
 
   // Only call these within a valid HandleScope.
-  v8::Handle<v8::Value> MakeCallback(const v8::Handle<v8::Function> cb,
+  v8::Local<v8::Value> MakeCallback(const v8::Local<v8::Function> cb,
                                      int argc,
-                                     v8::Handle<v8::Value>* argv);
-  inline v8::Handle<v8::Value> MakeCallback(const v8::Handle<v8::String> symbol,
+                                     v8::Local<v8::Value>* argv);
+  inline v8::Local<v8::Value> MakeCallback(const v8::Local<v8::String> symbol,
                                             int argc,
-                                            v8::Handle<v8::Value>* argv);
-  inline v8::Handle<v8::Value> MakeCallback(uint32_t index,
+                                            v8::Local<v8::Value>* argv);
+  inline v8::Local<v8::Value> MakeCallback(uint32_t index,
                                             int argc,
-                                            v8::Handle<v8::Value>* argv);
+                                            v8::Local<v8::Value>* argv);
 
   virtual size_t self_size() const = 0;
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -38,7 +38,6 @@ using v8::EscapableHandleScope;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -1240,9 +1239,9 @@ static void CaresTimerClose(Environment* env,
 }
 
 
-static void Initialize(Handle<Object> target,
-                       Handle<Value> unused,
-                       Handle<Context> context) {
+static void Initialize(Local<Object> target,
+                       Local<Value> unused,
+                       Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   int r = ares_library_init(ARES_LIB_INIT_ALL);

--- a/src/debug-agent.cc
+++ b/src/debug-agent.cc
@@ -39,7 +39,6 @@ using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -14,7 +14,6 @@ namespace node {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -24,9 +23,9 @@ using v8::Value;
 
 class FSEventWrap: public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context);
+  static void Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context);
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Start(const FunctionCallbackInfo<Value>& args);
   static void Close(const FunctionCallbackInfo<Value>& args);
@@ -34,7 +33,7 @@ class FSEventWrap: public HandleWrap {
   size_t self_size() const override { return sizeof(*this); }
 
  private:
-  FSEventWrap(Environment* env, Handle<Object> object);
+  FSEventWrap(Environment* env, Local<Object> object);
   virtual ~FSEventWrap() override;
 
   static void OnEvent(uv_fs_event_t* handle, const char* filename, int events,
@@ -45,7 +44,7 @@ class FSEventWrap: public HandleWrap {
 };
 
 
-FSEventWrap::FSEventWrap(Environment* env, Handle<Object> object)
+FSEventWrap::FSEventWrap(Environment* env, Local<Object> object)
     : HandleWrap(env,
                  object,
                  reinterpret_cast<uv_handle_t*>(&handle_),
@@ -59,9 +58,9 @@ FSEventWrap::~FSEventWrap() {
 }
 
 
-void FSEventWrap::Initialize(Handle<Object> target,
-                             Handle<Value> unused,
-                             Handle<Context> context) {
+void FSEventWrap::Initialize(Local<Object> target,
+                             Local<Value> unused,
+                             Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -11,7 +11,6 @@ namespace node {
 
 using v8::Context;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
@@ -59,7 +58,7 @@ void HandleWrap::Close(const FunctionCallbackInfo<Value>& args) {
 
 
 HandleWrap::HandleWrap(Environment* env,
-                       Handle<Object> object,
+                       Local<Object> object,
                        uv_handle_t* handle,
                        AsyncWrap::ProviderType provider,
                        AsyncWrap* parent)

--- a/src/handle_wrap.h
+++ b/src/handle_wrap.h
@@ -44,7 +44,7 @@ class HandleWrap : public AsyncWrap {
 
  protected:
   HandleWrap(Environment* env,
-             v8::Handle<v8::Object> object,
+             v8::Local<v8::Object> object,
              uv_handle_t* handle,
              AsyncWrap::ProviderType provider,
              AsyncWrap* parent = nullptr);

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -15,14 +15,13 @@ using v8::Context;
 using v8::External;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
 using v8::Value;
 
 
-JSStream::JSStream(Environment* env, Handle<Object> obj, AsyncWrap* parent)
+JSStream::JSStream(Environment* env, Local<Object> obj, AsyncWrap* parent)
     : StreamBase(env),
       AsyncWrap(env, obj, AsyncWrap::PROVIDER_JSSTREAM, parent) {
   node::Wrap(obj, this);
@@ -201,9 +200,9 @@ void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void JSStream::Initialize(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void JSStream::Initialize(Local<Object> target,
+                          Local<Value> unused,
+                          Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -10,9 +10,9 @@ namespace node {
 
 class JSStream : public StreamBase, public AsyncWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
 
   ~JSStream();
 
@@ -31,7 +31,7 @@ class JSStream : public StreamBase, public AsyncWrap {
   size_t self_size() const override { return sizeof(*this); }
 
  protected:
-  JSStream(Environment* env, v8::Handle<v8::Object> obj, AsyncWrap* parent);
+  JSStream(Environment* env, v8::Local<v8::Object> obj, AsyncWrap* parent);
 
   AsyncWrap* GetAsyncWrap() override;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -88,7 +88,6 @@ using v8::Exception;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::HeapStatistics;
 using v8::Integer;
@@ -985,11 +984,11 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-Handle<Value> MakeCallback(Environment* env,
-                           Handle<Value> recv,
-                           const Handle<Function> callback,
+Local<Value> MakeCallback(Environment* env,
+                           Local<Value> recv,
+                           const Local<Function> callback,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   // If you hit this assertion, you forgot to enter the v8::Context first.
   CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
@@ -1093,43 +1092,43 @@ Handle<Value> MakeCallback(Environment* env,
 
 
 // Internal only.
-Handle<Value> MakeCallback(Environment* env,
-                           Handle<Object> recv,
+Local<Value> MakeCallback(Environment* env,
+                           Local<Object> recv,
                            uint32_t index,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   Local<Value> cb_v = recv->Get(index);
   CHECK(cb_v->IsFunction());
   return MakeCallback(env, recv.As<Value>(), cb_v.As<Function>(), argc, argv);
 }
 
 
-Handle<Value> MakeCallback(Environment* env,
-                           Handle<Object> recv,
-                           Handle<String> symbol,
+Local<Value> MakeCallback(Environment* env,
+                           Local<Object> recv,
+                           Local<String> symbol,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   Local<Value> cb_v = recv->Get(symbol);
   CHECK(cb_v->IsFunction());
   return MakeCallback(env, recv.As<Value>(), cb_v.As<Function>(), argc, argv);
 }
 
 
-Handle<Value> MakeCallback(Environment* env,
-                           Handle<Object> recv,
+Local<Value> MakeCallback(Environment* env,
+                           Local<Object> recv,
                            const char* method,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   Local<String> method_string = OneByteString(env->isolate(), method);
   return MakeCallback(env, recv, method_string, argc, argv);
 }
 
 
-Handle<Value> MakeCallback(Isolate* isolate,
-                           Handle<Object> recv,
+Local<Value> MakeCallback(Isolate* isolate,
+                           Local<Object> recv,
                            const char* method,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   EscapableHandleScope handle_scope(isolate);
   Local<Context> context = recv->CreationContext();
   Environment* env = Environment::GetCurrent(context);
@@ -1139,11 +1138,11 @@ Handle<Value> MakeCallback(Isolate* isolate,
 }
 
 
-Handle<Value> MakeCallback(Isolate* isolate,
-                           Handle<Object> recv,
-                           Handle<String> symbol,
+Local<Value> MakeCallback(Isolate* isolate,
+                           Local<Object> recv,
+                           Local<String> symbol,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   EscapableHandleScope handle_scope(isolate);
   Local<Context> context = recv->CreationContext();
   Environment* env = Environment::GetCurrent(context);
@@ -1153,11 +1152,11 @@ Handle<Value> MakeCallback(Isolate* isolate,
 }
 
 
-Handle<Value> MakeCallback(Isolate* isolate,
-                           Handle<Object> recv,
-                           Handle<Function> callback,
+Local<Value> MakeCallback(Isolate* isolate,
+                           Local<Object> recv,
+                           Local<Function> callback,
                            int argc,
-                           Handle<Value> argv[]) {
+                           Local<Value> argv[]) {
   EscapableHandleScope handle_scope(isolate);
   Local<Context> context = recv->CreationContext();
   Environment* env = Environment::GetCurrent(context);
@@ -1247,7 +1246,7 @@ enum encoding ParseEncoding(const char* encoding,
 
 
 enum encoding ParseEncoding(Isolate* isolate,
-                            Handle<Value> encoding_v,
+                            Local<Value> encoding_v,
                             enum encoding default_encoding) {
   if (!encoding_v->IsString())
     return default_encoding;
@@ -1271,7 +1270,7 @@ Local<Value> Encode(Isolate* isolate, const uint16_t* buf, size_t len) {
 
 // Returns -1 if the handle was not valid for decoding
 ssize_t DecodeBytes(Isolate* isolate,
-                    Handle<Value> val,
+                    Local<Value> val,
                     enum encoding encoding) {
   HandleScope scope(isolate);
 
@@ -1289,14 +1288,14 @@ ssize_t DecodeBytes(Isolate* isolate,
 ssize_t DecodeWrite(Isolate* isolate,
                     char* buf,
                     size_t buflen,
-                    Handle<Value> val,
+                    Local<Value> val,
                     enum encoding encoding) {
   return StringBytes::Write(isolate, buf, buflen, val, encoding, nullptr);
 }
 
 void AppendExceptionLine(Environment* env,
-                         Handle<Value> er,
-                         Handle<Message> message) {
+                         Local<Value> er,
+                         Local<Message> message) {
   if (message.IsEmpty())
     return;
 
@@ -1404,8 +1403,8 @@ void AppendExceptionLine(Environment* env,
 
 
 static void ReportException(Environment* env,
-                            Handle<Value> er,
-                            Handle<Message> message) {
+                            Local<Value> er,
+                            Local<Message> message) {
   HandleScope scope(env->isolate());
 
   AppendExceptionLine(env, er, message);
@@ -1460,8 +1459,8 @@ static void ReportException(Environment* env, const TryCatch& try_catch) {
 
 // Executes a str within the current v8 context.
 static Local<Value> ExecuteString(Environment* env,
-                                  Handle<String> source,
-                                  Handle<String> filename) {
+                                  Local<String> source,
+                                  Local<String> filename) {
   EscapableHandleScope scope(env->isolate());
   TryCatch try_catch;
 
@@ -1684,7 +1683,7 @@ static const char* name_by_gid(gid_t gid) {
 #endif
 
 
-static uid_t uid_by_name(Isolate* isolate, Handle<Value> value) {
+static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
     return static_cast<uid_t>(value->Uint32Value());
   } else {
@@ -1694,7 +1693,7 @@ static uid_t uid_by_name(Isolate* isolate, Handle<Value> value) {
 }
 
 
-static gid_t gid_by_name(Isolate* isolate, Handle<Value> value) {
+static gid_t gid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
     return static_cast<gid_t>(value->Uint32Value());
   } else {
@@ -2051,7 +2050,7 @@ struct node_module* get_linked_module(const char* name) {
   return mp;
 }
 
-typedef void (UV_DYNAMIC* extInit)(Handle<Object> exports);
+typedef void (UV_DYNAMIC* extInit)(Local<Object> exports);
 
 // DLOpen is process.dlopen(module, filename).
 // Used to load 'module.node' dynamically shared objects.
@@ -2148,8 +2147,8 @@ NO_RETURN void FatalError(const char* location, const char* message) {
 
 
 void FatalException(Isolate* isolate,
-                    Handle<Value> error,
-                    Handle<Message> message) {
+                    Local<Value> error,
+                    Local<Message> message) {
   HandleScope scope(isolate);
 
   Environment* env = Environment::GetCurrent(isolate);
@@ -2195,7 +2194,7 @@ void FatalException(Isolate* isolate, const TryCatch& try_catch) {
 }
 
 
-void OnMessage(Handle<Message> message, Handle<Value> error) {
+void OnMessage(Local<Message> message, Local<Value> error) {
   // The current version of V8 sends messages for errors only
   // (thus `error` is always set).
   FatalException(Isolate::GetCurrent(), error, message);
@@ -2464,7 +2463,7 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
 }
 
 
-static Handle<Object> GetFeatures(Environment* env) {
+static Local<Object> GetFeatures(Environment* env) {
   EscapableHandleScope scope(env->isolate());
 
   Local<Object> obj = Object::New(env->isolate());
@@ -3706,7 +3705,7 @@ int EmitExit(Environment* env) {
   Local<Object> process_object = env->process_object();
   process_object->Set(env->exiting_string(), True(env->isolate()));
 
-  Handle<String> exitCode = env->exit_code_string();
+  Local<String> exitCode = env->exit_code_string();
   int code = process_object->Get(exitCode)->Int32Value();
 
   Local<Value> args[] = {
@@ -3723,7 +3722,7 @@ int EmitExit(Environment* env) {
 
 // Just a convenience method
 Environment* CreateEnvironment(Isolate* isolate,
-                               Handle<Context> context,
+                               Local<Context> context,
                                int argc,
                                const char* const* argv,
                                int exec_argc,
@@ -3745,7 +3744,7 @@ Environment* CreateEnvironment(Isolate* isolate,
 }
 
 static Environment* CreateEnvironment(Isolate* isolate,
-                                      Handle<Context> context,
+                                      Local<Context> context,
                                       NodeInstanceData* instance_data) {
   return CreateEnvironment(isolate,
                            instance_data->event_loop(),
@@ -3773,7 +3772,7 @@ static void HandleCleanup(Environment* env,
 
 Environment* CreateEnvironment(Isolate* isolate,
                                uv_loop_t* loop,
-                               Handle<Context> context,
+                               Local<Context> context,
                                int argc,
                                const char* const* argv,
                                int exec_argc,

--- a/src/node.h
+++ b/src/node.h
@@ -131,24 +131,24 @@ inline v8::Local<v8::Value> UVException(int errorno,
  * cb, you will appear to leak 4-bytes for every invocation. Take heed.
  */
 
-NODE_EXTERN v8::Handle<v8::Value> MakeCallback(
+NODE_EXTERN v8::Local<v8::Value> MakeCallback(
     v8::Isolate* isolate,
-    v8::Handle<v8::Object> recv,
+    v8::Local<v8::Object> recv,
     const char* method,
     int argc,
-    v8::Handle<v8::Value>* argv);
-NODE_EXTERN v8::Handle<v8::Value> MakeCallback(
+    v8::Local<v8::Value>* argv);
+NODE_EXTERN v8::Local<v8::Value> MakeCallback(
     v8::Isolate* isolate,
-    v8::Handle<v8::Object> recv,
-    v8::Handle<v8::String> symbol,
+    v8::Local<v8::Object> recv,
+    v8::Local<v8::String> symbol,
     int argc,
-    v8::Handle<v8::Value>* argv);
-NODE_EXTERN v8::Handle<v8::Value> MakeCallback(
+    v8::Local<v8::Value>* argv);
+NODE_EXTERN v8::Local<v8::Value> MakeCallback(
     v8::Isolate* isolate,
-    v8::Handle<v8::Object> recv,
-    v8::Handle<v8::Function> callback,
+    v8::Local<v8::Object> recv,
+    v8::Local<v8::Function> callback,
     int argc,
-    v8::Handle<v8::Value>* argv);
+    v8::Local<v8::Value>* argv);
 
 }  // namespace node
 
@@ -190,7 +190,7 @@ class Environment;
 
 NODE_EXTERN Environment* CreateEnvironment(v8::Isolate* isolate,
                                            struct uv_loop_s* loop,
-                                           v8::Handle<v8::Context> context,
+                                           v8::Local<v8::Context> context,
                                            int argc,
                                            const char* const* argv,
                                            int exec_argc,
@@ -201,7 +201,7 @@ NODE_EXTERN void LoadEnvironment(Environment* env);
 // CreateEnvironment() + LoadEnvironment() from above.
 // `uv_default_loop()` will be passed as `loop`.
 NODE_EXTERN Environment* CreateEnvironment(v8::Isolate* isolate,
-                                           v8::Handle<v8::Context> context,
+                                           v8::Local<v8::Context> context,
                                            int argc,
                                            const char* const* argv,
                                            int exec_argc,
@@ -249,14 +249,14 @@ inline void NODE_SET_METHOD(const TypeName& recv,
 
 // Used to be a macro, hence the uppercase name.
 // Not a template because it only makes sense for FunctionTemplates.
-inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
+inline void NODE_SET_PROTOTYPE_METHOD(v8::Local<v8::FunctionTemplate> recv,
                                       const char* name,
                                       v8::FunctionCallback callback) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope handle_scope(isolate);
-  v8::Handle<v8::Signature> s = v8::Signature::New(isolate, recv);
+  v8::Local<v8::Signature> s = v8::Signature::New(isolate, recv);
   v8::Local<v8::FunctionTemplate> t =
-      v8::FunctionTemplate::New(isolate, callback, v8::Handle<v8::Value>(), s);
+      v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), s);
   v8::Local<v8::Function> fn = t->GetFunction();
   recv->PrototypeTemplate()->Set(v8::String::NewFromUtf8(isolate, name), fn);
   v8::Local<v8::String> fn_name = v8::String::NewFromUtf8(isolate, name);
@@ -267,11 +267,11 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
 enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
 NODE_EXTERN enum encoding ParseEncoding(
     v8::Isolate* isolate,
-    v8::Handle<v8::Value> encoding_v,
+    v8::Local<v8::Value> encoding_v,
     enum encoding default_encoding = BINARY);
 NODE_DEPRECATED("Use ParseEncoding(isolate, ...)",
                 inline enum encoding ParseEncoding(
-      v8::Handle<v8::Value> encoding_v,
+      v8::Local<v8::Value> encoding_v,
       enum encoding default_encoding = BINARY) {
   return ParseEncoding(v8::Isolate::GetCurrent(), encoding_v, default_encoding);
 })
@@ -312,11 +312,11 @@ NODE_DEPRECATED("Use Encode(isolate, ...)",
 
 // Returns -1 if the handle was not valid for decoding
 NODE_EXTERN ssize_t DecodeBytes(v8::Isolate* isolate,
-                                v8::Handle<v8::Value>,
+                                v8::Local<v8::Value>,
                                 enum encoding encoding = BINARY);
 NODE_DEPRECATED("Use DecodeBytes(isolate, ...)",
                 inline ssize_t DecodeBytes(
-    v8::Handle<v8::Value> val,
+    v8::Local<v8::Value> val,
     enum encoding encoding = BINARY) {
   return DecodeBytes(v8::Isolate::GetCurrent(), val, encoding);
 })
@@ -325,12 +325,12 @@ NODE_DEPRECATED("Use DecodeBytes(isolate, ...)",
 NODE_EXTERN ssize_t DecodeWrite(v8::Isolate* isolate,
                                 char* buf,
                                 size_t buflen,
-                                v8::Handle<v8::Value>,
+                                v8::Local<v8::Value>,
                                 enum encoding encoding = BINARY);
 NODE_DEPRECATED("Use DecodeWrite(isolate, ...)",
                 inline ssize_t DecodeWrite(char* buf,
                                            size_t buflen,
-                                           v8::Handle<v8::Value> val,
+                                           v8::Local<v8::Value> val,
                                            enum encoding encoding = BINARY) {
   return DecodeWrite(v8::Isolate::GetCurrent(), buf, buflen, val, encoding);
 })
@@ -359,14 +359,14 @@ const char *signo_string(int errorno);
 
 
 typedef void (*addon_register_func)(
-    v8::Handle<v8::Object> exports,
-    v8::Handle<v8::Value> module,
+    v8::Local<v8::Object> exports,
+    v8::Local<v8::Value> module,
     void* priv);
 
 typedef void (*addon_context_register_func)(
-    v8::Handle<v8::Object> exports,
-    v8::Handle<v8::Value> module,
-    v8::Handle<v8::Context> context,
+    v8::Local<v8::Object> exports,
+    v8::Local<v8::Value> module,
+    v8::Local<v8::Context> context,
     void* priv);
 
 #define NM_F_BUILTIN 0x01

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -51,7 +51,6 @@ using v8::EscapableHandleScope;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -72,7 +71,7 @@ class CallbackInfo {
  public:
   static inline void Free(char* data, void* hint);
   static inline CallbackInfo* New(Isolate* isolate,
-                                  Handle<Object> object,
+                                  Local<Object> object,
                                   FreeCallback callback,
                                   void* hint = 0);
   inline void Dispose(Isolate* isolate);
@@ -81,7 +80,7 @@ class CallbackInfo {
   static void WeakCallback(const WeakCallbackData<Object, CallbackInfo>&);
   inline void WeakCallback(Isolate* isolate, Local<Object> object);
   inline CallbackInfo(Isolate* isolate,
-                      Handle<Object> object,
+                      Local<Object> object,
                       FreeCallback callback,
                       void* hint);
   ~CallbackInfo();
@@ -98,7 +97,7 @@ void CallbackInfo::Free(char* data, void*) {
 
 
 CallbackInfo* CallbackInfo::New(Isolate* isolate,
-                                Handle<Object> object,
+                                Local<Object> object,
                                 FreeCallback callback,
                                 void* hint) {
   return new CallbackInfo(isolate, object, callback, hint);
@@ -116,7 +115,7 @@ Persistent<Object>* CallbackInfo::persistent() {
 
 
 CallbackInfo::CallbackInfo(Isolate* isolate,
-                           Handle<Object> object,
+                           Local<Object> object,
                            FreeCallback callback,
                            void* hint)
     : persistent_(isolate, object),
@@ -156,12 +155,12 @@ void CallbackInfo::WeakCallback(Isolate* isolate, Local<Object> object) {
 
 // Buffer methods
 
-bool HasInstance(Handle<Value> val) {
+bool HasInstance(Local<Value> val) {
   return val->IsObject() && HasInstance(val.As<Object>());
 }
 
 
-bool HasInstance(Handle<Object> obj) {
+bool HasInstance(Local<Object> obj) {
   if (!obj->IsUint8Array())
     return false;
   Local<Uint8Array> array = obj.As<Uint8Array>();
@@ -170,7 +169,7 @@ bool HasInstance(Handle<Object> obj) {
 }
 
 
-char* Data(Handle<Value> val) {
+char* Data(Local<Value> val) {
   CHECK(val->IsObject());
   // Use a fully qualified name here to work around a bug in gcc 4.2.
   // It mistakes an unadorned call to Data() for the v8::String::Data type.
@@ -178,7 +177,7 @@ char* Data(Handle<Value> val) {
 }
 
 
-char* Data(Handle<Object> obj) {
+char* Data(Local<Object> obj) {
   CHECK(obj->IsUint8Array());
   Local<Uint8Array> ui = obj.As<Uint8Array>();
   ArrayBuffer::Contents ab_c = ui->Buffer()->GetContents();
@@ -186,13 +185,13 @@ char* Data(Handle<Object> obj) {
 }
 
 
-size_t Length(Handle<Value> val) {
+size_t Length(Local<Value> val) {
   CHECK(val->IsObject());
   return Length(val.As<Object>());
 }
 
 
-size_t Length(Handle<Object> obj) {
+size_t Length(Local<Object> obj) {
   CHECK(obj->IsUint8Array());
   Local<Uint8Array> ui = obj.As<Uint8Array>();
   return ui->ByteLength();
@@ -966,9 +965,9 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "setupBufferJS", SetupBufferJS);

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -16,12 +16,12 @@ static const unsigned int kMaxLength =
 
 NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
 
-NODE_EXTERN bool HasInstance(v8::Handle<v8::Value> val);
-NODE_EXTERN bool HasInstance(v8::Handle<v8::Object> val);
-NODE_EXTERN char* Data(v8::Handle<v8::Value> val);
-NODE_EXTERN char* Data(v8::Handle<v8::Object> val);
-NODE_EXTERN size_t Length(v8::Handle<v8::Value> val);
-NODE_EXTERN size_t Length(v8::Handle<v8::Object> val);
+NODE_EXTERN bool HasInstance(v8::Local<v8::Value> val);
+NODE_EXTERN bool HasInstance(v8::Local<v8::Object> val);
+NODE_EXTERN char* Data(v8::Local<v8::Value> val);
+NODE_EXTERN char* Data(v8::Local<v8::Object> val);
+NODE_EXTERN size_t Length(v8::Local<v8::Value> val);
+NODE_EXTERN size_t Length(v8::Local<v8::Object> val);
 
 // public constructor - data is copied
 NODE_EXTERN v8::MaybeLocal<v8::Object> Copy(v8::Isolate* isolate,
@@ -33,7 +33,7 @@ NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate, size_t length);
 
 // public constructor from string
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
-                                           v8::Handle<v8::String> string,
+                                           v8::Local<v8::String> string,
                                            enum encoding enc = UTF8);
 
 // public constructor - data is used, callback is passed data on object gc

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -21,10 +21,10 @@
 
 namespace node {
 
-using v8::Handle;
+using v8::Local;
 using v8::Object;
 
-void DefineErrnoConstants(Handle<Object> target) {
+void DefineErrnoConstants(Local<Object> target) {
 #ifdef E2BIG
   NODE_DEFINE_CONSTANT(target, E2BIG);
 #endif
@@ -342,7 +342,7 @@ void DefineErrnoConstants(Handle<Object> target) {
 #endif
 }
 
-void DefineWindowsErrorConstants(Handle<Object> target) {
+void DefineWindowsErrorConstants(Local<Object> target) {
 #ifdef WSAEINTR
   NODE_DEFINE_CONSTANT(target, WSAEINTR);
 #endif
@@ -576,7 +576,7 @@ void DefineWindowsErrorConstants(Handle<Object> target) {
 #endif
 }
 
-void DefineSignalConstants(Handle<Object> target) {
+void DefineSignalConstants(Local<Object> target) {
 #ifdef SIGHUP
   NODE_DEFINE_CONSTANT(target, SIGHUP);
 #endif
@@ -721,7 +721,7 @@ void DefineSignalConstants(Handle<Object> target) {
 #endif
 }
 
-void DefineOpenSSLConstants(Handle<Object> target) {
+void DefineOpenSSLConstants(Local<Object> target) {
 #ifdef SSL_OP_ALL
     NODE_DEFINE_CONSTANT(target, SSL_OP_ALL);
 #endif
@@ -965,7 +965,7 @@ void DefineOpenSSLConstants(Handle<Object> target) {
 #endif
 }
 
-void DefineSystemConstants(Handle<Object> target) {
+void DefineSystemConstants(Local<Object> target) {
   // file access modes
   NODE_DEFINE_CONSTANT(target, O_RDONLY);
   NODE_DEFINE_CONSTANT(target, O_WRONLY);
@@ -1104,11 +1104,11 @@ void DefineSystemConstants(Handle<Object> target) {
 #endif
 }
 
-void DefineUVConstants(Handle<Object> target) {
+void DefineUVConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, UV_UDP_REUSEADDR);
 }
 
-void DefineConstants(Handle<Object> target) {
+void DefineConstants(Local<Object> target) {
   DefineErrnoConstants(target);
   DefineWindowsErrorConstants(target);
   DefineSignalConstants(target);

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -5,7 +5,7 @@
 #include "v8.h"
 
 namespace node {
-void DefineConstants(v8::Handle<v8::Object> target);
+void DefineConstants(v8::Local<v8::Object> target);
 }  // namespace node
 
 #endif  // SRC_NODE_CONSTANTS_H_

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -21,7 +21,6 @@ using v8::External;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -189,7 +188,7 @@ class ContextifyContext {
     Local<Object> wrapper =
         env->script_data_constructor_function()->NewInstance();
     if (wrapper.IsEmpty())
-      return scope.Escape(Local<Value>::New(env->isolate(), Handle<Value>()));
+      return scope.Escape(Local<Value>::New(env->isolate(), Local<Value>()));
 
     Wrap(wrapper, this);
     return scope.Escape(wrapper);
@@ -732,9 +731,9 @@ class ContextifyScript : public BaseObject {
 };
 
 
-void InitContextify(Handle<Object> target,
-                    Handle<Value> unused,
-                    Handle<Context> context) {
+void InitContextify(Local<Object> target,
+                    Local<Value> unused,
+                    Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   ContextifyContext::Init(env, target);
   ContextifyScript::Init(env, target);

--- a/src/node_counters.cc
+++ b/src/node_counters.cc
@@ -14,7 +14,6 @@ using v8::GCCallbackFlags;
 using v8::GCEpilogueCallback;
 using v8::GCPrologueCallback;
 using v8::GCType;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -82,7 +81,7 @@ static void counter_gc_done(Isolate* isolate,
 }
 
 
-void InitPerfCounters(Environment* env, Handle<Object> target) {
+void InitPerfCounters(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   static struct {
@@ -118,7 +117,7 @@ void InitPerfCounters(Environment* env, Handle<Object> target) {
 }
 
 
-void TermPerfCounters(Handle<Object> target) {
+void TermPerfCounters(Local<Object> target) {
   // Only Windows performance counters supported
   // To enable other OS, use conditional compilation here
   TermPerfCountersWin32();

--- a/src/node_counters.h
+++ b/src/node_counters.h
@@ -26,8 +26,8 @@
 
 namespace node {
 
-void InitPerfCounters(Environment* env, v8::Handle<v8::Object> target);
-void TermPerfCounters(v8::Handle<v8::Object> target);
+void InitPerfCounters(Environment* env, v8::Local<v8::Object> target);
+void TermPerfCounters(v8::Local<v8::Object> target);
 
 }  // namespace node
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -72,7 +72,6 @@ using v8::External;
 using v8::False;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -135,7 +134,7 @@ X509_STORE* root_cert_store;
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;
 template void SSLWrap<TLSWrap>::AddMethods(Environment* env,
-                                           Handle<FunctionTemplate> t);
+                                           Local<FunctionTemplate> t);
 template void SSLWrap<TLSWrap>::InitNPN(SecureContext* sc);
 template SSL_SESSION* SSLWrap<TLSWrap>::GetSessionCallback(
     SSL* s,
@@ -276,7 +275,7 @@ bool EntropySource(unsigned char* buffer, size_t length) {
 }
 
 
-void SecureContext::Initialize(Environment* env, Handle<Object> target) {
+void SecureContext::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(SecureContext::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext"));
@@ -400,7 +399,7 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
 
 // Takes a string or buffer and loads it into a BIO.
 // Caller responsible for BIO_free_all-ing the returned object.
-static BIO* LoadBIO(Environment* env, Handle<Value> v) {
+static BIO* LoadBIO(Environment* env, Local<Value> v) {
   BIO* bio = NodeBIO::New();
   if (!bio)
     return nullptr;
@@ -429,7 +428,7 @@ static BIO* LoadBIO(Environment* env, Handle<Value> v) {
 
 // Takes a string or buffer and loads it into an X509
 // Caller responsible for X509_free-ing the returned object.
-static X509* LoadX509(Environment* env, Handle<Value> v) {
+static X509* LoadX509(Environment* env, Local<Value> v) {
   HandleScope scope(env->isolate());
 
   BIO *bio = LoadBIO(env, v);
@@ -1016,7 +1015,7 @@ void SecureContext::GetCertificate(const FunctionCallbackInfo<Value>& args) {
 
 
 template <class Base>
-void SSLWrap<Base>::AddMethods(Environment* env, Handle<FunctionTemplate> t) {
+void SSLWrap<Base>::AddMethods(Environment* env, Local<FunctionTemplate> t) {
   HandleScope scope(env->isolate());
 
   env->SetProtoMethod(t, "getPeerCertificate", GetPeerCertificate);
@@ -1805,7 +1804,7 @@ int SSLWrap<Base>::SelectNextProtoCallback(SSL* s,
   size_t len = Buffer::Length(obj);
 
   int status = SSL_select_next_proto(out, outlen, in, inlen, npn_protos, len);
-  Handle<Value> result;
+  Local<Value> result;
   switch (status) {
     case OPENSSL_NPN_UNSUPPORTED:
       result = Null(env->isolate());
@@ -2217,7 +2216,7 @@ void Connection::NewSessionDoneCb() {
 }
 
 
-void Connection::Initialize(Environment* env, Handle<Object> target) {
+void Connection::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Connection::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Connection"));
@@ -2725,7 +2724,7 @@ void Connection::SetSNICallback(const FunctionCallbackInfo<Value>& args) {
 #endif
 
 
-void CipherBase::Initialize(Environment* env, Handle<Object> target) {
+void CipherBase::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -3094,7 +3093,7 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Hmac::Initialize(Environment* env, v8::Handle<v8::Object> target) {
+void Hmac::Initialize(Environment* env, v8::Local<v8::Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -3223,7 +3222,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Hash::Initialize(Environment* env, v8::Handle<v8::Object> target) {
+void Hash::Initialize(Environment* env, v8::Local<v8::Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -3368,7 +3367,7 @@ void SignBase::CheckThrow(SignBase::Error error) {
 
 
 
-void Sign::Initialize(Environment* env, v8::Handle<v8::Object> target) {
+void Sign::Initialize(Environment* env, v8::Local<v8::Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -3537,7 +3536,7 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Verify::Initialize(Environment* env, v8::Handle<v8::Object> target) {
+void Verify::Initialize(Environment* env, v8::Local<v8::Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -3876,7 +3875,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void DiffieHellman::Initialize(Environment* env, Handle<Object> target) {
+void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
 
   const PropertyAttribute attributes =
@@ -4262,7 +4261,7 @@ bool DiffieHellman::VerifyContext() {
 }
 
 
-void ECDH::Initialize(Environment* env, Handle<Object> target) {
+void ECDH::Initialize(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -4991,7 +4990,7 @@ void GetCurves(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Certificate::Initialize(Environment* env, Handle<Object> target) {
+void Certificate::Initialize(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -5255,9 +5254,9 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
 
 
 // FIXME(bnoordhuis) Handle global init correctly.
-void InitCrypto(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context,
+void InitCrypto(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context,
                 void* priv) {
   static uv_once_t init_once = UV_ONCE_INIT;
   uv_once(&init_once, InitCryptoOnce);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -59,7 +59,7 @@ class SecureContext : public BaseObject {
     FreeCTXMem();
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   X509_STORE* ca_store_;
   SSL_CTX* ctx_;
@@ -193,7 +193,7 @@ class SSLWrap {
       sizeof(SSL) + sizeof(SSL3_STATE) + 42 * 1024;
 
   static void InitNPN(SecureContext* sc);
-  static void AddMethods(Environment* env, v8::Handle<v8::FunctionTemplate> t);
+  static void AddMethods(Environment* env, v8::Local<v8::FunctionTemplate> t);
 
   static SSL_SESSION* GetSessionCallback(SSL* s,
                                          unsigned char* key,
@@ -295,7 +295,7 @@ class Connection : public SSLWrap<Connection>, public AsyncWrap {
 #endif
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
   void NewSessionDoneCb();
 
 #ifdef OPENSSL_NPN_NEGOTIATED
@@ -385,7 +385,7 @@ class CipherBase : public BaseObject {
     EVP_CIPHER_CTX_cleanup(&ctx_);
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
   enum CipherKind {
@@ -448,7 +448,7 @@ class Hmac : public BaseObject {
     HMAC_CTX_cleanup(&ctx_);
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
   void HmacInit(const char* hash_type, const char* key, int key_len);
@@ -481,7 +481,7 @@ class Hash : public BaseObject {
     EVP_MD_CTX_cleanup(&mdctx_);
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   bool HashInit(const char* hash_type);
   bool HashUpdate(const char* data, int len);
@@ -539,7 +539,7 @@ class SignBase : public BaseObject {
 class Sign : public SignBase {
  public:
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   Error SignInit(const char* sign_type);
   Error SignUpdate(const char* data, int len);
@@ -562,7 +562,7 @@ class Sign : public SignBase {
 
 class Verify : public SignBase {
  public:
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   Error VerifyInit(const char* verify_type);
   Error VerifyUpdate(const char* data, int len);
@@ -621,7 +621,7 @@ class DiffieHellman : public BaseObject {
     }
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   bool Init(int primeLength, int g);
   bool Init(const char* p, int p_len, int g);
@@ -668,7 +668,7 @@ class ECDH : public BaseObject {
     group_ = nullptr;
   }
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
   ECDH(Environment* env, v8::Local<v8::Object> wrap, EC_KEY* key)
@@ -697,9 +697,9 @@ class ECDH : public BaseObject {
 
 class Certificate : public AsyncWrap {
  public:
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
-  v8::Handle<v8::Value> CertificateInit(const char* sign_type);
+  v8::Local<v8::Value> CertificateInit(const char* sign_type);
   bool VerifySpkac(const char* data, unsigned int len);
   const char* ExportPublicKey(const char* data, int len);
   const char* ExportChallenge(const char* data, int len);
@@ -722,7 +722,7 @@ bool EntropySource(unsigned char* buffer, size_t length);
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif  // !OPENSSL_NO_ENGINE
-void InitCrypto(v8::Handle<v8::Object> target);
+void InitCrypto(v8::Local<v8::Object> target);
 
 }  // namespace crypto
 }  // namespace node

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -37,7 +37,6 @@ using v8::GCCallbackFlags;
 using v8::GCEpilogueCallback;
 using v8::GCPrologueCallback;
 using v8::GCType;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -241,7 +240,7 @@ void dtrace_gc_done(Isolate* isolate, GCType type, GCCallbackFlags flags) {
 }
 
 
-void InitDTrace(Environment* env, Handle<Object> target) {
+void InitDTrace(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   static struct {

--- a/src/node_dtrace.h
+++ b/src/node_dtrace.h
@@ -54,7 +54,7 @@ typedef struct {
 
 namespace node {
 
-void InitDTrace(Environment* env, v8::Handle<v8::Object> target);
+void InitDTrace(Environment* env, v8::Local<v8::Object> target);
 
 }  // namespace node
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -32,7 +32,6 @@ using v8::EscapableHandleScope;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -1188,9 +1187,9 @@ void FSInitialize(const FunctionCallbackInfo<Value>& args) {
   env->set_fs_stats_constructor_function(stats_constructor);
 }
 
-void InitFs(Handle<Object> target,
-            Handle<Value> unused,
-            Handle<Context> context,
+void InitFs(Local<Object> target,
+            Local<Value> unused,
+            Local<Context> context,
             void* priv) {
   Environment* env = Environment::GetCurrent(context);
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -6,7 +6,7 @@
 
 namespace node {
 
-void InitFs(v8::Handle<v8::Object> target);
+void InitFs(v8::Local<v8::Object> target);
 
 }  // namespace node
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -40,7 +40,6 @@ using v8::Exception;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -560,9 +559,9 @@ const struct http_parser_settings Parser::settings = {
 };
 
 
-void InitHttpParser(Handle<Object> target,
-                    Handle<Value> unused,
-                    Handle<Context> context,
+void InitHttpParser(Local<Object> target,
+                    Local<Value> unused,
+                    Local<Context> context,
                     void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);

--- a/src/node_http_parser.h
+++ b/src/node_http_parser.h
@@ -7,7 +7,7 @@
 
 namespace node {
 
-void InitHttpParser(v8::Handle<v8::Object> target);
+void InitHttpParser(v8::Local<v8::Object> target);
 
 }  // namespace node
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -26,32 +26,32 @@ inline v8::Local<TypeName> PersistentToLocal(
     const v8::Persistent<TypeName>& persistent);
 
 // Call with valid HandleScope and while inside Context scope.
-v8::Handle<v8::Value> MakeCallback(Environment* env,
-                                   v8::Handle<v8::Object> recv,
+v8::Local<v8::Value> MakeCallback(Environment* env,
+                                   v8::Local<v8::Object> recv,
                                    const char* method,
                                    int argc = 0,
-                                   v8::Handle<v8::Value>* argv = nullptr);
+                                   v8::Local<v8::Value>* argv = nullptr);
 
 // Call with valid HandleScope and while inside Context scope.
-v8::Handle<v8::Value> MakeCallback(Environment* env,
-                                   v8::Handle<v8::Object> recv,
+v8::Local<v8::Value> MakeCallback(Environment* env,
+                                   v8::Local<v8::Object> recv,
                                    uint32_t index,
                                    int argc = 0,
-                                   v8::Handle<v8::Value>* argv = nullptr);
+                                   v8::Local<v8::Value>* argv = nullptr);
 
 // Call with valid HandleScope and while inside Context scope.
-v8::Handle<v8::Value> MakeCallback(Environment* env,
-                                   v8::Handle<v8::Object> recv,
-                                   v8::Handle<v8::String> symbol,
+v8::Local<v8::Value> MakeCallback(Environment* env,
+                                   v8::Local<v8::Object> recv,
+                                   v8::Local<v8::String> symbol,
                                    int argc = 0,
-                                   v8::Handle<v8::Value>* argv = nullptr);
+                                   v8::Local<v8::Value>* argv = nullptr);
 
 // Call with valid HandleScope and while inside Context scope.
-v8::Handle<v8::Value> MakeCallback(Environment* env,
-                                   v8::Handle<v8::Value> recv,
-                                   v8::Handle<v8::Function> callback,
+v8::Local<v8::Value> MakeCallback(Environment* env,
+                                   v8::Local<v8::Value> recv,
+                                   v8::Local<v8::Function> callback,
                                    int argc = 0,
-                                   v8::Handle<v8::Value>* argv = nullptr);
+                                   v8::Local<v8::Value>* argv = nullptr);
 
 // Convert a struct sockaddr to a { address: '1.2.3.4', port: 1234 } JS object.
 // Sets address and port properties on the info object and returns it.
@@ -59,7 +59,7 @@ v8::Handle<v8::Value> MakeCallback(Environment* env,
 v8::Local<v8::Object> AddressToJS(
     Environment* env,
     const sockaddr* addr,
-    v8::Local<v8::Object> info = v8::Handle<v8::Object>());
+    v8::Local<v8::Object> info = v8::Local<v8::Object>());
 
 #ifdef _WIN32
 // emulate snprintf() on windows, _snprintf() doesn't zero-terminate the buffer
@@ -99,8 +99,8 @@ inline static int snprintf(char* buf, unsigned int len, const char* fmt, ...) {
 #endif
 
 void AppendExceptionLine(Environment* env,
-                         v8::Handle<v8::Value> er,
-                         v8::Handle<v8::Message> message);
+                         v8::Local<v8::Value> er,
+                         v8::Local<v8::Message> message);
 
 NO_RETURN void FatalError(const char* location, const char* message);
 
@@ -131,7 +131,7 @@ inline bool IsBigEndian() {
 }
 
 // parse index for external array data
-inline MUST_USE_RESULT bool ParseArrayIndex(v8::Handle<v8::Value> arg,
+inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
                                             size_t def,
                                             size_t* ret) {
   if (arg->IsUndefined()) {

--- a/src/node_javascript.cc
+++ b/src/node_javascript.cc
@@ -11,23 +11,22 @@
 
 namespace node {
 
-using v8::Handle;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
 using v8::String;
 
-Handle<String> MainSource(Environment* env) {
+Local<String> MainSource(Environment* env) {
   return OneByteString(env->isolate(), node_native, sizeof(node_native) - 1);
 }
 
-void DefineJavaScript(Environment* env, Handle<Object> target) {
+void DefineJavaScript(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   for (int i = 0; natives[i].name; i++) {
     if (natives[i].source != node_native) {
       Local<String> name = String::NewFromUtf8(env->isolate(), natives[i].name);
-      Handle<String> source = String::NewFromUtf8(env->isolate(),
+      Local<String> source = String::NewFromUtf8(env->isolate(),
                                                   natives[i].source,
                                                   String::kNormalString,
                                                   natives[i].source_len);

--- a/src/node_javascript.h
+++ b/src/node_javascript.h
@@ -6,8 +6,8 @@
 
 namespace node {
 
-void DefineJavaScript(Environment* env, v8::Handle<v8::Object> target);
-v8::Handle<v8::String> MainSource(Environment* env);
+void DefineJavaScript(Environment* env, v8::Local<v8::Object> target);
+v8::Local<v8::String> MainSource(Environment* env);
 
 }  // namespace node
 

--- a/src/node_lttng.cc
+++ b/src/node_lttng.cc
@@ -32,7 +32,6 @@ using v8::GCCallbackFlags;
 using v8::GCEpilogueCallback;
 using v8::GCPrologueCallback;
 using v8::GCType;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -234,7 +233,7 @@ void lttng_gc_done(Isolate* isolate, GCType type, GCCallbackFlags flags) {
   NODE_GC_DONE(type, flags, isolate);
 }
 
-void InitLTTNG(Environment* env, Handle<Object> target) {
+void InitLTTNG(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   static struct {

--- a/src/node_lttng.h
+++ b/src/node_lttng.h
@@ -33,7 +33,7 @@ typedef struct {
 
 namespace node {
 
-void InitLTTNG(Environment* env, v8::Handle<v8::Object> target);
+void InitLTTNG(Environment* env, v8::Local<v8::Object> target);
 
 }  // namespace node
 

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -24,7 +24,7 @@ class ObjectWrap {
 
 
   template <class T>
-  static inline T* Unwrap(v8::Handle<v8::Object> handle) {
+  static inline T* Unwrap(v8::Local<v8::Object> handle) {
     assert(!handle.IsEmpty());
     assert(handle->InternalFieldCount() > 0);
     // Cast to ObjectWrap before casting to T.  A direct cast from void
@@ -51,7 +51,7 @@ class ObjectWrap {
 
 
  protected:
-  inline void Wrap(v8::Handle<v8::Object> handle) {
+  inline void Wrap(v8::Local<v8::Object> handle) {
     assert(persistent().IsEmpty());
     assert(handle->InternalFieldCount() > 0);
     handle->SetAlignedPointerInInternalField(0, this);

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -30,7 +30,6 @@ using v8::Array;
 using v8::Boolean;
 using v8::Context;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::Integer;
 using v8::Local;
 using v8::Number;
@@ -291,9 +290,9 @@ static void GetHomeDirectory(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "getHostname", GetHostname);
   env->SetMethod(target, "getLoadAvg", GetLoadAvg);

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -14,7 +14,6 @@ namespace node {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -22,7 +21,7 @@ using v8::Object;
 using v8::Value;
 
 
-void StatWatcher::Initialize(Environment* env, Handle<Object> target) {
+void StatWatcher::Initialize(Environment* env, Local<Object> target) {
   HandleScope scope(env->isolate());
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(StatWatcher::New);

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -13,7 +13,7 @@ class StatWatcher : public AsyncWrap {
  public:
   virtual ~StatWatcher() override;
 
-  static void Initialize(Environment* env, v8::Handle<v8::Object> target);
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
  protected:
   StatWatcher(Environment* env, v8::Local<v8::Object> wrap);

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -11,7 +11,6 @@ using v8::ArrayBuffer;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HeapStatistics;
 using v8::Isolate;
 using v8::Local;
@@ -58,9 +57,9 @@ void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void InitializeV8Bindings(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void InitializeV8Bindings(Local<Object> target,
+                          Local<Value> unused,
+                          Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target,
                  "updateHeapStatisticsArrayBuffer",

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -22,7 +22,6 @@ using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -43,7 +42,7 @@ enum node_zlib_mode {
 };
 
 
-void InitZlib(v8::Handle<v8::Object> target);
+void InitZlib(v8::Local<v8::Object> target);
 
 
 /**
@@ -573,9 +572,9 @@ class ZCtx : public AsyncWrap {
 };
 
 
-void InitZlib(Handle<Object> target,
-              Handle<Value> unused,
-              Handle<Context> context,
+void InitZlib(Local<Object> target,
+              Local<Value> unused,
+              Local<Context> context,
               void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> z = env->NewFunctionTemplate(ZCtx::New);

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -22,7 +22,6 @@ using v8::External;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -70,9 +69,9 @@ Local<Object> PipeWrap::Instantiate(Environment* env, AsyncWrap* parent) {
 }
 
 
-void PipeWrap::Initialize(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void PipeWrap::Initialize(Local<Object> target,
+                          Local<Value> unused,
+                          Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -123,7 +122,7 @@ void PipeWrap::New(const FunctionCallbackInfo<Value>& args) {
 
 
 PipeWrap::PipeWrap(Environment* env,
-                   Handle<Object> object,
+                   Local<Object> object,
                    bool ipc,
                    AsyncWrap* parent)
     : StreamWrap(env,

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -12,15 +12,15 @@ class PipeWrap : public StreamWrap {
   uv_pipe_t* UVHandle();
 
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
 
   size_t self_size() const override { return sizeof(*this); }
 
  private:
   PipeWrap(Environment* env,
-           v8::Handle<v8::Object> object,
+           v8::Local<v8::Object> object,
            bool ipc,
            AsyncWrap* parent);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -15,7 +15,6 @@ using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -26,9 +25,9 @@ using v8::Value;
 
 class ProcessWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -58,7 +57,7 @@ class ProcessWrap : public HandleWrap {
     new ProcessWrap(env, args.This());
   }
 
-  ProcessWrap(Environment* env, Handle<Object> object)
+  ProcessWrap(Environment* env, Local<Object> object)
       : HandleWrap(env,
                    object,
                    reinterpret_cast<uv_handle_t*>(&process_),

--- a/src/req-wrap-inl.h
+++ b/src/req-wrap-inl.h
@@ -13,7 +13,7 @@ namespace node {
 
 template <typename T>
 ReqWrap<T>::ReqWrap(Environment* env,
-                    v8::Handle<v8::Object> object,
+                    v8::Local<v8::Object> object,
                     AsyncWrap::ProviderType provider)
     : AsyncWrap(env, object, provider) {
   if (env->in_domain())

--- a/src/req-wrap.h
+++ b/src/req-wrap.h
@@ -12,7 +12,7 @@ template <typename T>
 class ReqWrap : public AsyncWrap {
  public:
   inline ReqWrap(Environment* env,
-                 v8::Handle<v8::Object> object,
+                 v8::Local<v8::Object> object,
                  AsyncWrap::ProviderType provider);
   inline ~ReqWrap() override;
   inline void Dispatched();  // Call this after the req has been dispatched.

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -13,7 +13,6 @@ using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -22,9 +21,9 @@ using v8::Value;
 
 class SignalWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -52,7 +51,7 @@ class SignalWrap : public HandleWrap {
     new SignalWrap(env, args.This());
   }
 
-  SignalWrap(Environment* env, Handle<Object> object)
+  SignalWrap(Environment* env, Local<Object> object)
       : HandleWrap(env,
                    object,
                    reinterpret_cast<uv_handle_t*>(&handle_),

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -13,7 +13,6 @@ using v8::Array;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -340,9 +339,9 @@ void SyncProcessStdioPipe::CloseCallback(uv_handle_t* handle) {
 }
 
 
-void SyncProcessRunner::Initialize(Handle<Object> target,
-                                   Handle<Value> unused,
-                                   Handle<Context> context) {
+void SyncProcessRunner::Initialize(Local<Object> target,
+                                   Local<Value> unused,
+                                   Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "spawn", Spawn);
 }

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -9,7 +9,6 @@ namespace node {
 using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -129,9 +128,9 @@ class SyncProcessRunner {
   };
 
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context);
+  static void Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context);
   static void Spawn(const FunctionCallbackInfo<Value>& args);
 
  private:

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -12,7 +12,6 @@ namespace node {
 
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
@@ -23,7 +22,7 @@ using v8::Value;
 
 template <class Base>
 void StreamBase::AddMethods(Environment* env,
-                            Handle<FunctionTemplate> t,
+                            Local<FunctionTemplate> t,
                             int flags) {
   HandleScope scope(env->isolate());
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -19,7 +19,6 @@ namespace node {
 using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -110,14 +109,14 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
   for (size_t i = 0; i < count; i++) {
     storage_size = ROUND_UP(storage_size, WriteWrap::kAlignSize);
 
-    Handle<Value> chunk = chunks->Get(i * 2);
+    Local<Value> chunk = chunks->Get(i * 2);
 
     if (Buffer::HasInstance(chunk))
       continue;
       // Buffer chunk, no additional storage required
 
     // String chunk
-    Handle<String> string = chunk->ToString(env->isolate());
+    Local<String> string = chunk->ToString(env->isolate());
     enum encoding encoding = ParseEncoding(env->isolate(),
                                            chunks->Get(i * 2 + 1));
     size_t chunk_size;
@@ -144,7 +143,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
   uint32_t bytes = 0;
   size_t offset = 0;
   for (size_t i = 0; i < count; i++) {
-    Handle<Value> chunk = chunks->Get(i * 2);
+    Local<Value> chunk = chunks->Get(i * 2);
 
     // Write buffer
     if (Buffer::HasInstance(chunk)) {
@@ -160,7 +159,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
     char* str_storage = req_wrap->Extra(offset);
     size_t str_size = storage_size - offset;
 
-    Handle<String> string = chunk->ToString(env->isolate());
+    Local<String> string = chunk->ToString(env->isolate());
     enum encoding encoding = ParseEncoding(env->isolate(),
                                            chunks->Get(i * 2 + 1));
     str_size = StringBytes::Write(env->isolate(),

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -181,7 +181,7 @@ class StreamBase : public StreamResource {
 
   template <class Base>
   static inline void AddMethods(Environment* env,
-                                v8::Handle<v8::FunctionTemplate> target,
+                                v8::Local<v8::FunctionTemplate> target,
                                 int flags = kFlagNone);
 
   virtual void* Cast() = 0;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -27,7 +27,6 @@ using v8::Context;
 using v8::EscapableHandleScope;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -40,9 +39,9 @@ using v8::Undefined;
 using v8::Value;
 
 
-void StreamWrap::Initialize(Handle<Object> target,
-                            Handle<Value> unused,
-                            Handle<Context> context) {
+void StreamWrap::Initialize(Local<Object> target,
+                            Local<Value> unused,
+                            Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> sw =
@@ -81,7 +80,7 @@ StreamWrap::StreamWrap(Environment* env,
 
 
 void StreamWrap::AddMethods(Environment* env,
-                            v8::Handle<v8::FunctionTemplate> target,
+                            v8::Local<v8::FunctionTemplate> target,
                             int flags) {
   env->SetProtoMethod(target, "setBlocking", SetBlocking);
   StreamBase::AddMethods<StreamWrap>(env, target, flags);

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -15,9 +15,9 @@ class StreamWrap;
 
 class StreamWrap : public HandleWrap, public StreamBase {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
 
   int GetFD() override;
   void* Cast() override;
@@ -68,7 +68,7 @@ class StreamWrap : public HandleWrap, public StreamBase {
   void UpdateWriteQueueSize();
 
   static void AddMethods(Environment* env,
-                         v8::Handle<v8::FunctionTemplate> target,
+                         v8::Local<v8::FunctionTemplate> target,
                          int flags = StreamBase::kFlagNone);
 
  private:

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -15,7 +15,6 @@
 namespace node {
 
 using v8::EscapableHandleScope;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -239,7 +238,7 @@ size_t hex_decode(char* buf,
 
 
 bool StringBytes::GetExternalParts(Isolate* isolate,
-                                   Handle<Value> val,
+                                   Local<Value> val,
                                    const char** data,
                                    size_t* len) {
   if (Buffer::HasInstance(val)) {
@@ -275,7 +274,7 @@ bool StringBytes::GetExternalParts(Isolate* isolate,
 size_t StringBytes::Write(Isolate* isolate,
                           char* buf,
                           size_t buflen,
-                          Handle<Value> val,
+                          Local<Value> val,
                           enum encoding encoding,
                           int* chars_written) {
   HandleScope scope(isolate);
@@ -370,7 +369,7 @@ size_t StringBytes::Write(Isolate* isolate,
 
 
 bool StringBytes::IsValidString(Isolate* isolate,
-                                Handle<String> string,
+                                Local<String> string,
                                 enum encoding enc) {
   if (enc == HEX && string->Length() % 2 != 0)
     return false;
@@ -383,7 +382,7 @@ bool StringBytes::IsValidString(Isolate* isolate,
 // Will always be at least big enough, but may have some extra
 // UTF8 can be as much as 3x the size, Base64 can have 1-2 extra bytes
 size_t StringBytes::StorageSize(Isolate* isolate,
-                                Handle<Value> val,
+                                Local<Value> val,
                                 enum encoding encoding) {
   HandleScope scope(isolate);
   size_t data_size = 0;
@@ -432,7 +431,7 @@ size_t StringBytes::StorageSize(Isolate* isolate,
 
 
 size_t StringBytes::Size(Isolate* isolate,
-                         Handle<Value> val,
+                         Local<Value> val,
                          enum encoding encoding) {
   HandleScope scope(isolate);
   size_t data_size = 0;

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -1,7 +1,7 @@
 #ifndef SRC_STRING_BYTES_H_
 #define SRC_STRING_BYTES_H_
 
-// Decodes a v8::Handle<v8::String> or Buffer to a raw char*
+// Decodes a v8::Local<v8::String> or Buffer to a raw char*
 
 #include "v8.h"
 #include "node.h"
@@ -24,8 +24,8 @@ class StringBytes {
     }
 
     inline bool Decode(Environment* env,
-                       v8::Handle<v8::String> string,
-                       v8::Handle<v8::Value> encoding,
+                       v8::Local<v8::String> string,
+                       v8::Local<v8::Value> encoding,
                        enum encoding _default) {
       enum encoding enc = ParseEncoding(env->isolate(), encoding, _default);
       if (!StringBytes::IsValidString(env->isolate(), string, enc)) {
@@ -61,25 +61,25 @@ class StringBytes {
   // Example: a HEX string must have a length that's a multiple of two.
   // FIXME(bnoordhuis) IsMaybeValidString()? Naming things is hard...
   static bool IsValidString(v8::Isolate* isolate,
-                            v8::Handle<v8::String> string,
+                            v8::Local<v8::String> string,
                             enum encoding enc);
 
   // Fast, but can be 2 bytes oversized for Base64, and
   // as much as triple UTF-8 strings <= 65536 chars in length
   static size_t StorageSize(v8::Isolate* isolate,
-                            v8::Handle<v8::Value> val,
+                            v8::Local<v8::Value> val,
                             enum encoding enc);
 
   // Precise byte count, but slightly slower for Base64 and
   // very much slower for UTF-8
   static size_t Size(v8::Isolate* isolate,
-                     v8::Handle<v8::Value> val,
+                     v8::Local<v8::Value> val,
                      enum encoding enc);
 
   // If the string is external then assign external properties to data and len,
   // then return true. If not return false.
   static bool GetExternalParts(v8::Isolate* isolate,
-                               v8::Handle<v8::Value> val,
+                               v8::Local<v8::Value> val,
                                const char** data,
                                size_t* len);
 
@@ -90,7 +90,7 @@ class StringBytes {
   static size_t Write(v8::Isolate* isolate,
                       char* buf,
                       size_t buflen,
-                      v8::Handle<v8::Value> val,
+                      v8::Local<v8::Value> val,
                       enum encoding enc,
                       int* chars_written = nullptr);
 
@@ -110,25 +110,25 @@ class StringBytes {
 
   NODE_DEPRECATED("Use IsValidString(isolate, ...)",
                   static inline bool IsValidString(
-      v8::Handle<v8::String> string,
+      v8::Local<v8::String> string,
       enum encoding enc) {
     return IsValidString(v8::Isolate::GetCurrent(), string, enc);
   })
 
   NODE_DEPRECATED("Use StorageSize(isolate, ...)",
-                  static inline size_t StorageSize(v8::Handle<v8::Value> val,
+                  static inline size_t StorageSize(v8::Local<v8::Value> val,
                                                   enum encoding enc) {
     return StorageSize(v8::Isolate::GetCurrent(), val, enc);
   })
 
   NODE_DEPRECATED("Use Size(isolate, ...)",
-                  static inline size_t Size(v8::Handle<v8::Value> val,
+                  static inline size_t Size(v8::Local<v8::Value> val,
                                             enum encoding enc) {
     return Size(v8::Isolate::GetCurrent(), val, enc);
   })
 
   NODE_DEPRECATED("Use GetExternalParts(isolate, ...)",
-                  static inline bool GetExternalParts(v8::Handle<v8::Value> val,
+                  static inline bool GetExternalParts(v8::Local<v8::Value> val,
                                                       const char** data,
                                                       size_t* len) {
     return GetExternalParts(v8::Isolate::GetCurrent(), val, data, len);
@@ -137,7 +137,7 @@ class StringBytes {
   NODE_DEPRECATED("Use Write(isolate, ...)",
                   static inline size_t Write(char* buf,
                                              size_t buflen,
-                                             v8::Handle<v8::Value> val,
+                                             v8::Local<v8::Value> val,
                                              enum encoding enc,
                                              int* chars_written = nullptr) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -23,7 +23,6 @@ using v8::External;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -64,9 +63,9 @@ Local<Object> TCPWrap::Instantiate(Environment* env, AsyncWrap* parent) {
 }
 
 
-void TCPWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TCPWrap::Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -144,7 +143,7 @@ void TCPWrap::New(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-TCPWrap::TCPWrap(Environment* env, Handle<Object> object, AsyncWrap* parent)
+TCPWrap::TCPWrap(Environment* env, Local<Object> object, AsyncWrap* parent)
     : StreamWrap(env,
                  object,
                  reinterpret_cast<uv_stream_t*>(&handle_),

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -10,16 +10,16 @@ namespace node {
 class TCPWrap : public StreamWrap {
  public:
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
 
   uv_tcp_t* UVHandle();
 
   size_t self_size() const override { return sizeof(*this); }
 
  private:
-  TCPWrap(Environment* env, v8::Handle<v8::Object> object, AsyncWrap* parent);
+  TCPWrap(Environment* env, v8::Local<v8::Object> object, AsyncWrap* parent);
   ~TCPWrap();
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -14,7 +14,6 @@ using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -25,9 +24,9 @@ const uint32_t kOnTimeout = 0;
 
 class TimerWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -63,7 +62,7 @@ class TimerWrap : public HandleWrap {
     new TimerWrap(env, args.This());
   }
 
-  TimerWrap(Environment* env, Handle<Object> object)
+  TimerWrap(Environment* env, Local<Object> object)
       : HandleWrap(env,
                    object,
                    reinterpret_cast<uv_handle_t*>(&handle_),

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -25,7 +25,6 @@ using v8::Exception;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::Integer;
 using v8::Local;
 using v8::Null;
@@ -868,9 +867,9 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
 
-void TLSWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TLSWrap::Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "wrap", TLSWrap::Wrap);

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -27,9 +27,9 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
  public:
   ~TLSWrap() override;
 
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
 
   void* Cast() override;
   int GetFD() override;

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -18,7 +18,6 @@ using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
@@ -27,9 +26,9 @@ using v8::String;
 using v8::Value;
 
 
-void TTYWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TTYWrap::Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -130,7 +129,7 @@ void TTYWrap::New(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-TTYWrap::TTYWrap(Environment* env, Handle<Object> object, int fd, bool readable)
+TTYWrap::TTYWrap(Environment* env, Local<Object> object, int fd, bool readable)
     : StreamWrap(env,
                  object,
                  reinterpret_cast<uv_stream_t*>(&handle_),

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -9,9 +9,9 @@ namespace node {
 
 class TTYWrap : public StreamWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
 
   uv_tty_t* UVHandle();
 
@@ -19,7 +19,7 @@ class TTYWrap : public StreamWrap {
 
  private:
   TTYWrap(Environment* env,
-          v8::Handle<v8::Object> object,
+          v8::Local<v8::Object> object,
           int fd,
           bool readable);
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -19,7 +19,6 @@ using v8::External;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
@@ -61,7 +60,7 @@ static void NewSendWrap(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-UDPWrap::UDPWrap(Environment* env, Handle<Object> object, AsyncWrap* parent)
+UDPWrap::UDPWrap(Environment* env, Local<Object> object, AsyncWrap* parent)
     : HandleWrap(env,
                  object,
                  reinterpret_cast<uv_handle_t*>(&handle_),
@@ -71,9 +70,9 @@ UDPWrap::UDPWrap(Environment* env, Handle<Object> object, AsyncWrap* parent)
 }
 
 
-void UDPWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void UDPWrap::Initialize(Local<Object> target,
+                         Local<Value> unused,
+                         Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -13,9 +13,9 @@ namespace node {
 
 class UDPWrap: public HandleWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Value> unused,
+                         v8::Local<v8::Context> context);
   static void GetFD(v8::Local<v8::String>,
                     const v8::PropertyCallbackInfo<v8::Value>&);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -40,7 +40,7 @@ class UDPWrap: public HandleWrap {
   size_t self_size() const override { return sizeof(*this); }
 
  private:
-  UDPWrap(Environment* env, v8::Handle<v8::Object> object, AsyncWrap* parent);
+  UDPWrap(Environment* env, v8::Local<v8::Object> object, AsyncWrap* parent);
 
   static void DoBind(const v8::FunctionCallbackInfo<v8::Value>& args,
                      int family);

--- a/src/util.cc
+++ b/src/util.cc
@@ -3,7 +3,7 @@
 
 namespace node {
 
-Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
+Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value)
     : length_(0), str_(str_st_) {
   if (value.IsEmpty())
     return;

--- a/src/util.h
+++ b/src/util.h
@@ -170,7 +170,7 @@ inline TypeName* Unwrap(v8::Local<v8::Object> object);
 
 class Utf8Value {
   public:
-    explicit Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value);
+    explicit Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
     ~Utf8Value() {
       if (str_ != str_st_)

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -9,7 +9,7 @@ namespace uv {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
+using v8::Local;
 using v8::Integer;
 using v8::Object;
 using v8::String;
@@ -26,9 +26,9 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target,
+                Local<Value> unused,
+                Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "errname"),
               env->NewFunctionTemplate(ErrName)->GetFunction());

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -24,7 +24,7 @@ void AfterAsync(uv_work_t* r) {
   HandleScope scope(isolate);
   async_req* req = reinterpret_cast<async_req*>(r->data);
 
-  Handle<Value> argv[2] = {
+  Local<Value> argv[2] = {
     Null(isolate),
     Integer::New(isolate, req->output)
   };
@@ -62,7 +62,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                 (uv_after_work_cb)AfterAsync);
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -5,7 +5,6 @@
 #include <v8.h>
 
 using node::AtExit;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -36,7 +35,7 @@ static void sanity_check(void) {
   assert(at_exit_cb2_called == 2);
 }
 
-void init(Handle<Object> target) {
+void init(Local<Object> target) {
   AtExit(at_exit_cb1);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -9,7 +9,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -9,7 +9,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> target) {
+void init(Local<Object> target) {
   NODE_SET_METHOD(target, "hello", Method);
 }
 

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -3,7 +3,7 @@
 
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
+using v8::Local;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Object;
@@ -19,7 +19,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                      NULL);
 }
 
-void init(Handle<Object> target) {
+void init(Local<Object> target) {
   NODE_SET_METHOD(target, "method", Method);
 }
 

--- a/test/gc/node_modules/weak/src/weakref.cc
+++ b/test/gc/node_modules/weak/src/weakref.cc
@@ -27,7 +27,6 @@ using v8::Exception;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -51,7 +50,7 @@ typedef struct proxy_container {
 Persistent<ObjectTemplate> proxyClass;
 
 
-bool IsDead(Handle<Object> proxy) {
+bool IsDead(Local<Object> proxy) {
   assert(proxy->InternalFieldCount() == 1);
   proxy_container *cont = reinterpret_cast<proxy_container*>(
       proxy->GetAlignedPointerFromInternalField(0));
@@ -59,7 +58,7 @@ bool IsDead(Handle<Object> proxy) {
 }
 
 
-Handle<Object> Unwrap(Handle<Object> proxy) {
+Local<Object> Unwrap(Local<Object> proxy) {
   assert(!IsDead(proxy));
   proxy_container *cont = reinterpret_cast<proxy_container*>(
       proxy->GetAlignedPointerFromInternalField(0));
@@ -67,7 +66,7 @@ Handle<Object> Unwrap(Handle<Object> proxy) {
   return Local<Object>::New(isolate, cont->target);
 }
 
-Handle<Array> GetCallbacks(Handle<Object> proxy) {
+Local<Array> GetCallbacks(Local<Object> proxy) {
   proxy_container *cont = reinterpret_cast<proxy_container*>(
       proxy->GetAlignedPointerFromInternalField(0));
   assert(cont != NULL);
@@ -78,7 +77,7 @@ Handle<Array> GetCallbacks(Handle<Object> proxy) {
 
 #define UNWRAP                            \
   HandleScope scope(info.GetIsolate());   \
-  Handle<Object> obj;                     \
+  Local<Object> obj;                     \
   const bool dead = IsDead(info.This());  \
   if (!dead) obj = Unwrap(info.This());   \
 
@@ -152,8 +151,8 @@ void WeakPropertyEnumerator(const PropertyCallbackInfo<Array>& info) {
 }
 
 
-void AddCallback(Isolate* isolate, Handle<Object> proxy, Handle<Function> callback) {
-  Handle<Array> callbacks = GetCallbacks(proxy);
+void AddCallback(Isolate* isolate, Local<Object> proxy, Local<Function> callback) {
+  Local<Array> callbacks = GetCallbacks(proxy);
   callbacks->Set(Integer::New(isolate, callbacks->Length()), callback);
 }
 
@@ -168,11 +167,11 @@ static void TargetCallback(const v8::WeakCallbackData<v8::Object, proxy_containe
   // invoke any listening callbacks
   Local<Array> callbacks = Local<Array>::New(isolate, cont->callbacks);
   uint32_t len = callbacks->Length();
-  Handle<Value> argv[1];
+  Local<Value> argv[1];
   argv[0] = target;
   for (uint32_t i=0; i<len; i++) {
 
-    Handle<Function> cb = Handle<Function>::Cast(
+    Local<Function> cb = Local<Function>::Cast(
         callbacks->Get(Integer::New(isolate, i)));
 
     TryCatch try_catch;
@@ -212,7 +211,7 @@ void Create(const FunctionCallbackInfo<Value>& args) {
   cont->target.SetWeak(cont, TargetCallback);
 
   if (args.Length() >= 2) {
-    AddCallback(args.GetIsolate(), proxy, Handle<Function>::Cast(args[1]));
+    AddCallback(args.GetIsolate(), proxy, Local<Function>::Cast(args[1]));
   }
 
   args.GetReturnValue().Set(proxy);
@@ -222,7 +221,7 @@ void Create(const FunctionCallbackInfo<Value>& args) {
  * TODO: Make this better.
  */
 
-bool isWeakRef (Handle<Value> val) {
+bool isWeakRef (Local<Value> val) {
   return val->IsObject() && val->ToObject()->InternalFieldCount() == 1;
 }
 
@@ -241,7 +240,7 @@ void Get(const FunctionCallbackInfo<Value>& args) {
   Local<Object> proxy = args[0]->ToObject();
   if (IsDead(proxy)) return;
 
-  Handle<Object> obj = Unwrap(proxy);
+  Local<Object> obj = Unwrap(proxy);
   args.GetReturnValue().Set(obj);
 }
 
@@ -283,7 +282,7 @@ void AddCallback(const FunctionCallbackInfo<Value>& args) {
   }
 
   Local<Object> proxy = args[0]->ToObject();
-  AddCallback(args.GetIsolate(), proxy, Handle<Function>::Cast(args[1]));
+  AddCallback(args.GetIsolate(), proxy, Local<Function>::Cast(args[1]));
 }
 
 void Callbacks(const FunctionCallbackInfo<Value>& args) {
@@ -299,7 +298,7 @@ void Callbacks(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target) {
+void Initialize(Local<Object> target) {
   HandleScope scope(target->CreationContext()->GetIsolate());
 
   Local<ObjectTemplate> tmpl = ObjectTemplate::New();


### PR DESCRIPTION
v8::Handle is deprecated: https://codereview.chromium.org/1224623004

I am targeting next+1 but can change it to next because Handle is already an alias of Local in v8 4.4.