### PR TITLE
tools: enable no-extra-semi rule in the linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,8 @@ rules:
   no-unreachable: 2
   ## require valid typeof compared string like typeof foo === 'strnig'
   valid-typeof: 2
+  ## disallow unnecessary semicolons after function declarations
+  no-extra-semi: 2
 
   # Best Practices
   # list: https://github.com/eslint/eslint/tree/master/docs/rules#best-practices

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -573,7 +573,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
           });
           cb(null, mirror);
         }
-      };
+      }
     });
     return;
   } else if (handle.type === 'function') {
@@ -798,7 +798,7 @@ function Interface(stdin, stdout, args) {
     } else {
       self.repl.context[key] = fn;
     }
-  };
+  }
 
   // Copy all prototype methods in repl context
   // Setup them as getters if possible

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -154,7 +154,8 @@ RoundRobinHandle.prototype.remove = function(worker) {
   var index = this.free.indexOf(worker);
   if (index !== -1) this.free.splice(index, 1);
   if (Object.getOwnPropertyNames(this.all).length !== 0) return false;
-  for (var handle; handle = this.handles.shift(); handle.close());
+  var handle;
+  while (handle = this.handles.shift()) handle.close();
   this.handle.close();
   this.handle = null;
   return true;

--- a/lib/url.js
+++ b/lib/url.js
@@ -499,7 +499,9 @@ Url.prototype.resolveObject = function(relative) {
         !/^file:?$/.test(relative.protocol) &&
         !hostlessProtocol[relative.protocol]) {
       var relPath = (relative.pathname || '').split('/');
-      while (relPath.length && !(relative.host = relPath.shift()));
+      while(!(relative.host = relPath.shift())) {
+        if (!relPath.length || relative.host) break;
+      }
       if (!relative.host) relative.host = '';
       if (!relative.hostname) relative.hostname = '';
       if (relPath[0] !== '') relPath.unshift('');

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -22,7 +22,9 @@ var dInput = new stream.Readable();
 var dOutput = new stream.Writable();
 
 dInput._read = function _read(size) {
-  while (lines.length > 0 && this.push(lines.shift()));
+  while (lines.length > 0 && this.push(lines.shift())) {
+    // do nothing
+  }
   if (lines.length === 0)
     this.push(null);
 };

--- a/test/common.js
+++ b/test/common.js
@@ -309,7 +309,7 @@ function leakedGlobals() {
       leaked.push(val);
 
   return leaked;
-};
+}
 exports.leakedGlobals = leakedGlobals;
 
 // Turn this off if the test should not check for global leaks.

--- a/test/debugger/helper-debugger-repl.js
+++ b/test/debugger/helper-debugger-repl.js
@@ -103,7 +103,7 @@ function addTest(input, output) {
     } else {
       quit();
     }
-  };
+  }
   expected.push({input: input, lines: output, callback: next});
 }
 

--- a/test/parallel/test-http-1.0-keep-alive.js
+++ b/test/parallel/test-http-1.0-keep-alive.js
@@ -123,7 +123,7 @@ function check(tests) {
         current++;
         if (ctx.expectClose) return;
         conn.removeListener('close', onclose);
-        conn.removeListener('data', ondata);;
+        conn.removeListener('data', ondata);
         connected();
       }
       conn.on('data', ondata);

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -8,7 +8,7 @@ var passed = false;
 
 function PassThrough() {
   stream.Transform.call(this);
-};
+}
 util.inherits(PassThrough, stream.Transform);
 PassThrough.prototype._transform = function(chunk, encoding, done) {
   this.push(chunk);
@@ -17,7 +17,7 @@ PassThrough.prototype._transform = function(chunk, encoding, done) {
 
 function TestStream() {
   stream.Transform.call(this);
-};
+}
 util.inherits(TestStream, stream.Transform);
 TestStream.prototype._transform = function(chunk, encoding, done) {
   if (!passed) {

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -8,7 +8,7 @@ var util = require('util');
 function MyWritable(fn, options) {
   stream.Writable.call(this, options);
   this.fn = fn;
-};
+}
 
 util.inherits(MyWritable, stream.Writable);
 
@@ -17,7 +17,7 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
   callback();
 };
 
-;(function decodeStringsTrue() {
+(function decodeStringsTrue() {
   var m = new MyWritable(function(isBuffer, type, enc) {
     assert(isBuffer);
     assert.equal(type, 'object');
@@ -28,7 +28,7 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
   m.end();
 })();
 
-;(function decodeStringsFalse() {
+(function decodeStringsFalse() {
   var m = new MyWritable(function(isBuffer, type, enc) {
     assert(!isBuffer);
     assert.equal(type, 'string');

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -17,7 +17,7 @@ src._read = function(n) {
       src.push(new Buffer('1'));
       src.push(null);
     });
-  };
+  }
 };
 
 dst._write = function(chunk, enc, cb) {

--- a/test/parallel/test-stream3-pause-then-read.js
+++ b/test/parallel/test-stream3-pause-then-read.js
@@ -42,7 +42,7 @@ function read100() {
 function readn(n, then) {
   console.error('read %d', n);
   expectEndingData -= n;
-  ;(function read() {
+  (function read() {
     var c = r.read(n);
     if (!c)
       r.once('readable', read);

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -60,6 +60,8 @@ server.listen(PORT, function() {
   }
   function write() {
     // this needs to return false eventually
-    while (false !== conn.write(chunk));
+    while (false !== conn.write(chunk)) {
+      // do nothing
+    }
   }
 });

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -85,7 +85,7 @@ function startTest() {
 
       callback();
     });
-  };
+  }
 
   connectClient(clientsOptions[0], function() {
     connectClient(clientsOptions[1], function() {

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -136,7 +136,7 @@ function startTest() {
       else
         connectClient(i + 1, callback);
     }
-  };
+  }
 
   connectClient(0, function() {
     server.close();

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1573,6 +1573,6 @@ var throws = [
 ];
 for (var i = 0; i < throws.length; i++) {
   assert.throws(function() { url.format(throws[i]); }, TypeError);
-};
+}
 assert(url.format('') === '');
 assert(url.format({}) === '');

--- a/test/parallel/test-zlib-params.js
+++ b/test/parallel/test-zlib-params.js
@@ -18,7 +18,9 @@ var chunk1 = file.slice(0, chunkSize),
 
 deflater.write(chunk1, function() {
   deflater.params(0, zlib.Z_DEFAULT_STRATEGY, function() {
-    while (deflater.read());
+    while (deflater.read()) {
+      // do nothing
+    }
     deflater.end(chunk2, function() {
       var bufs = [], buf;
       while (buf = deflater.read())
@@ -26,7 +28,9 @@ deflater.write(chunk1, function() {
       actual = Buffer.concat(bufs);
     });
   });
-  while (deflater.read());
+  while (deflater.read()) {
+    // do nothing
+  }
 });
 
 process.once('exit', function() {

--- a/test/pummel/test-process-hrtime.js
+++ b/test/pummel/test-process-hrtime.js
@@ -9,7 +9,9 @@ assert(Array.isArray(start));
 
 // busy-loop for 2 seconds
 var now = Date.now();
-while (Date.now() - now < 2000);
+while (Date.now() - now < 2000) {
+  // do nothing
+}
 
 // get a diff reading
 var diff = process.hrtime(start);

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -24,7 +24,7 @@ var options = {
 function Mediator() {
   stream.Writable.call(this);
   this.buf = '';
-};
+}
 util.inherits(Mediator, stream.Writable);
 
 Mediator.prototype._write = function write(data, enc, cb) {

--- a/test/sequential/test-child-process-fork-getconnections.js
+++ b/test/sequential/test-child-process-fork-getconnections.js
@@ -81,7 +81,7 @@ if (process.argv[2] === 'child') {
         closeSockets(i + 1);
       });
     });
-  };
+  }
 
   var closeEmitted = false;
   server.on('close', function() {

--- a/test/sequential/test-fs-watch-recursive.js
+++ b/test/sequential/test-fs-watch-recursive.js
@@ -24,7 +24,7 @@ if (process.platform === 'darwin') {
   function cleanup() {
     try { fs.unlinkSync(filepathOne); } catch (e) { }
     try { fs.rmdirSync(testsubdir); } catch (e) { }
-  };
+  }
 
   try { fs.mkdirSync(testsubdir, 0o700); } catch (e) {}
 

--- a/test/sequential/test-http-pipeline-flood.js
+++ b/test/sequential/test-http-pipeline-flood.js
@@ -87,6 +87,8 @@ function child() {
   });
 
   function write() {
-    while (false !== conn.write(req, 'ascii'));
+    while (false !== conn.write(req, 'ascii')) {
+      // do nothing
+    }
   }
 }

--- a/test/sequential/test-tcp-wrap-listen.js
+++ b/test/sequential/test-tcp-wrap-listen.js
@@ -65,7 +65,7 @@ server.onconnection = function(err, client) {
         writeCount++;
         console.log('write ' + writeCount);
         maybeCloseClient();
-      };
+      }
 
       sliceCount++;
     } else {


### PR DESCRIPTION
The [`no-extra-semi`](http://eslint.org/docs/rules/no-extra-semi) rule was requested multiple times, so here it is:

The big issue here were bodyless `while` and `for` loops. I took the time to refactor two cases in `lib` to hopefully be more readable. There were a few cases in `test` that do things like call a function until it returns false, where I opted to just put an empty body with a comment. If these are too ugly, we can wait on https://github.com/eslint/eslint/issues/3075 for a fix.

cc: @targos 