### PR TITLE
test: add -no_rand_screen to s_client opts on Win

### DIFF
--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -53,6 +53,10 @@ server.listen(common.PORT, function() {
               '-cert', join(common.fixturesDir, 'foafssl.crt'),
               '-key', join(common.fixturesDir, 'foafssl.key')];
 
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    args.push('-no_rand_screen');
+
   var client = spawn(common.opensslCli, args);
 
   client.stdout.on('data', function(data) {

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -33,6 +33,11 @@ var server = tls.Server({
 }, null).listen(common.PORT, function() {
   var args = ['s_client', '-quiet', '-tls1_1',
               '-connect', '127.0.0.1:' + common.PORT];
+
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    args.push('-no_rand_screen');
+
   var client = spawn(common.opensslCli, args);
   var out = '';
   client.stderr.setEncoding('utf8');

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -43,6 +43,11 @@ function test(keylen, expectedCipher, cb) {
   server.listen(common.PORT, '127.0.0.1', function() {
     var args = ['s_client', '-connect', '127.0.0.1:' + common.PORT,
                 '-cipher', ciphers];
+
+    // for the performance and stability issue in s_client on Windows
+    if (process.platform === 'win32')
+      args.push('-no_rand_screen');
+
     var client = spawn(common.opensslCli, args);
     var out = '';
     client.stdout.setEncoding('utf8');

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -33,6 +33,10 @@ server.listen(common.PORT, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ' -connect 127.0.0.1:' + common.PORT;
 
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    cmd += ' -no_rand_screen';
+
   exec(cmd, function(err, stdout, stderr) {
     // Old versions of openssl will still exit with 0 so we
     // can't just check if err is not null.

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -36,6 +36,10 @@ server.listen(common.PORT, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ' -connect 127.0.0.1:' + common.PORT;
 
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    cmd += ' -no_rand_screen';
+
   exec(cmd, function(err, stdout, stderr) {
     if (err) throw err;
     response = stdout;

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -29,6 +29,11 @@ server.listen(common.PORT, '127.0.0.1', function() {
               '-no_tls1_1',
               '-no_tls1_2',
               '-connect', address];
+
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    args.push('-no_rand_screen');
+
   var client = spawn(common.opensslCli, args, { stdio: 'inherit' });
   client.once('exit', common.mustCall(function(exitCode) {
     assert.equal(exitCode, 1);

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -93,8 +93,14 @@ var opensslExitCode = -1;
 
 server.listen(common.PORT, function() {
   // To test use: openssl s_client -connect localhost:8000
-  var client = spawn(common.opensslCli, ['s_client', '-connect', '127.0.0.1:' +
-        common.PORT]);
+
+  var args = ['s_client', '-connect', '127.0.0.1:' + common.PORT];
+
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    args.push('-no_rand_screen');
+
+  var client = spawn(common.opensslCli, args);
 
 
   var out = '';

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -70,16 +70,23 @@ function doTest(testOptions, callback) {
       callback(null, session.data);
     }, 100);
   });
+
+  var args = [
+    's_client',
+    '-tls1',
+    '-connect', 'localhost:' + common.PORT,
+    '-servername', 'ohgod',
+    '-key', join(common.fixturesDir, 'agent.key'),
+    '-cert', join(common.fixturesDir, 'agent.crt'),
+    '-reconnect'
+  ].concat(testOptions.tickets ? [] : '-no_ticket');
+
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    args.push('-no_rand_screen');
+
   server.listen(common.PORT, function() {
-    var client = spawn(common.opensslCli, [
-      's_client',
-      '-tls1',
-      '-connect', 'localhost:' + common.PORT,
-      '-servername', 'ohgod',
-      '-key', join(common.fixturesDir, 'agent.key'),
-      '-cert', join(common.fixturesDir, 'agent.crt'),
-      '-reconnect'
-    ].concat(testOptions.tickets ? [] : '-no_ticket'), {
+    var client = spawn(common.opensslCli, args, {
       stdio: [ 0, 1, 'pipe' ]
     });
     var err = '';

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -40,6 +40,10 @@ server.listen(common.PORT, '127.0.0.1', function() {
   var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ' -connect 127.0.0.1:' + common.PORT;
 
+  // for the performance and stability issue in s_client on Windows
+  if (process.platform === 'win32')
+    cmd += ' -no_rand_screen';
+
   exec(cmd, function(err, stdout, stderr) {
     if (err) throw err;
     response = stdout;


### PR DESCRIPTION
`RAND_screen()` causes stability issues in invoking `openssl-cli` s_client on win2008r2 in CI. Disable to use it by adding `-no_rand_screen` options to all tls tests that use `common.opensslCli`.

The result of CI is https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/173/. There are existed errors on Ubuntu15 and arm but tls test errors on Win2008 are resolved as I've also made several tests on iojs+pr+win. 

Fixes: #2150

R= @joaocgreis, @orangemocha  or @rvagg 
