### PR TITLE
doc: Replace util.debug with console.error

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -675,7 +675,7 @@ Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
 
     fs.exists('/etc/passwd', function (exists) {
-      util.debug(exists ? "it's there" : "no passwd!");
+      console.log(exists ? "it's there" : 'no passwd!');
     });
 
 `fs.exists()` is an anachronism and exists only for historical reasons.
@@ -717,8 +717,8 @@ a possible error argument. If any of the accessibility checks fail, the error
 argument will be populated. The following example checks if the file
 `/etc/passwd` can be read and written by the current process.
 
-    fs.access('/etc/passwd', fs.R_OK | fs.W_OK, function(err) {
-      util.debug(err ? 'no access!' : 'can read/write');
+    fs.access('/etc/passwd', fs.R_OK | fs.W_OK, function (err) {
+      console.log(err ? 'no access!' : 'can read/write');
     });
 
 ## fs.accessSync(path[, mode])


### PR DESCRIPTION
I found util.debug in our API document.
`util.debug` is deprecated, according to [here](https://iojs.org/api/util.html#util_util_debug_string)
