### PR TITLE
buffer: fix not return on error

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -287,7 +287,6 @@ MaybeLocal<Object> Copy(Isolate* isolate, const char* data, size_t length) {
 }
 
 
-// Make a copy of "data". Why this isn't called "Copy", we'll never know.
 MaybeLocal<Object> New(Environment* env, const char* data, size_t length) {
   EscapableHandleScope scope(env->isolate());
 
@@ -474,7 +473,7 @@ void Slice(const FunctionCallbackInfo<Value>& args) {
   Maybe<bool> mb =
       ui->SetPrototype(env->context(), env->buffer_prototype_object());
   if (!mb.FromMaybe(false))
-    env->ThrowError("Unable to set Object prototype");
+    return env->ThrowError("Unable to set Object prototype");
   args.GetReturnValue().Set(ui);
 }
 


### PR DESCRIPTION
Throwing a JS error from C++ does not mean the function will return
early. This must be done manually.

Also remove extraneous comment no longer relevant.

Fix: 2903030 "buffer: switch API to return MaybeLocal<T>"

Note: There is no way to add a test for this.

CI: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/178/

/cc @rvagg 