### PR TITLE
build: add 'x86' option back in to configure

### DIFF
--- a/configure
+++ b/configure
@@ -27,7 +27,7 @@ parser = optparse.OptionParser()
 
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux', 'android')
 valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 'x32',
-              'x64')
+              'x64', 'x86')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')
 valid_mips_arch = ('loongson', 'r1', 'r2', 'r6', 'rx')
 valid_mips_fpu = ('fp32', 'fp64', 'fpxx')


### PR DESCRIPTION
Accidentally removed @ https://github.com/nodejs/io.js/pull/2124 when ppc support was added

/R= @jbergstroem 
/R= @mhdawson 

Note that the full CI run was not run in #2124 so this was not picked up as a problem, otherwise the x86 slaves we have would have borked.