### PR TITLE
build: produce symbol map files on windows

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -163,6 +163,8 @@
           }],
         ],
         'GenerateDebugInformation': 'true',
+        'GenerateMapFile': 'true', # /MAP
+        'MapExports': 'true', # /MAPINFO:EXPORTS
         'RandomizedBaseAddress': 2, # enable ASLR
         'DataExecutionPrevention': 2, # enable DEP
         'AllowIsolation': 'true',


### PR DESCRIPTION
This produces map files as part of the build on windows. The existence of
these files enable profiling and tick-processing using the --prof command
line.
See: https://github.com/nodejs/io.js/pull/2090#issuecomment-124746673

Map files are documented here:
https://msdn.microsoft.com/en-us/library/k7xkk3e2.aspx

R=@nodejs/build?