### PR TITLE
util: delay creation of debug context

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,8 +2,8 @@
 
 const uv = process.binding('uv');
 const Buffer = require('buffer').Buffer;
-const Debug = require('vm').runInDebugContext('Debug');
 const internalUtil = require('internal/util');
+var Debug;
 
 const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
@@ -168,6 +168,7 @@ function arrayToHash(array) {
 
 
 function inspectPromise(p) {
+  Debug = Debug || require('vm').runInDebugContext('Debug');
   var mirror = Debug.MakeMirror(p, true);
   if (!mirror.isPromise())
     return null;


### PR DESCRIPTION
Now that it is *really* simple to take profiles with node (thanks to #2090), I was looking a profile I got from a trivial `JSON.stringify` benchmark.

I was really surprised by the number of ticks I got in `RunInDebugContext`. The full profile is [here](https://gist.github.com/ofrobots/3b031d8319e77acbfc0f) but here's an excerpt:

```
38    0.7%    0.7%  node::ContextifyContext::RunInDebugContext(v8::FunctionCallbackInfo<v8::Value> const&)
```

I looked into this. It seems that #1471 introduced a change which now creates a Debug context by default in the util module. This is needed to be able to inspect promises. I think this is fine, but we should not be doing the really expensive operation of creating a Debug context on default startup of node. This patch fixes that.

Based on my measurements, this saves ~24ms in node startup time measured as follows:

```shell
#!/usr/bin/bash
# Note: this requires GNU date
start=$(date +%s%N)
for c in {0..60}
do
  iojs -e " "
done
new=$(date +%s%N)
elapsed=$(((new - start)/60))
echo $elapsed
```

This reduces startup time from ~90ms → ~66ms on my machine. I think it is important that node startup is as fast as possible. I don't like deferred initialization as I am proposing, but I think it is a much lesser evil than spending 24ms on each node startup.

R=@bnoordhuis, @monsanto 

