### PR TITLE
net: return if not _connecting

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -927,7 +927,8 @@ function lookupAndConnect(self, options) {
   var addressType = exports.isIP(host);
   if (addressType) {
     process.nextTick(function() {
-      connect(self, host, port, addressType, localAddress, localPort);
+      if (self._connecting)
+        connect(self, host, port, addressType, localAddress, localPort);
     });
     return;
   }

--- a/test/parallel/test-net-connect-immediate-destroy.js
+++ b/test/parallel/test-net-connect-immediate-destroy.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const socket = net.connect(common.PORT, common.localhostIPv4, assert.fail);
+socket.on('error', assert.fail);
+socket.destroy();


### PR DESCRIPTION
Fixes regression introduced in af249fa8a15bad8996187e73b480b30dcd881bad.

With `connect` being deferred to the next tick, `Socket.destroy` could be
called before `connect`. `Socket.destroy` sets _connecting to false which
would cause an assertion error.

Fixes: https://github.com/nodejs/io.js/issues/2250