### PR TITLE
timers: improve Timer.now() performance

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -171,6 +171,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
                                 uv_loop_t* loop)
     : isolate_(context->GetIsolate()),
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate(), loop)),
+      timer_base_(uv_now(loop)),
       using_smalloc_alloc_cb_(false),
       using_domains_(false),
       using_abort_on_uncaught_exc_(false),
@@ -284,6 +285,10 @@ inline Environment::DomainFlag* Environment::domain_flag() {
 
 inline Environment::TickInfo* Environment::tick_info() {
   return &tick_info_;
+}
+
+inline uint64_t Environment::timer_base() const {
+  return timer_base_;
 }
 
 inline bool Environment::using_smalloc_alloc_cb() const {

--- a/src/env.h
+++ b/src/env.h
@@ -398,6 +398,7 @@ class Environment {
   inline AsyncHooks* async_hooks();
   inline DomainFlag* domain_flag();
   inline TickInfo* tick_info();
+  inline uint64_t timer_base() const;
 
   static inline Environment* from_cares_timer_handle(uv_timer_t* handle);
   inline uv_timer_t* cares_timer_handle();
@@ -501,6 +502,7 @@ class Environment {
   AsyncHooks async_hooks_;
   DomainFlag domain_flag_;
   TickInfo tick_info_;
+  const uint64_t timer_base_;
   uv_timer_t cares_timer_handle_;
   ares_channel cares_channel_;
   ares_task_list cares_task_list_;

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -101,6 +101,8 @@ class TimerWrap : public HandleWrap {
     Environment* env = Environment::GetCurrent(args);
     uv_update_time(env->event_loop());
     uint64_t now = uv_now(env->event_loop());
+    CHECK(now >= env->timer_base());
+    now -= env->timer_base();
     if (now <= 0xfffffff)
       args.GetReturnValue().Set(static_cast<uint32_t>(now));
     else

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -43,7 +43,6 @@ class TimerWrap : public HandleWrap {
 
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
-    env->SetProtoMethod(constructor, "again", Again);
 
     target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Timer"),
                 constructor->GetFunction());
@@ -87,15 +86,6 @@ class TimerWrap : public HandleWrap {
     CHECK(HandleWrap::IsAlive(wrap));
 
     int err = uv_timer_stop(&wrap->handle_);
-    args.GetReturnValue().Set(err);
-  }
-
-  static void Again(const FunctionCallbackInfo<Value>& args) {
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
-
-    CHECK(HandleWrap::IsAlive(wrap));
-
-    int err = uv_timer_again(&wrap->handle_);
     args.GetReturnValue().Set(err);
   }
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -43,7 +43,6 @@ class TimerWrap : public HandleWrap {
 
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
-    env->SetProtoMethod(constructor, "getRepeat", GetRepeat);
     env->SetProtoMethod(constructor, "again", Again);
 
     target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Timer"),
@@ -98,18 +97,6 @@ class TimerWrap : public HandleWrap {
 
     int err = uv_timer_again(&wrap->handle_);
     args.GetReturnValue().Set(err);
-  }
-
-  static void GetRepeat(const FunctionCallbackInfo<Value>& args) {
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
-
-    CHECK(HandleWrap::IsAlive(wrap));
-
-    int64_t repeat = uv_timer_get_repeat(&wrap->handle_);
-    if (repeat <= 0xfffffff)
-      args.GetReturnValue().Set(static_cast<uint32_t>(repeat));
-    else
-      args.GetReturnValue().Set(static_cast<double>(repeat));
   }
 
   static void OnTimeout(uv_timer_t* handle) {

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -43,7 +43,6 @@ class TimerWrap : public HandleWrap {
 
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
-    env->SetProtoMethod(constructor, "setRepeat", SetRepeat);
     env->SetProtoMethod(constructor, "getRepeat", GetRepeat);
     env->SetProtoMethod(constructor, "again", Again);
 
@@ -99,16 +98,6 @@ class TimerWrap : public HandleWrap {
 
     int err = uv_timer_again(&wrap->handle_);
     args.GetReturnValue().Set(err);
-  }
-
-  static void SetRepeat(const FunctionCallbackInfo<Value>& args) {
-    TimerWrap* wrap = Unwrap<TimerWrap>(args.Holder());
-
-    CHECK(HandleWrap::IsAlive(wrap));
-
-    int64_t repeat = args[0]->IntegerValue();
-    uv_timer_set_repeat(&wrap->handle_, repeat);
-    args.GetReturnValue().Set(0);
   }
 
   static void GetRepeat(const FunctionCallbackInfo<Value>& args) {

--- a/test/parallel/test-timers-now.js
+++ b/test/parallel/test-timers-now.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// Return value of Timer.now() should easily fit in a SMI right after start-up.
+const Timer = process.binding('timer_wrap').Timer;
+assert(Timer.now() < 0x3ffffff);


### PR DESCRIPTION
Record the start time so we can make the return value of Timer.now()
relative to it, increasing the chances that it fits in a tagged integer
instead of a heap-allocated double, at least for the first one or two
billion milliseconds.

R=@trevnorris?

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/203/