### PR TITLE
test: fix fs.readFile('/dev/stdin') tests

### DIFF
--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -12,11 +12,6 @@ if (process.platform === 'win32') {
 
 var fs = require('fs');
 
-var filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
-var dataExpected = new Array(1000000).join('a');
-common.refreshTmpDir();
-fs.writeFileSync(filename, dataExpected);
-
 if (process.argv[2] === 'child') {
   fs.readFile('/dev/stdin', function(er, data) {
     if (er) throw er;
@@ -24,6 +19,11 @@ if (process.argv[2] === 'child') {
   });
   return;
 }
+
+var filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
+var dataExpected = new Array(1000000).join('a');
+common.refreshTmpDir();
+fs.writeFileSync(filename, dataExpected);
 
 var exec = require('child_process').exec;
 var f = JSON.stringify(__filename);

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -12,15 +12,15 @@ if (process.platform === 'win32') {
 
 var fs = require('fs');
 
-var filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
-var dataExpected = new Array(1000000).join('a');
-common.refreshTmpDir();
-fs.writeFileSync(filename, dataExpected);
-
 if (process.argv[2] === 'child') {
   process.stdout.write(fs.readFileSync('/dev/stdin', 'utf8'));
   return;
 }
+
+var filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
+var dataExpected = new Array(1000000).join('a');
+common.refreshTmpDir();
+fs.writeFileSync(filename, dataExpected);
 
 var exec = require('child_process').exec;
 var f = JSON.stringify(__filename);


### PR DESCRIPTION
The tests were creating the temp fixture file in both the parent
and the child process, leading to interesting race conditions on
the slower buildbots.

R=@Fishrock123

CI: https://jenkins-iojs.nodesource.com/job/node-test-pull-request/21/
Previous ARM-only run: https://jenkins-iojs.nodesource.com/job/iojs+pr+arm/192/

[Note to self: add link to https://github.com/nodejs/io.js/issues/2261 in commit log.]