### PR TITLE
cluster: add handle ref/unref stubs in rr mode

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -603,12 +603,22 @@ function workerInit() {
       return 0;
     }
 
+    // XXX(bnoordhuis) Probably no point in implementing ref() and unref()
+    // because the control channel is going to keep the worker alive anyway.
+    function ref() {
+    }
+
+    function unref() {
+    }
+
     // Faux handle. Mimics a TCPWrap with just enough fidelity to get away
     // with it. Fools net.Server into thinking that it's backed by a real
     // handle.
     var handle = {
       close: close,
-      listen: listen
+      listen: listen,
+      ref: ref,
+      unref: unref,
     };
     if (message.sockname) {
       handle.getsockname = getsockname;  // TCP handles only.

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isMaster) {
+  cluster.fork().on('message', function(msg) {
+    if (msg === 'done') this.kill();
+  });
+} else {
+  const server = net.createServer(assert.fail);
+  server.listen(common.PORT, function() {
+    server.unref();
+    server.ref();
+    server.close(function() {
+      process.send('done');
+    });
+  });
+}


### PR DESCRIPTION
Add ref() and unref() stub methods to the faux handle in round-robin
mode.  Fixes the following TypeError when calling `server.unref()` in
the worker:

    net.js:1521
        this._handle.unref();
                     ^
    TypeError: this._handle.unref is not a function
        at Server.unref (net.js:1521:18)

No actual reference counting is implemented.  It would effectively be
a no-op because the control channel would still keep the worker alive.

Fixes: https://github.com/nodejs/node/issues/73

CI: https://jenkins-iojs.nodesource.com/job/node-test-pull-request/24/