### PR TITLE
test: changing the hostname to an invalid name

### DIFF
--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -3,12 +3,12 @@ var common = require('../common');
 var net = require('net');
 var assert = require('assert');
 
-var c = net.createConnection(common.PORT, 'blah.blah');
+var c = net.createConnection(common.PORT, '...');
 
 c.on('connect', assert.fail);
 
 c.on('error', common.mustCall(function(e) {
   assert.equal(e.code, 'ENOTFOUND');
   assert.equal(e.port, common.PORT);
-  assert.equal(e.hostname, 'blah.blah');
+  assert.equal(e.hostname, '...');
 }));


### PR DESCRIPTION
In my Ubuntu 14.04.2 LTS machine, it tries to resolve the name
'blah.blah' and it fails with `ETIMEOUT` instead of `ENOTFOUND`. This patch
changes the hostname to `...`, an invalid name, so that it will fail
immediately.

cc @evanlucas 