### PR TITLE
test: fix messages and use return to skip tests

### DIFF
--- a/test/disabled/tls_server.js
+++ b/test/disabled/tls_server.js
@@ -13,8 +13,8 @@ var certPem = fs.readFileSync(common.fixturesDir + '/cert.pem');
 try {
   var credentials = crypto.createCredentials({key: keyPem, cert: certPem});
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.log('1..0 # Skipped: node compiled without OpenSSL.');
+  return;
 }
 var i = 0;
 var server = net.createServer(function(connection) {

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -19,8 +19,9 @@ var assert = require('assert');
 var common = require('../common');
 
 if (common.isWindows) {
-  console.error('Sending dgram sockets to child processes not supported');
-  process.exit(0);
+  console.log('1..0 # Skipped: Sending dgram sockets to child processes is ' +
+              'not supported');
+  return;
 }
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -10,8 +10,8 @@ if (common.isWindows) {
 }
 
 if (process.getuid() === 0) {
-  console.log('Do not run this test as root.');
-  process.exit(0);
+  console.log('1..0 # Skipped: Test is not supposed to be run as root.');
+  return;
 }
 
 if (cluster.isMaster) {

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -9,8 +9,9 @@ var dgram = require('dgram');
 
 
 if (common.isWindows) {
-  console.warn('dgram clustering is currently not supported on windows.');
-  process.exit(0);
+  console.log('1..0 # Skipped: dgram clustering is currently not supported ' +
+              'on windows.');
+  return;
 }
 
 if (cluster.isMaster)

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -9,8 +9,9 @@ var dgram = require('dgram');
 
 
 if (common.isWindows) {
-  console.warn('dgram clustering is currently not supported on windows.');
-  process.exit(0);
+  console.log('1..0 # Skipped: dgram clustering is currently not supported ' +
+              'on windows.');
+  return;
 }
 
 if (cluster.isMaster)

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -5,9 +5,10 @@ const assert = require('assert');
 const cluster = require('cluster');
 const http = require('http');
 
-// It is not possible to send pipe handles over the IPC pipe on Windows.
 if (common.isWindows) {
-  process.exit(0);
+  console.log('1..0 # Skipped: It is not possible to send pipe handles over ' +
+              'the IPC pipe on Windows');
+  return;
 }
 
 if (cluster.isMaster) {

--- a/test/parallel/test-dh-padding.js
+++ b/test/parallel/test-dh-padding.js
@@ -5,8 +5,8 @@ var assert = require('assert');
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.log('1..0 # Skipped: Not compiled with OPENSSL support.');
+  return;
 }
 
 var prime = 'c51f7bf8f0e1cf899243cdf408b1bc7c09c010e33ef7f3fbe5bd5feaf906113b';

--- a/test/parallel/test-dh-padding.js
+++ b/test/parallel/test-dh-padding.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('1..0 # Skipped: Not compiled with OPENSSL support.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL.');
   return;
 }
 

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -2,7 +2,7 @@
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('1..0 # Skipped: Not compiled with OPENSSL support.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL.');
   return;
 }
 

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -2,8 +2,8 @@
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.log('1..0 # Skipped: Not compiled with OPENSSL support.');
+  return;
 }
 
 // the missing var keyword is intentional

--- a/test/parallel/test-process-remove-all-signal-listeners.js
+++ b/test/parallel/test-process-remove-all-signal-listeners.js
@@ -5,8 +5,8 @@ const spawn = require('child_process').spawn;
 const common = require('../common');
 
 if (common.isWindows) {
-  // Win32 doesn't have signals, just a kindof emulation, insufficient
-  // for this test to apply.
+  console.log('1..0 # Skipped: Win32 doesn\'t have signals, just a kind of ' +
+              'emulation, insufficient for this test to apply.');
   return;
 }
 

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -3,9 +3,9 @@
 const common = require('../common');
 const assert = require('assert');
 
-// SIGUSR1 and SIGHUP are not supported on Windows
 if (common.isWindows) {
-  process.exit(0);
+  console.log('1..0 # Skipped: SIGUSR1 and SIGHUP signals are not supported');
+  return;
 }
 
 console.log('process.pid: ' + process.pid);

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -2,7 +2,7 @@
 if (!process.features.tls_npn) {
   console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
-  process.exit(0);
+  return;
 }
 
 var common = require('../common'),

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -4,7 +4,7 @@ var common = require('../common');
 if (!process.features.tls_ocsp) {
   console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
-  process.exit(0);
+  return;
 }
 if (!common.opensslCli) {
   console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -2,7 +2,7 @@
 if (!process.features.tls_sni) {
   console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
-  process.exit(0);
+  return;
 }
 
 var common = require('../common'),

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -2,7 +2,7 @@
 if (!process.features.tls_sni) {
   console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
               'with old OpenSSL version.');
-  process.exit(0);
+  return;
 }
 
 var common = require('../common'),

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -5,8 +5,8 @@ var assert = require('assert');
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
+  console.log('1..0 # Skipped: Not compiled with OPENSSL support.');
+  return;
 }
 
 assert.throws(function() {

--- a/test/pummel/test-crypto-dh.js
+++ b/test/pummel/test-crypto-dh.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 try {
   var crypto = require('crypto');
 } catch (e) {
-  console.log('1..0 # Skipped: Not compiled with OPENSSL support.');
+  console.log('1..0 # Skipped: node compiled without OpenSSL.');
   return;
 }
 

--- a/test/sequential/test-regress-GH-3542.js
+++ b/test/sequential/test-regress-GH-3542.js
@@ -7,7 +7,8 @@ var common = require('../common'),
 
 // This test is only relevant on Windows.
 if (!common.isWindows) {
-  return process.exit(0);
+  console.log('1..0 # Skipped: Windows specific test.');
+  return;
 }
 
 function test(p) {


### PR DESCRIPTION
This is a followup of https://github.com/nodejs/io.js/pull/2109.
The tests which didn't make it in #2109, are included in this patch.
The skip messages are supposed to follow the format

    1..0 # Skipped: [Actual reason why the test is skipped]

and the tests should be skipped with the return statement.

cc @bnoordhuis @jbergstroem 