### PR TITLE
tls: fix session resumption check

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -584,17 +584,6 @@ TLSSocket.prototype._start = function() {
   this._handle.start();
 };
 
-TLSSocket.prototype._isSessionResumed = function _isSessionResumed(session) {
-  if (!session)
-    return false;
-
-  var next = this.getSession();
-  if (!next)
-    return false;
-
-  return next.equals(session);
-};
-
 TLSSocket.prototype.setServername = function(name) {
   this._handle.setServername(name);
 };
@@ -1011,7 +1000,7 @@ exports.connect = function(/* [port, host], options, cb */) {
 
     // Verify that server's identity matches it's certificate's names
     // Unless server has resumed our existing session
-    if (!verifyError && !socket._isSessionResumed(options.session)) {
+    if (!verifyError && !socket.isSessionReused()) {
       var cert = socket.getPeerCertificate();
       verifyError = options.checkServerIdentity(hostname, cert);
     }

--- a/src/env.h
+++ b/src/env.h
@@ -198,6 +198,7 @@ namespace node {
   V(syscall_string, "syscall")                                                \
   V(tick_callback_string, "_tickCallback")                                    \
   V(tick_domain_cb_string, "_tickDomainCallback")                             \
+  V(ticketkeycallback_string, "onticketkeycallback")                          \
   V(timeout_string, "timeout")                                                \
   V(times_string, "times")                                                    \
   V(timestamp_string, "timestamp")                                            \

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -68,6 +68,13 @@ class SecureContext : public BaseObject {
 
   static const int kMaxSessionSize = 10 * 1024;
 
+  // See TicketKeyCallback
+  static const int kTicketKeyReturnIndex = 0;
+  static const int kTicketKeyHMACIndex = 1;
+  static const int kTicketKeyAESIndex = 2;
+  static const int kTicketKeyNameIndex = 3;
+  static const int kTicketKeyIVIndex = 4;
+
  protected:
   static const int64_t kExternalSize = sizeof(SSL_CTX);
 
@@ -92,11 +99,20 @@ class SecureContext : public BaseObject {
   static void SetTicketKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetFreeListLength(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void EnableTicketKeyCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CtxGetter(v8::Local<v8::String> property,
                         const v8::PropertyCallbackInfo<v8::Value>& info);
 
   template <bool primary>
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static int TicketKeyCallback(SSL* ssl,
+                               unsigned char* name,
+                               unsigned char* iv,
+                               EVP_CIPHER_CTX* ectx,
+                               HMAC_CTX* hctx,
+                               int enc);
 
   SecureContext(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),

--- a/test/parallel/test-https-resume-after-renew.js
+++ b/test/parallel/test-https-resume-after-renew.js
@@ -1,0 +1,56 @@
+'use strict';
+var common = require('../common');
+var fs = require('fs');
+var https = require('https');
+var crypto = require('crypto');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+};
+
+var server = https.createServer(options, function(req, res) {
+  res.end('hello');
+});
+
+var aes = new Buffer(16);
+aes.fill('S');
+var hmac = new Buffer(16);
+hmac.fill('H');
+
+server._sharedCreds.context.enableTicketKeyCallback();
+server._sharedCreds.context.onticketkeycallback = function(name, iv, enc) {
+  if (enc) {
+    var newName = new Buffer(16);
+    var newIV = crypto.randomBytes(16);
+    newName.fill('A');
+  } else {
+    // Renew
+    return [ 2, hmac, aes ];
+  }
+
+  return [ 1, hmac, aes, newName, newIV ];
+};
+
+server.listen(common.PORT, function() {
+  var addr = this.address();
+
+  function doReq(callback) {
+    https.request({
+      method: 'GET',
+      port: addr.port,
+      servername: 'agent1',
+      ca: options.ca
+    }, function(res) {
+      res.resume();
+      res.once('end', callback);
+    }).end();
+  }
+
+  doReq(function() {
+    doReq(function() {
+      server.close();
+    });
+  });
+});


### PR DESCRIPTION
Before checking server's identity call to OpenSSL internals to ensure
that the session was not reused. In such case - certificate is going to
be empty and validation will crash.

Fix: #2304

P.S.

This is introducing big thing as a part of commit, which should probably be eventually exposed to user-land.

cc @nodejs/crypto 