### PR TITLE
os.release reports incorrect version in Windows 10

### DIFF
--- a/src/res/node.exe.extra.manifest
+++ b/src/res/node.exe.extra.manifest
@@ -2,6 +2,8 @@
 <assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows 8 -->


### PR DESCRIPTION
io.js isn't manifested for Windows 10, which is required for `os.release()` to report the correct NT version. This request fixes that issue, enabling detection of Windows 10.

See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx

The relevant section:

Applications not manifested for Windows 8.1 or Windows 10 will return the Windows 8 OS version value (6.2). Once an application is manifested for a given operating system version, GetVersionEx will always return the version that the application is manifested for in future releases. To manifest your applications for Windows 8.1 or Windows 10, refer to Targeting your application for Windows.