### PR TITLE
child_process: set stdin properties when `exec`ed

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -717,6 +717,12 @@
         stdin._handle.readStop();
       });
 
+      stdin.isTTY = true;
+      stdin.isRaw = false;
+      stdin.setRawMode = function setRawMode() {
+        throw new Error('Not a raw device');
+      };
+
       return stdin;
     });
 

--- a/test/fixtures/child-process-stdin.js
+++ b/test/fixtures/child-process-stdin.js
@@ -1,0 +1,7 @@
+console.log(process.stdin.isTTY);
+console.log(process.stdin.isRaw);
+try {
+  process.stdin.setRawMode();
+} catch (ex) {
+  console.error(ex);
+}

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-const os = require('os');
 const path = require('path');
 var spawn = require('child_process').spawn;
 const exec = require('child_process').exec;
@@ -74,12 +73,12 @@ const cpFile = path.join(common.fixturesDir, 'child-process-stdin.js');
 const nodeBinary = process.argv[0];
 
 exec(`${nodeBinary} ${cpFile}`, function(err, stdout, stderr) {
-  const stdoutLines = stdout.split(os.EOL);
+  const stdoutLines = stdout.split('\n');
   assert.strictEqual(stdoutLines[0], 'true');
   assert.strictEqual(stdoutLines[1], 'false');
   assert.strictEqual(stdoutLines.length, 3);
 
-  const stderrLines = stderr.split(os.EOL);
+  const stderrLines = stderr.split('\n');
   assert.strictEqual(stderrLines[0], '[Error: Not a raw device]');
   assert.strictEqual(stderrLines.length, 2);
 });

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -1,8 +1,10 @@
 'use strict';
 var common = require('../common');
 var assert = require('assert');
-
+const os = require('os');
+const path = require('path');
 var spawn = require('child_process').spawn;
+const exec = require('child_process').exec;
 
 var cat = spawn(common.isWindows ? 'more' : 'cat');
 cat.stdin.write('hello');
@@ -65,4 +67,19 @@ process.on('exit', function() {
   } else {
     assert.equal('hello world', response);
   }
+});
+
+// Regression test for https://github.com/nodejs/io.js/issues/2333
+const cpFile = path.join(common.fixturesDir, 'child-process-stdin.js');
+const nodeBinary = process.argv[0];
+
+exec(`${nodeBinary} ${cpFile}`, function(err, stdout, stderr) {
+  const stdoutLines = stdout.split(os.EOL);
+  assert.strictEqual(stdoutLines[0], 'true');
+  assert.strictEqual(stdoutLines[1], 'false');
+  assert.strictEqual(stdoutLines.length, 3);
+
+  const stderrLines = stderr.split(os.EOL);
+  assert.strictEqual(stderrLines[0], '[Error: Not a raw device]');
+  assert.strictEqual(stderrLines.length, 2);
 });


### PR DESCRIPTION
When a child process is created, the `stdin` will not have `isTTY`,
`isRaw` and `setRawMode` properties. Because, `uv_guess_handle` in
`guessHandleType` call returns `PIPE` for fd 0. So, we create a
`net.Socket` and return. But normally it will return `TTY` and we create
`tty.ReadStream` and return where all those properties are properly set.

This path explicitly sets the above mentioned properties on the returned
socket object.

Fixes: https://github.com/nodejs/io.js/issues/2333