### PR TITLE
Release proposal: v3.1.0

### DIFF
--- a/configure
+++ b/configure
@@ -335,6 +335,9 @@ parser.add_option('--enable-static',
 
 (options, args) = parser.parse_args()
 
+# Expand ~ in the install prefix now, it gets written to multiple files.
+options.prefix = os.path.expanduser(options.prefix or '')
+
 # set up auto-download list
 auto_downloads = nodedownload.parse(options.download_list)
 
@@ -611,7 +614,7 @@ def configure_mips(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
-  o['variables']['node_prefix'] = os.path.expanduser(options.prefix or '')
+  o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
 

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -43,7 +43,7 @@ Creating a typed array from a `Buffer` works with the following caveats:
 
 2. The buffer's memory is interpreted as an array, not a byte array.  That is,
    `new Uint32Array(new Buffer([1,2,3,4]))` creates a 4-element `Uint32Array`
-   with elements `[1,2,3,4]`, not an `Uint32Array` with a single element
+   with elements `[1,2,3,4]`, not a `Uint32Array` with a single element
    `[0x1020304]` or `[0x4030201]`.
 
 NOTE: Node.js v0.8 simply retained a reference to the buffer in `array.buffer`
@@ -66,6 +66,10 @@ Allocates a new buffer of `size` bytes.  `size` must be less than
 1,073,741,824 bytes (1 GB) on 32 bits architectures or
 2,147,483,648 bytes (2 GB) on 64 bits architectures,
 otherwise a `RangeError` is thrown.
+
+Unlike `ArrayBuffers`, the underlying memory for buffers is not initialized. So
+the contents of a newly created `Buffer` is unknown. Use `buf.fill(0)`to
+initialize a buffer to zeroes.
 
 ### new Buffer(array)
 

--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -279,7 +279,7 @@ Here is an example of sending a server:
       child.send('server', server);
     });
 
-And the child would the receive the server object as:
+And the child would then receive the server object as:
 
     process.on('message', function(m, server) {
       if (m === 'server') {

--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -121,7 +121,7 @@ values are `"rr"` and `"none"`.
 ## cluster.settings
 
 * {Object}
-  * `execArgv` {Array} list of string arguments passed to the io.js executable. 
+  * `execArgv` {Array} list of string arguments passed to the io.js executable.
     (Default=`process.execArgv`)
   * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
   * `args` {Array} string arguments passed to worker.
@@ -613,7 +613,7 @@ It is not emitted in the worker.
 
 ### Event: 'disconnect'
 
-Similar to the `cluster.on('disconnect')` event, but specfic to this worker.
+Similar to the `cluster.on('disconnect')` event, but specific to this worker.
 
     cluster.fork().on('disconnect', function() {
       // Worker has disconnected

--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -85,7 +85,7 @@ All properties are optional. An example usage of options is shown below.
 ```
 
 The callback has arguments `(err, address, family)`. `address` is a string
-representation of a IP v4 or v6 address. `family` is either the integer 4 or 6
+representation of an IP v4 or v6 address. `family` is either the integer 4 or 6
 and denotes the family of `address` (not necessarily the value initially passed
 to `lookup`).
 
@@ -163,7 +163,7 @@ attribute (e.g. `[{'priority': 10, 'exchange': 'mx.example.com'},...]`).
 ## dns.resolveTxt(hostname, callback)
 
 The same as `dns.resolve()`, but only for text queries (`TXT` records).
-`addresses` is an 2-d array of the text records available for `hostname` (e.g.,
+`addresses` is a 2-d array of the text records available for `hostname` (e.g.,
 `[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`). Each sub-array contains TXT chunks of
 one record. Depending on the use case, the could be either joined together or
 treated separately.

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -122,7 +122,7 @@ Note that `emitter.setMaxListeners(n)` still has precedence over
 
 ### emitter.listeners(event)
 
-Returns an array of listeners for the specified event.
+Returns a copy of the array of listeners for the specified event.
 
     server.on('connection', function (stream) {
       console.log('someone connected!');

--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -801,6 +801,10 @@ on Unix systems, it never was.
 
 Returns a new ReadStream object (See `Readable Stream`).
 
+Be aware that, unlike the default value set for `highWaterMark` on a
+readable stream (16 kb), the stream returned by this method has a
+default value of 64 kb for the same parameter.
+
 `options` is an object or string with the following defaults:
 
     { flags: 'r',
@@ -822,6 +826,9 @@ there's an error.  It is your responsibility to close it and make sure
 there's no file descriptor leak.  If `autoClose` is set to true (default
 behavior), on `error` or `end` the file descriptor will be closed
 automatically.
+
+`mode` sets the file mode (permission and sticky bits), but only if the
+file was created.
 
 An example to read the last 10 bytes of a file which is 100 bytes long:
 
@@ -847,14 +854,14 @@ Returns a new WriteStream object (See `Writable Stream`).
 `options` is an object or string with the following defaults:
 
     { flags: 'w',
-      encoding: null,
+      defaultEncoding: 'utf8',
       fd: null,
       mode: 0o666 }
 
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
 than replacing it may require a `flags` mode of `r+` rather than the
-default mode `w`. The `encoding` can be `'utf8'`, `'ascii'`, `binary`,
+default mode `w`. The `defaultEncoding` can be `'utf8'`, `'ascii'`, `binary`,
 or `'base64'`.
 
 Like `ReadStream` above, if `fd` is specified, `WriteStream` will ignore the

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -462,6 +462,7 @@ automatically parsed with [url.parse()][].
 
 Options:
 
+- `protocol`: Protocol to use. Defaults to `'http'`.
 - `host`: A domain name or IP address of the server to issue the request to.
   Defaults to `'localhost'`.
 - `hostname`: Alias for `host`. To support `url.parse()` `hostname` is
@@ -911,7 +912,8 @@ is finished.
 
 ### request.abort()
 
-Aborts a request.  (New since v0.3.8.)
+Marks the request as aborting. Calling this will cause remaining data
+in the response to be dropped and the socket to be destroyed.
 
 ### request.setTimeout(timeout[, callback])
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -359,7 +359,7 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   var req = socket._httpMessage;
 
 
-  // propogate "domain" setting...
+  // propagate "domain" setting...
   if (req.domain && !res.domain) {
     debug('setting "res.domain"');
     res.domain = req.domain;
@@ -465,7 +465,7 @@ function tickOnSocket(req, socket) {
   socket.parser = parser;
   socket._httpMessage = req;
 
-  // Setup "drain" propogation.
+  // Setup "drain" propagation.
   httpSocketSetup(socket);
 
   // Propagate headers limit from request object to parser

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -584,17 +584,6 @@ TLSSocket.prototype._start = function() {
   this._handle.start();
 };
 
-TLSSocket.prototype._isSessionResumed = function _isSessionResumed(session) {
-  if (!session)
-    return false;
-
-  var next = this.getSession();
-  if (!next)
-    return false;
-
-  return next.equals(session);
-};
-
 TLSSocket.prototype.setServername = function(name) {
   this._handle.setServername(name);
 };
@@ -1011,7 +1000,7 @@ exports.connect = function(/* [port, host], options, cb */) {
 
     // Verify that server's identity matches it's certificate's names
     // Unless server has resumed our existing session
-    if (!verifyError && !socket._isSessionResumed(options.session)) {
+    if (!verifyError && !socket.isSessionReused()) {
       var cert = socket.getPeerCertificate();
       verifyError = options.checkServerIdentity(hostname, cert);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -93,6 +93,7 @@ function initSocketHandle(self) {
   self.destroyed = false;
   self.bytesRead = 0;
   self._bytesDispatched = 0;
+  self._sockname = null;
 
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {
@@ -469,6 +470,7 @@ Socket.prototype._destroy = function(exception, cb) {
     });
     this._handle.onread = noop;
     this._handle = null;
+    this._sockname = null;
   }
 
   // we set destroyed to true before firing error callbacks in order
@@ -871,6 +873,7 @@ Socket.prototype.connect = function(options, cb) {
     this.destroyed = false;
     this._handle = null;
     this._peername = null;
+    this._sockname = null;
   }
 
   var self = this;
@@ -1032,6 +1035,7 @@ function afterConnect(status, handle, req, readable, writable) {
 
   assert.ok(self._connecting);
   self._connecting = false;
+  self._sockname = null;
 
   if (status == 0) {
     self.readable = readable;

--- a/lib/path.js
+++ b/lib/path.js
@@ -76,7 +76,7 @@ function win32SplitPath(filename) {
   // Separate device+slash from tail
   var result = splitDeviceRe.exec(filename),
       device = (result[1] || '') + (result[2] || ''),
-      tail = result[3] || '';
+      tail = result[3];
   // Split the tail into dir, basename and extension
   var result2 = splitTailRe.exec(tail),
       dir = result2[1],
@@ -386,9 +386,6 @@ win32.parse = function(pathString) {
   assertPath(pathString);
 
   var allParts = win32SplitPath(pathString);
-  if (!allParts || allParts.length !== 4) {
-    throw new TypeError("Invalid path '" + pathString + "'");
-  }
   return {
     root: allParts[0],
     dir: allParts[0] + allParts[1].slice(0, -1),
@@ -590,13 +587,6 @@ posix.parse = function(pathString) {
   assertPath(pathString);
 
   var allParts = posixSplitPath(pathString);
-  if (!allParts || allParts.length !== 4) {
-    throw new TypeError("Invalid path '" + pathString + "'");
-  }
-  allParts[1] = allParts[1] || '';
-  allParts[2] = allParts[2] || '';
-  allParts[3] = allParts[3] || '';
-
   return {
     root: allParts[0],
     dir: allParts[0] + allParts[1].slice(0, -1),

--- a/lib/url.js
+++ b/lib/url.js
@@ -587,7 +587,7 @@ Url.prototype.resolveObject = function(relative) {
     if (psychotic) {
       result.hostname = result.host = srcPath.shift();
       //occationaly the auth can get stuck only in host
-      //this especialy happens in cases like
+      //this especially happens in cases like
       //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
       var authInHost = result.host && result.host.indexOf('@') > 0 ?
                        result.host.split('@') : false;
@@ -669,7 +669,7 @@ Url.prototype.resolveObject = function(relative) {
     result.hostname = result.host = isAbsolute ? '' :
                                     srcPath.length ? srcPath.shift() : '';
     //occationaly the auth can get stuck only in host
-    //this especialy happens in cases like
+    //this especially happens in cases like
     //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
     var authInHost = result.host && result.host.indexOf('@') > 0 ?
                      result.host.split('@') : false;

--- a/lib/util.js
+++ b/lib/util.js
@@ -167,6 +167,22 @@ function arrayToHash(array) {
 }
 
 
+function getConstructorOf(obj) {
+  while (obj) {
+    var descriptor = Object.getOwnPropertyDescriptor(obj, 'constructor');
+    if (descriptor !== undefined &&
+        typeof descriptor.value === 'function' &&
+        descriptor.value.name !== '') {
+      return descriptor.value;
+    }
+
+    obj = Object.getPrototypeOf(obj);
+  }
+
+  return null;
+}
+
+
 function inspectPromise(p) {
   Debug = Debug || require('vm').runInDebugContext('Debug');
   var mirror = Debug.MakeMirror(p, true);
@@ -260,14 +276,17 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
+  var constructor = getConstructorOf(value);
   var base = '', empty = false, braces, formatter;
 
   if (Array.isArray(value)) {
+    if (constructor === Array)
+      constructor = null;
     braces = ['[', ']'];
     empty = value.length === 0;
     formatter = formatArray;
   } else if (value instanceof Set) {
-    braces = ['Set {', '}'];
+    braces = ['{', '}'];
     // With `showHidden`, `length` will display as a hidden property for
     // arrays. For consistency's sake, do the same for `size`, even though this
     // property isn't selected by Object.getOwnPropertyNames().
@@ -276,7 +295,7 @@ function formatValue(ctx, value, recurseTimes) {
     empty = value.size === 0;
     formatter = formatSet;
   } else if (value instanceof Map) {
-    braces = ['Map {', '}'];
+    braces = ['{', '}'];
     // Ditto.
     if (ctx.showHidden)
       keys.unshift('size');
@@ -286,9 +305,11 @@ function formatValue(ctx, value, recurseTimes) {
     // Only create a mirror if the object superficially looks like a Promise.
     var promiseInternals = value instanceof Promise && inspectPromise(value);
     if (promiseInternals) {
-      braces = ['Promise {', '}'];
+      braces = ['{', '}'];
       formatter = formatPromise;
     } else {
+      if (constructor === Object)
+        constructor = null;
       braces = ['{', '}'];
       empty = true;  // No other data than keys.
       formatter = formatObject;
@@ -335,6 +356,10 @@ function formatValue(ctx, value, recurseTimes) {
     formatted = formatPrimitiveNoColor(ctx, raw);
     base = ' ' + '[Boolean: ' + formatted + ']';
   }
+
+  // Add constructor name if available
+  if (base === '' && constructor)
+    braces[0] = constructor.name + ' ' + braces[0];
 
   if (empty === true) {
     return braces[0] + base + braces[1];

--- a/src/env.h
+++ b/src/env.h
@@ -198,6 +198,7 @@ namespace node {
   V(syscall_string, "syscall")                                                \
   V(tick_callback_string, "_tickCallback")                                    \
   V(tick_domain_cb_string, "_tickDomainCallback")                             \
+  V(ticketkeycallback_string, "onticketkeycallback")                          \
   V(timeout_string, "timeout")                                                \
   V(times_string, "times")                                                    \
   V(timestamp_string, "timestamp")                                            \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2184,7 +2184,7 @@ static void OnFatalError(const char* location, const char* message) {
 
 NO_RETURN void FatalError(const char* location, const char* message) {
   OnFatalError(location, message);
-  // to supress compiler warning
+  // to suppress compiler warning
   abort();
 }
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -68,6 +68,13 @@ class SecureContext : public BaseObject {
 
   static const int kMaxSessionSize = 10 * 1024;
 
+  // See TicketKeyCallback
+  static const int kTicketKeyReturnIndex = 0;
+  static const int kTicketKeyHMACIndex = 1;
+  static const int kTicketKeyAESIndex = 2;
+  static const int kTicketKeyNameIndex = 3;
+  static const int kTicketKeyIVIndex = 4;
+
  protected:
   static const int64_t kExternalSize = sizeof(SSL_CTX);
 
@@ -92,11 +99,20 @@ class SecureContext : public BaseObject {
   static void SetTicketKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetFreeListLength(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void EnableTicketKeyCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CtxGetter(v8::Local<v8::String> property,
                         const v8::PropertyCallbackInfo<v8::Value>& info);
 
   template <bool primary>
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static int TicketKeyCallback(SSL* ssl,
+                               unsigned char* name,
+                               unsigned char* iv,
+                               EVP_CIPHER_CTX* ectx,
+                               HMAC_CTX* hctx,
+                               int enc);
 
   SecureContext(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),

--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -80,7 +80,7 @@ class ObjectWrap {
    * attached to detached state it will be freed. Be careful not to access
    * the object after making this call as it might be gone!
    * (A "weak reference" means an object that only has a
-   * persistant handle.)
+   * persistent handle.)
    *
    * DO NOT CALL THIS FROM DESTRUCTOR
    */

--- a/src/res/node.exe.extra.manifest
+++ b/src/res/node.exe.extra.manifest
@@ -2,6 +2,8 @@
 <assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows 8 -->

--- a/test/internet/test-dgram-multicast-multi-process.js
+++ b/test/internet/test-dgram-multicast-multi-process.js
@@ -3,7 +3,6 @@ var common = require('../common'),
     assert = require('assert'),
     dgram = require('dgram'),
     util = require('util'),
-    assert = require('assert'),
     Buffer = require('buffer').Buffer,
     fork = require('child_process').fork,
     LOCAL_BROADCAST_HOST = '224.0.0.114',
@@ -183,10 +182,9 @@ if (process.argv[2] === 'child') {
     process.send({ message: buf.toString() });
 
     if (receivedMessages.length == messages.length) {
+      // .dropMembership() not strictly needed but here as a sanity check
       listenSocket.dropMembership(LOCAL_BROADCAST_HOST);
-
-      process.nextTick(function() { // TODO should be changed to below.
-        // listenSocket.dropMembership(LOCAL_BROADCAST_HOST, function() {
+      process.nextTick(function() {
         listenSocket.close();
       });
     }

--- a/test/parallel/test-http-default-encoding.js
+++ b/test/parallel/test-http-default-encoding.js
@@ -11,16 +11,11 @@ var server = http.Server(function(req, res) {
   req.on('data', function(chunk) {
     result += chunk;
   }).on('end', function() {
-    clearTimeout(timeout);
     server.close();
+    res.writeHead(200);
+    res.end('hello world\n');
   });
 
-  var timeout = setTimeout(function() {
-    process.exit(1);
-  }, 100);
-
-  res.writeHead(200);
-  res.end('hello world\n');
 });
 
 server.listen(common.PORT, function() {

--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -14,10 +14,10 @@ var server = http.Server(function(req, res) {
 
   req.on('end', function() {
     server.close();
+    res.writeHead(200);
+    res.end('hello world\n');
   });
 
-  res.writeHead(200);
-  res.end('hello world\n');
 });
 
 server.listen(common.PORT, function() {

--- a/test/parallel/test-https-resume-after-renew.js
+++ b/test/parallel/test-https-resume-after-renew.js
@@ -1,0 +1,56 @@
+'use strict';
+var common = require('../common');
+var fs = require('fs');
+var https = require('https');
+var crypto = require('crypto');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+};
+
+var server = https.createServer(options, function(req, res) {
+  res.end('hello');
+});
+
+var aes = new Buffer(16);
+aes.fill('S');
+var hmac = new Buffer(16);
+hmac.fill('H');
+
+server._sharedCreds.context.enableTicketKeyCallback();
+server._sharedCreds.context.onticketkeycallback = function(name, iv, enc) {
+  if (enc) {
+    var newName = new Buffer(16);
+    var newIV = crypto.randomBytes(16);
+    newName.fill('A');
+  } else {
+    // Renew
+    return [ 2, hmac, aes ];
+  }
+
+  return [ 1, hmac, aes, newName, newIV ];
+};
+
+server.listen(common.PORT, function() {
+  var addr = this.address();
+
+  function doReq(callback) {
+    https.request({
+      method: 'GET',
+      port: addr.port,
+      servername: 'agent1',
+      ca: options.ca
+    }, function(res) {
+      res.resume();
+      res.once('end', callback);
+    }).end();
+  }
+
+  doReq(function() {
+    doReq(function() {
+      server.close();
+    });
+  });
+});

--- a/test/parallel/test-listen-fd-server.js
+++ b/test/parallel/test-listen-fd-server.js
@@ -13,54 +13,50 @@ if (common.isWindows) {
 
 switch (process.argv[2]) {
   case 'child': return child();
-  case 'parent': return parent();
-  default: return test();
 }
 
-// spawn the parent, and listen for it to tell us the pid of the child.
+var ok;
+
+process.on('exit', function() {
+  assert.ok(ok);
+});
+
 // WARNING: This is an example of listening on some arbitrary FD number
 // that has already been bound elsewhere in advance.  However, binding
 // server handles to stdio fd's is NOT a good or reliable way to do
 // concurrency in HTTP servers!  Use the cluster module, or if you want
 // a more low-level approach, use child process IPC manually.
-function test() {
-  var parent = spawn(process.execPath, [__filename, 'parent'], {
-    stdio: [ 0, 'pipe', 2 ]
-  });
-  var json = '';
-  parent.stdout.on('data', function(c) {
-    json += c.toString();
-    if (json.indexOf('\n') !== -1) next();
-  });
-  function next() {
-    console.error('output from parent = %s', json);
-    var child = JSON.parse(json);
-    // now make sure that we can request to the child, then kill it.
-    http.get({
-      server: 'localhost',
-      port: PORT,
-      path: '/',
-    }).on('response', function(res) {
-      var s = '';
-      res.on('data', function(c) {
-        s += c.toString();
-      });
-      res.on('end', function() {
-        // kill the child before we start doing asserts.
-        // it's really annoying when tests leave orphans!
-        process.kill(child.pid, 'SIGKILL');
-        try {
-          parent.kill();
-        } catch (e) {}
-
+test(function(child) {
+  // now make sure that we can request to the child, then kill it.
+  http.get({
+    server: 'localhost',
+    port: PORT,
+    path: '/',
+  }).on('response', function(res) {
+    var s = '';
+    res.on('data', function(c) {
+      s += c.toString();
+    });
+    res.on('end', function() {
+      child.kill();
+      child.on('exit', function() {
         assert.equal(s, 'hello from child\n');
         assert.equal(res.statusCode, 200);
+        console.log('ok');
+        ok = true;
       });
     });
-  }
-}
+  });
+});
 
 function child() {
+  // Prevent outliving the parent process in case it is terminated before
+  // killing this child process.
+  process.on('disconnect', function() {
+    console.error('exit on disconnect');
+    process.exit(0);
+  });
+
   // start a server on fd=3
   http.createServer(function(req, res) {
     console.error('request on child');
@@ -68,10 +64,11 @@ function child() {
     res.end('hello from child\n');
   }).listen({ fd: 3 }, function() {
     console.error('child listening on fd=3');
+    process.send('listening');
   });
 }
 
-function parent() {
+function test(cb) {
   var server = net.createServer(function(conn) {
     console.error('connection on parent');
     conn.end('hello from parent\n');
@@ -80,7 +77,7 @@ function parent() {
 
     var spawn = require('child_process').spawn;
     var child = spawn(process.execPath, [__filename, 'child'], {
-      stdio: [ 0, 1, 2, server._handle ]
+      stdio: [ 0, 1, 2, server._handle, 'ipc' ]
     });
 
     console.log('%j\n', { pid: child.pid });
@@ -90,13 +87,10 @@ function parent() {
     // be accepted, because the child has the fd open.
     server.close();
 
-    child.on('exit', function(code) {
-      console.error('child exited', code);
+    child.on('message', function(msg) {
+      if (msg === 'listening') {
+        cb(child);
+      }
     });
-
-    child.on('close', function() {
-      console.error('child closed');
-    });
-    console.error('child spawned');
   });
 }

--- a/test/parallel/test-net-socket-local-address.js
+++ b/test/parallel/test-net-socket-local-address.js
@@ -1,0 +1,34 @@
+'use strict';
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var conns = 0;
+var clientLocalPorts = [];
+var serverRemotePorts = [];
+
+var server = net.createServer(function(socket) {
+  serverRemotePorts.push(socket.remotePort);
+  conns++;
+});
+
+var client = new net.Socket();
+
+server.on('close', function() {
+  assert.deepEqual(clientLocalPorts, serverRemotePorts,
+                   'client and server should agree on the ports used');
+  assert.equal(2, conns);
+});
+
+server.listen(common.PORT, common.localhostIPv4, testConnect);
+
+function testConnect() {
+  if (conns == 2) {
+    return server.close();
+  }
+  client.connect(common.PORT, common.localhostIPv4, function() {
+    clientLocalPorts.push(this.localPort);
+    this.once('close', testConnect);
+    this.destroy();
+  });
+}

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -9,6 +9,7 @@ var winPaths = [
   '\\foo\\C:',
   'file',
   '.\\file',
+  '',
 
   // unc
   '\\\\server\\share\\file_path',
@@ -32,7 +33,8 @@ var unixPaths = [
   'file',
   '.\\file',
   './file',
-  'C:\\foo'
+  'C:\\foo',
+  ''
 ];
 
 var unixSpecialCaseFormatTests = [
@@ -52,8 +54,6 @@ var errors = [
    message: /Path must be a string. Received 1/},
   {method: 'parse', input: [],
    message: /Path must be a string. Received undefined/},
-  // {method: 'parse', input: [''],
-  //  message: /Invalid path/}, // omitted because it's hard to trigger!
   {method: 'format', input: [null],
    message: /Parameter 'pathObject' must be an object, not/},
   {method: 'format', input: [''],
@@ -93,8 +93,13 @@ function checkErrors(path) {
 }
 
 function checkParseFormat(path, paths) {
-  paths.forEach(function(element, index, array) {
+  paths.forEach(function(element) {
     var output = path.parse(element);
+    assert.strictEqual(typeof output.root, 'string');
+    assert.strictEqual(typeof output.dir, 'string');
+    assert.strictEqual(typeof output.base, 'string');
+    assert.strictEqual(typeof output.ext, 'string');
+    assert.strictEqual(typeof output.name, 'string');
     assert.strictEqual(path.format(output), element);
     assert.strictEqual(output.dir, output.dir ? path.dirname(element) : '');
     assert.strictEqual(output.base, path.basename(element));

--- a/test/parallel/test-sys.js
+++ b/test/parallel/test-sys.js
@@ -17,7 +17,7 @@ assert.equal(new Date('2010-02-14T12:48:40+01:00').toString(),
 assert.equal("'\\n\\u0001'", common.inspect('\n\u0001'));
 
 assert.equal('[]', common.inspect([]));
-assert.equal('{}', common.inspect(Object.create([])));
+assert.equal('Array {}', common.inspect(Object.create([])));
 assert.equal('[ 1, 2 ]', common.inspect([1, 2]));
 assert.equal('[ 1, [ 2, 3 ] ]', common.inspect([1, [2, 3]]));
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -61,7 +61,7 @@ assert.ok(ex.indexOf('[message]') != -1);
 
 // GH-1941
 // should not throw:
-assert.equal(util.inspect(Object.create(Date.prototype)), '{}');
+assert.equal(util.inspect(Object.create(Date.prototype)), 'Date {}');
 
 // GH-1944
 assert.doesNotThrow(function() {
@@ -306,3 +306,44 @@ checkAlignment(function() {
 }());
 checkAlignment(new Set(big_array));
 checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
+
+
+// Test display of constructors
+
+class ObjectSubclass {}
+class ArraySubclass extends Array {}
+class SetSubclass extends Set {}
+class MapSubclass extends Map {}
+class PromiseSubclass extends Promise {}
+
+var x = new ObjectSubclass();
+x.foo = 42;
+assert.equal(util.inspect(x),
+             'ObjectSubclass { foo: 42 }');
+assert.equal(util.inspect(new ArraySubclass(1, 2, 3)),
+             'ArraySubclass [ 1, 2, 3 ]');
+assert.equal(util.inspect(new SetSubclass([1, 2, 3])),
+             'SetSubclass { 1, 2, 3 }');
+assert.equal(util.inspect(new MapSubclass([['foo', 42]])),
+            'MapSubclass { \'foo\' => 42 }');
+assert.equal(util.inspect(new PromiseSubclass(function() {})),
+             'PromiseSubclass { <pending> }');
+
+// Corner cases.
+var x = { constructor: 42 };
+assert.equal(util.inspect(x), '{ constructor: 42 }');
+
+var x = {};
+Object.defineProperty(x, 'constructor', {
+  get: function() {
+    throw new Error('should not access constructor');
+  },
+  enumerable: true
+});
+assert.equal(util.inspect(x), '{ constructor: [Getter] }');
+
+var x = new (function() {});
+assert.equal(util.inspect(x), '{}');
+
+var x = Object.create(null);
+assert.equal(util.inspect(x), '{}');


### PR DESCRIPTION
The usual weekly-ish. Less chun than usual due to collab summit and major bump. I think the `util._inspect` thing is semver-minor.

* [[`3a48c7220e`](https://github.com/nodejs/io.js/commit/3a48c7220e)] - **build**: update manifest to include Windows 10 (Lucien Greathouse) [#2332](https://github.com/nodejs/io.js/pull/2332)
* [[`0bb099f444`](https://github.com/nodejs/io.js/commit/0bb099f444)] - **build**: expand ~ in install prefix early (Ben Noordhuis) [#2307](https://github.com/nodejs/io.js/pull/2307)
* [[`2f154b52da`](https://github.com/nodejs/io.js/commit/2f154b52da)] - **doc**: multiple documentation updates cherry picked from v0.12 (James M Snell) [#2302](https://github.com/nodejs/io.js/pull/2302)
* [[`6f89de9c9a`](https://github.com/nodejs/io.js/commit/6f89de9c9a)] - **net**: ensure Socket reported address is current (Ryan Graham) [#2095](https://github.com/nodejs/io.js/pull/2095)
* [[`4750a2af19`](https://github.com/nodejs/io.js/commit/4750a2af19)] - **path**: remove dead code in favor of unit tests (Nathan Woltman) [#2282](https://github.com/nodejs/io.js/pull/2282)
* [[`bed03ea143`](https://github.com/nodejs/io.js/commit/bed03ea143)] - **test**: clarify dropMembership() call (Rich Trott) [#2062](https://github.com/nodejs/io.js/pull/2062)
* [[`6ef7aea587`](https://github.com/nodejs/io.js/commit/6ef7aea587)] - **test**: make listen-fd-cluster/server more robust (Sam Roberts) [#1944](https://github.com/nodejs/io.js/pull/1944)
* [[`c8282de860`](https://github.com/nodejs/io.js/commit/c8282de860)] - **test**: address timing issues in simple http tests (Gireesh Punathil) [#2294](https://github.com/nodejs/io.js/pull/2294)
* [[`581850b10c`](https://github.com/nodejs/io.js/commit/581850b10c)] - **tls**: fix check for reused session (Fedor Indutny) [#2312](https://github.com/nodejs/io.js/pull/2312)
* [[`51b6bdcb49`](https://github.com/nodejs/io.js/commit/51b6bdcb49)] - **tls**: introduce internal `onticketkeycallback` (Fedor Indutny) [#2312](https://github.com/nodejs/io.js/pull/2312)
* [[`ee9dd683e5`](https://github.com/nodejs/io.js/commit/ee9dd683e5)] - **(SEMVER-MINOR)** **util**: display constructor when inspecting objects (Christopher Monsanto) [#1935](https://github.com/nodejs/io.js/pull/1935) 
