### PR TITLE
src: add total_available_size to v8 statistics

### DIFF
--- a/doc/api/v8.markdown
+++ b/doc/api/v8.markdown
@@ -15,6 +15,7 @@ Returns an object with the following properties
   total_heap_size: 7326976,
   total_heap_size_executable: 4194304,
   total_physical_size: 7326976,
+  total_available_size: 1152656,
   used_heap_size: 3476208,
   heap_size_limit: 1535115264
 }

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -22,6 +22,7 @@ const heapStatisticsBuffer =
 const kTotalHeapSizeIndex = v8binding.kTotalHeapSizeIndex;
 const kTotalHeapSizeExecutableIndex = v8binding.kTotalHeapSizeExecutableIndex;
 const kTotalPhysicalSizeIndex = v8binding.kTotalPhysicalSizeIndex;
+const kTotalAvailableSize = v8binding.kTotalAvailableSize;
 const kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
 const kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
 
@@ -34,6 +35,7 @@ exports.getHeapStatistics = function() {
     'total_heap_size': buffer[kTotalHeapSizeIndex],
     'total_heap_size_executable': buffer[kTotalHeapSizeExecutableIndex],
     'total_physical_size': buffer[kTotalPhysicalSizeIndex],
+    'total_available_size': buffer[kTotalAvailableSize],
     'used_heap_size': buffer[kUsedHeapSizeIndex],
     'heap_size_limit': buffer[kHeapSizeLimitIndex]
   };

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -26,8 +26,9 @@ using v8::Value;
   V(0, total_heap_size, kTotalHeapSizeIndex)                                  \
   V(1, total_heap_size_executable, kTotalHeapSizeExecutableIndex)             \
   V(2, total_physical_size, kTotalPhysicalSizeIndex)                          \
-  V(3, used_heap_size, kUsedHeapSizeIndex)                                    \
-  V(4, heap_size_limit, kHeapSizeLimitIndex)
+  V(3, total_available_size, kTotalAvailableSize)                             \
+  V(4, used_heap_size, kUsedHeapSizeIndex)                                    \
+  V(5, heap_size_limit, kHeapSizeLimitIndex)
 
 #define V(a, b, c) +1
 static const size_t kHeapStatisticsPropertiesCount =

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -6,6 +6,7 @@ var v8 = require('v8');
 var s = v8.getHeapStatistics();
 var keys = [
   'heap_size_limit',
+  'total_available_size',
   'total_heap_size',
   'total_heap_size_executable',
   'total_physical_size',


### PR DESCRIPTION
v8 introduced the new heap statistics flag `total_available_size` in version 4.4 and upwards. This flag is now available on `v8.getHeapStatistics` with the name `total_available_size`. It contains the total available heap size of v8. 
